### PR TITLE
feat: Add node registry with global registration functions

### DIFF
--- a/services/rune-worker/pkg/nodes/base.go
+++ b/services/rune-worker/pkg/nodes/base.go
@@ -2,8 +2,8 @@ package nodes
 
 import (
 	"fmt"
-	"sync"
 	"rune-worker/plugin"
+	"sync"
 )
 
 // Factory creates a Node using the provided execution context.
@@ -14,6 +14,9 @@ type Registry struct {
 	mu        sync.RWMutex
 	factories map[string]Factory
 }
+
+// globalRegistry is the default package-level registry instance.
+var globalRegistry = NewRegistry()
 
 // NewRegistry creates an empty registry instance.
 func NewRegistry() *Registry {
@@ -39,4 +42,61 @@ func (r *Registry) Create(nodeType string, ctx plugin.ExecutionContext) (plugin.
 	}
 
 	return factory(ctx), nil
+}
+
+// GetAllTypes returns a list of all registered node types.
+func (r *Registry) GetAllTypes() []string {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	types := make([]string, 0, len(r.factories))
+	for nodeType := range r.factories {
+		types = append(types, nodeType)
+	}
+	return types
+}
+
+// RegisterNode registers a node type with its factory in the global registry.
+// This is a thread-safe operation that allows registration of node implementations
+// by their type name (e.g., "http", "conditional", "log").
+//
+// Parameters:
+//   - nodeType: The unique identifier for the node type (e.g., "http", "conditional")
+//   - factory: A function that creates a new instance of the node
+//
+// Example:
+//
+//	RegisterNode("http", func(ctx plugin.ExecutionContext) plugin.Node {
+//	    return &HTTPNode{}
+//	})
+func RegisterNode(nodeType string, factory Factory) {
+	globalRegistry.Register(nodeType, factory)
+}
+
+// GetNode retrieves a node factory from the global registry by its type name.
+// This is a thread-safe operation that returns the factory function for creating
+// instances of the specified node type.
+//
+// Parameters:
+//   - nodeType: The unique identifier for the node type (e.g., "http", "conditional")
+//
+// Returns:
+//   - Factory: The factory function for creating the node
+//   - error: An error if the node type is not registered
+//
+// Example:
+//
+//	factory, err := GetNode("http")
+//	if err != nil {
+//	    log.Fatal(err)
+//	}
+//	node := factory(execCtx)
+func GetNode(nodeType string, ctx plugin.ExecutionContext) (plugin.Node, error) {
+	return globalRegistry.Create(nodeType, ctx)
+}
+
+// GetGlobalRegistry returns the global registry instance.
+// This can be used for advanced operations or testing purposes.
+func GetGlobalRegistry() *Registry {
+	return globalRegistry
 }

--- a/services/rune-worker/pkg/nodes/base_test.go
+++ b/services/rune-worker/pkg/nodes/base_test.go
@@ -1,0 +1,185 @@
+package nodes_test
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	"rune-worker/pkg/nodes"
+	"rune-worker/plugin"
+)
+
+// MockNode is a simple node implementation for testing
+type MockNode struct {
+	Type string
+}
+
+func (m *MockNode) Execute(ctx context.Context, execCtx plugin.ExecutionContext) (map[string]any, error) {
+	return map[string]any{"type": m.Type}, nil
+}
+
+func TestRegisterNode(t *testing.T) {
+	// Create a new registry for isolated testing
+	reg := nodes.NewRegistry()
+
+	// Register a mock node
+	reg.Register("mock", func(execCtx plugin.ExecutionContext) plugin.Node {
+		return &MockNode{Type: "mock"}
+	})
+
+	// Create a node instance
+	execCtx := plugin.ExecutionContext{
+		NodeID:     "test-node",
+		WorkflowID: "test-workflow",
+	}
+
+	node, err := reg.Create("mock", execCtx)
+	if err != nil {
+		t.Fatalf("Failed to create node: %v", err)
+	}
+
+	if node == nil {
+		t.Fatal("Expected non-nil node")
+	}
+
+	// Execute the node
+	result, err := node.Execute(context.Background(), execCtx)
+	if err != nil {
+		t.Fatalf("Failed to execute node: %v", err)
+	}
+
+	if result["type"] != "mock" {
+		t.Errorf("Expected type 'mock', got '%v'", result["type"])
+	}
+}
+
+func TestGetNodeNotRegistered(t *testing.T) {
+	reg := nodes.NewRegistry()
+	execCtx := plugin.ExecutionContext{}
+
+	_, err := reg.Create("nonexistent", execCtx)
+	if err == nil {
+		t.Fatal("Expected error for unregistered node type")
+	}
+}
+
+func TestThreadSafeRegistration(t *testing.T) {
+	reg := nodes.NewRegistry()
+	var wg sync.WaitGroup
+
+	// Concurrently register 10 different node types
+	for i := 0; i < 10; i++ {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+			nodeType := string(rune('a' + idx))
+			reg.Register(nodeType, func(execCtx plugin.ExecutionContext) plugin.Node {
+				return &MockNode{Type: nodeType}
+			})
+		}(i)
+	}
+
+	wg.Wait()
+
+	// Verify all nodes were registered
+	types := reg.GetAllTypes()
+	if len(types) != 10 {
+		t.Errorf("Expected 10 registered types, got %d", len(types))
+	}
+}
+
+func TestThreadSafeRetrieval(t *testing.T) {
+	reg := nodes.NewRegistry()
+
+	// Register a node
+	reg.Register("concurrent", func(execCtx plugin.ExecutionContext) plugin.Node {
+		return &MockNode{Type: "concurrent"}
+	})
+
+	var wg sync.WaitGroup
+	execCtx := plugin.ExecutionContext{}
+
+	// Concurrently retrieve the same node type multiple times
+	for i := 0; i < 100; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			node, err := reg.Create("concurrent", execCtx)
+			if err != nil {
+				t.Errorf("Failed to create node: %v", err)
+				return
+			}
+			if node == nil {
+				t.Error("Expected non-nil node")
+			}
+		}()
+	}
+
+	wg.Wait()
+}
+
+func TestGlobalRegistryFunctions(t *testing.T) {
+	// Note: This test uses the global registry, so it may be affected by other tests
+	// In production, consider resetting the global registry between tests if needed
+
+	// Register using the global function
+	nodes.RegisterNode("global-test", func(execCtx plugin.ExecutionContext) plugin.Node {
+		return &MockNode{Type: "global-test"}
+	})
+
+	// Retrieve using the global function
+	execCtx := plugin.ExecutionContext{
+		NodeID:     "global-node",
+		WorkflowID: "global-workflow",
+	}
+
+	node, err := nodes.GetNode("global-test", execCtx)
+	if err != nil {
+		t.Fatalf("Failed to get node from global registry: %v", err)
+	}
+
+	if node == nil {
+		t.Fatal("Expected non-nil node from global registry")
+	}
+
+	// Execute to verify functionality
+	result, err := node.Execute(context.Background(), execCtx)
+	if err != nil {
+		t.Fatalf("Failed to execute node: %v", err)
+	}
+
+	if result["type"] != "global-test" {
+		t.Errorf("Expected type 'global-test', got '%v'", result["type"])
+	}
+}
+
+func TestGetAllTypes(t *testing.T) {
+	reg := nodes.NewRegistry()
+
+	// Register multiple node types
+	nodeTypes := []string{"http", "conditional", "log", "email"}
+	for _, nodeType := range nodeTypes {
+		reg.Register(nodeType, func(execCtx plugin.ExecutionContext) plugin.Node {
+			return &MockNode{Type: nodeType}
+		})
+	}
+
+	// Get all registered types
+	registeredTypes := reg.GetAllTypes()
+
+	if len(registeredTypes) != len(nodeTypes) {
+		t.Errorf("Expected %d types, got %d", len(nodeTypes), len(registeredTypes))
+	}
+
+	// Verify all types are present
+	typeMap := make(map[string]bool)
+	for _, typ := range registeredTypes {
+		typeMap[typ] = true
+	}
+
+	for _, expected := range nodeTypes {
+		if !typeMap[expected] {
+			t.Errorf("Expected type '%s' not found in registered types", expected)
+		}
+	}
+}


### PR DESCRIPTION
Implements a registry system for managing and retrieving workflow node implementations by their type name (e.g., "http", "conditional", "log").