### PR TITLE
feat(api): add workflow for generating API client and OpenAPI schema

### DIFF
--- a/.github/workflows/generate-client.yml
+++ b/.github/workflows/generate-client.yml
@@ -1,0 +1,52 @@
+name: Generate API Client
+on:
+  workflow_dispatch:
+
+jobs:
+  generate-client:
+    name: Generate API Client
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: "pip"
+          cache-dependency-path: services/api/requirements.txt
+      
+      - name: Install pnpm
+        uses: pnpm/action-setup@v5
+        with:
+          version: 10
+      
+      - name: Set up Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version: '22'
+          cache: 'pnpm'
+      
+      - name: Install API dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          pip install pyyaml
+        working-directory: ./services/api
+      
+      - name: Generate OpenAPI schema
+        run: python -m scripts.generate_openapi
+        working-directory: ./services/api
+      
+      - name: Generate client with hey-api
+        run: pnpm dlx @hey-api/openapi-ts -f heyapi.conf.js
+      
+      - name: Commit and push client changes
+        run: |
+          git config --local user.email "github-actions[bot]@users.noreply.github.com"
+          git config --local user.name "github-actions[bot]"
+          git add .
+          git diff --staged --quiet || git commit -m "chore: regenerate API client"
+          git push

--- a/heyapi.conf.js
+++ b/heyapi.conf.js
@@ -1,5 +1,5 @@
 export default {
-  input: 'services/api/openapi.json', // sign up at app.heyapi.dev
+  input: 'services/api/openapi.json',
   output: 'apps/web/src/client',
   plugins: [
     {

--- a/services/api/scripts/openapi.py
+++ b/services/api/scripts/openapi.py
@@ -1,0 +1,23 @@
+import yaml
+from fastapi.openapi.utils import get_openapi
+from src.app import app
+
+
+def get_openapi_yaml():
+    openapi_schema = get_openapi(
+        title=app.title,
+        version=app.version,
+        description=app.description,
+        routes=app.routes,
+    )
+
+    # Write the schema as YAML to a file
+    with open("./openapi.yaml", "w") as file:
+        yaml.dump(openapi_schema, file, sort_keys=False)
+
+    return openapi_schema
+
+
+if __name__ == "__main__":
+    openapi_schema = get_openapi_yaml()
+    print("OpenAPI schema written to openapi.yaml")


### PR DESCRIPTION
This pull request introduces automation for generating the API client and adds a script to export the OpenAPI schema in YAML format. The main changes include adding a new GitHub Actions workflow to automate client generation, and introducing a script to output the OpenAPI schema as YAML.

**Automation and CI:**
* Added a new GitHub Actions workflow `.github/workflows/generate-client.yml` to automate the process of generating the API client, including setting up Python and Node.js environments, installing dependencies, generating the OpenAPI schema, running the client generator, and committing any changes.

**OpenAPI Schema Generation:**
* Added `services/api/scripts/openapi.py`, a script that generates the OpenAPI schema from the FastAPI app and writes it to `openapi.yaml` in YAML format.

**Configuration:**
* Cleaned up the `input` comment in `heyapi.conf.js` for clarity.