### PR TITLE
feat(frontend): Implement expanding sidebar on `create/` dashboard

### DIFF
--- a/apps/web/src/components/layout/AppSidebar.tsx
+++ b/apps/web/src/components/layout/AppSidebar.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { type ReactNode, useCallback, useState } from "react";
+import { type ReactNode, useCallback, useEffect, useState } from "react";
 
 import Link from "next/link";
 import { usePathname } from "next/navigation";
@@ -92,13 +92,14 @@ function NavLink({
 
   const content = item.renderIcon
     ? item.renderIcon(isActive)
-    : item.icon && <item.icon className="h-5 w-5" aria-hidden />;
+    : item.icon && <item.icon className="h-5 w-5" aria-hidden={true} />;
 
   return (
     <Link
       href={item.href}
+      aria-current={isActive ? "page" : undefined}
       className={cn(
-        "group relative flex h-12 w-full items-center rounded-xl border border-transparent text-sm font-medium text-muted-foreground transition-all duration-200 ease-out",
+        "group relative flex h-12 w-full items-center rounded-xl border border-transparent text-sm font-medium text-muted-foreground motion-safe:transition-all motion-safe:duration-200 motion-safe:ease-out",
         "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 focus-visible:ring-offset-background",
         isExpanded ? "justify-start gap-3 px-3" : "justify-center gap-0 px-0",
         isActive
@@ -106,13 +107,13 @@ function NavLink({
           : "hover:border-border/70 hover:bg-muted/40 hover:text-foreground"
       )}
     >
-      <span className="flex h-5 w-5 items-center justify-center text-inherit">
+      <span aria-hidden={true} className="flex h-5 w-5 items-center justify-center text-inherit">
         {content}
       </span>
       <span
-        aria-hidden="true"
+        aria-hidden={!isExpanded}
         className={cn(
-          "pointer-events-none select-none overflow-hidden whitespace-nowrap text-sm font-medium transition-[margin,max-width,opacity,transform] duration-200 ease-out",
+          "pointer-events-none select-none overflow-hidden whitespace-nowrap text-sm font-medium motion-safe:transition-[margin,max-width,opacity,transform] motion-safe:duration-200 motion-safe:ease-out",
           isExpanded
             ? "ml-1.5 max-w-[12rem] translate-x-0 opacity-100"
             : "ml-0 max-w-0 -translate-x-1 opacity-0"
@@ -120,11 +121,11 @@ function NavLink({
       >
         {item.title}
       </span>
-      <span className="sr-only">{item.title}</span>
+      {!isExpanded && <span className="sr-only">{item.title}</span>}
       {!isExpanded && (
         <span
-          aria-hidden="true"
-          className="pointer-events-none absolute left-full top-1/2 ml-3 -translate-y-1/2 rounded-[calc(var(--radius)-0.25rem)] border border-border/70 bg-background/95 px-2 py-1 text-xs font-medium text-muted-foreground opacity-0 shadow-sm transition-all duration-150 ease-out group-hover:-translate-y-1/2 group-hover:text-foreground group-hover:opacity-100"
+          aria-hidden={true}
+          className="pointer-events-none absolute left-full top-1/2 ml-3 -translate-y-1/2 rounded-[calc(var(--radius)-0.25rem)] border border-border/70 bg-background/95 px-2 py-1 text-xs font-medium text-muted-foreground opacity-0 shadow-sm motion-safe:transition-all motion-safe:duration-150 motion-safe:ease-out group-hover:opacity-100 group-focus-visible:opacity-100"
         >
           {item.title}
         </span>
@@ -135,17 +136,28 @@ function NavLink({
 
 export function AppSidebar() {
   const pathname = usePathname();
-  const [isExpanded, setIsExpanded] = useState(false);
+  const [isExpanded, setIsExpanded] = useState<boolean>(false);
+
+  useEffect(() => {
+    try {
+      setIsExpanded(window.localStorage.getItem("sidebar:expanded") === "1");
+    } catch {}
+  }, []);
 
   const toggleExpanded = useCallback(() => {
-    setIsExpanded((prev) => !prev);
+    setIsExpanded((prev) => {
+      const next = !prev;
+      try {
+        window.localStorage.setItem("sidebar:expanded", next ? "1" : "0");
+      } catch {}
+      return next;
+    });
   }, []);
 
   return (
     <aside
-      data-expanded={isExpanded}
       className={cn(
-        "sticky top-0 hidden h-screen flex-shrink-0 flex-col overflow-visible border-r border-border/60 bg-background/95 backdrop-blur transition-[width] duration-300 ease-out lg:flex",
+        "sticky top-0 hidden h-screen flex-shrink-0 flex-col overflow-visible border-r border-border/60 bg-background/95 backdrop-blur motion-safe:transition-[width] motion-safe:duration-300 motion-safe:ease-out lg:flex",
         isExpanded ? "w-60" : "w-20"
       )}
     >
@@ -158,7 +170,7 @@ export function AppSidebar() {
             )}
           >
             {isExpanded && (
-              <span className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+              <span className="text-[11px] font-medium uppercase tracking-wider text-muted-foreground">
                 Navigation
               </span>
             )}
@@ -166,18 +178,18 @@ export function AppSidebar() {
               type="button"
               onClick={toggleExpanded}
               className={cn(
-                "inline-flex h-8 w-8 items-center justify-center text-muted-foreground transition-colors cursor-pointer",
-                "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-0",
-                "hover:text-foreground"
+                "inline-flex h-10 w-10 items-center justify-center rounded-md text-muted-foreground cursor-pointer",
+                "hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent"
               )}
               aria-label={isExpanded ? "Collapse sidebar" : "Expand sidebar"}
               aria-expanded={isExpanded}
             >
               {isExpanded ? (
-                <ChevronsLeft className="h-5 w-5" aria-hidden />
+                <ChevronsLeft className="h-5 w-5" aria-hidden={true} />
               ) : (
-                <ChevronsRight className="h-5 w-5" aria-hidden />
+                <ChevronsRight className="h-5 w-5" aria-hidden={true} />
               )}
+              <span className="sr-only">{isExpanded ? "Collapse" : "Expand"}</span>
             </button>
           </div>
           <nav className="flex flex-col items-stretch gap-3 px-2">


### PR DESCRIPTION
Adds the ability to expand the sidebar on the Create Dashboard page, displaying item titles when expanded. Also improves accessibility by showing item titles on hover when the sidebar is collapsed.