### PR TITLE
feat(api): Add get_current_admin dependency and restructure user routers

### DIFF
--- a/services/api/src/app.py
+++ b/services/api/src/app.py
@@ -15,7 +15,7 @@ from src.db.redis import close_redis
 from src.queue.rabbitmq import close_rabbitmq
 from src.auth.router import router as auth_router
 from src.workflow.router import router as workflow_router
-from src.users.router import router as users_router
+from src.users.routers import admin_router, profile_router
 
 # Get settings
 settings = get_settings()
@@ -54,4 +54,5 @@ app.add_exception_handler(Exception, generic_exception_handler)
 # Include routers
 app.include_router(auth_router)
 app.include_router(workflow_router)
-app.include_router(users_router)
+app.include_router(admin_router)
+app.include_router(profile_router)

--- a/services/api/src/auth/security.py
+++ b/services/api/src/auth/security.py
@@ -41,10 +41,12 @@ def create_access_token(user: User) -> str:
     expires_delta = timedelta(minutes=settings.access_token_expire_minutes)
     expire = now + expires_delta
 
+    #! Should INCLUDE ALL USER DATA NEEDED FOR AUTHORIZATION DECISIONS
     payload = {
         "sub": str(user.id),
         "email": user.email,
         "name": user.name,
+        "role": user.role,
         "iat": now,
         "exp": expire,
     }
@@ -75,6 +77,7 @@ def decode_access_token(token: str) -> User:
             id=int(payload["sub"]),
             email=payload["email"],
             name=payload["name"],
+            role=payload.get("role", "user"),
         )
         return user
     except jwt.ExpiredSignatureError:

--- a/services/api/src/core/dependencies.py
+++ b/services/api/src/core/dependencies.py
@@ -6,7 +6,7 @@ from sqlmodel.ext.asyncio.session import AsyncSession
 from src.auth.security import decode_access_token
 from src.core.exceptions import Unauthorized
 from src.db.config import get_db
-from src.db.models import User
+from src.db.models import User, UserRole
 from src.db.redis import get_redis
 
 
@@ -67,5 +67,15 @@ Usage:
         return workflow
 
 """
+
+
+def get_current_admin(current_user: CurrentUser) -> User:
+    if current_user.role != UserRole.ADMIN:
+        raise Unauthorized(detail="Admin privileges required")
+    return current_user
+
+
+CurrentAdmin = Annotated[User, Depends(get_current_admin)]
+
 
 RedisDep = Annotated[Redis, Depends(get_redis)]

--- a/services/api/src/users/routers/__init__.py
+++ b/services/api/src/users/routers/__init__.py
@@ -1,0 +1,4 @@
+from src.users.routers.admin import router as admin_router
+from src.users.routers.profile import router as profile_router
+
+__all__ = ["admin_router", "profile_router"]

--- a/services/api/src/users/routers/admin.py
+++ b/services/api/src/users/routers/admin.py
@@ -1,14 +1,14 @@
 from fastapi import APIRouter, Depends, status
-from src.core.dependencies import DatabaseDep, CurrentUser
+from src.core.dependencies import DatabaseDep, get_current_admin
 from src.core.responses import ApiResponse
-from src.core.exceptions import Forbidden
-from src.users.schemas import UserCreate, AdminUserUpdate, ProfileUpdate, UserResponse
+from src.users.schemas import UserCreate, AdminUserUpdate, UserResponse
 from src.users.service import UserService
 
 
 router = APIRouter(
     prefix="/users",
     tags=["Users"],
+    dependencies=[Depends(get_current_admin)],  # All routes require admin by default
 )
 
 
@@ -23,7 +23,6 @@ def get_user_service(db: DatabaseDep) -> UserService:
     description="Retrieve a list of all users in the system",
 )
 async def get_all_users(
-    current_user: CurrentUser,
     service: UserService = Depends(get_user_service),
 ) -> ApiResponse[list[UserResponse]]:
     """
@@ -38,47 +37,6 @@ async def get_all_users(
 
 
 @router.get(
-    "/me",
-    response_model=ApiResponse[UserResponse],
-    summary="Get my profile",
-    description="Retrieve the user's own profile info.",
-)
-async def get_my_profile(
-    current_user: CurrentUser,
-) -> ApiResponse[UserResponse]:
-    """
-    GET /users/me
-    """
-    return ApiResponse(
-        success=True,
-        message="Profile retrieved successfully",
-        data=current_user,
-    )
-
-
-@router.put(
-    "/me",
-    response_model=ApiResponse[UserResponse],
-    summary="Update my profile",
-    description="Update your own profile info.",
-)
-async def update_my_profile(
-    profile_data: ProfileUpdate,
-    current_user: CurrentUser,
-    service: UserService = Depends(get_user_service),
-) -> ApiResponse[UserResponse]:
-    """
-    PUT /users/me
-    """
-    updated_user = await service.update_profile(current_user.id, profile_data)
-    return ApiResponse(
-        success=True,
-        message="Profile updated successfully",
-        data=updated_user,
-    )
-
-
-@router.get(
     "/{user_id}",
     response_model=ApiResponse[UserResponse],
     summary="Admin gets user by ID",
@@ -86,19 +44,12 @@ async def update_my_profile(
 )
 async def get_user_by_id(
     user_id: int,
-    current_user: CurrentUser,
     service: UserService = Depends(get_user_service),
 ) -> ApiResponse[UserResponse]:
     """
     GET /users/{user_id}
     Admin-only endpoint.
-
-    Note: this explicit role checking is just for the mvp but in the future,
-    this better be replaced with a dependency for RBAC
     """
-    # Simple role check
-    if current_user.role != "admin":
-        raise Forbidden(detail="Only admins can access this endpoint")
 
     user = await service.get_user_by_id(user_id)
     return ApiResponse(
@@ -117,7 +68,6 @@ async def get_user_by_id(
 )
 async def create_user(
     user_data: UserCreate,
-    current_user: CurrentUser,
     service: UserService = Depends(get_user_service),
 ) -> ApiResponse[UserResponse]:
     """
@@ -140,19 +90,12 @@ async def create_user(
 async def update_user(
     user_id: int,
     user_data: AdminUserUpdate,
-    current_user: CurrentUser,
     service: UserService = Depends(get_user_service),
 ) -> ApiResponse[UserResponse]:
     """
     PUT /users/{user_id}
     Admin-only endpoint.
-
-    Note: this explicit role checking is just for the mvp but in the future,
-    this better be replaced with a dependency for RBAC
     """
-    # Simple role check
-    if current_user.role != "admin":
-        raise Forbidden(detail="Only admins can access this endpoint")
 
     updated_user = await service.admin_update_user(user_id, user_data)
     return ApiResponse(
@@ -170,7 +113,6 @@ async def update_user(
 )
 async def delete_user(
     user_id: int,
-    current_user: CurrentUser,
     service: UserService = Depends(get_user_service),
 ) -> None:
     """

--- a/services/api/src/users/routers/profile.py
+++ b/services/api/src/users/routers/profile.py
@@ -1,0 +1,55 @@
+from fastapi import APIRouter, Depends
+from src.core.dependencies import CurrentUser, DatabaseDep
+from src.users.service import UserService
+from src.core.responses import ApiResponse
+from src.users.schemas import ProfileUpdate, UserResponse
+
+router = APIRouter(
+    prefix="/profile",
+    tags=["Profile"],
+)
+
+
+def get_user_service(db: DatabaseDep) -> UserService:
+    return UserService(db=db)
+
+
+@router.get(
+    "/me",
+    response_model=ApiResponse[UserResponse],
+    summary="Get my profile",
+    description="Retrieve the user's own profile info.",
+)
+async def get_my_profile(
+    current_user: CurrentUser,
+) -> ApiResponse[UserResponse]:
+    """
+    GET /profile/me
+    """
+    return ApiResponse(
+        success=True,
+        message="Profile retrieved successfully",
+        data=current_user,
+    )
+
+
+@router.put(
+    "/me",
+    response_model=ApiResponse[UserResponse],
+    summary="Update my profile",
+    description="Update your own profile info.",
+)
+async def update_my_profile(
+    profile_data: ProfileUpdate,
+    current_user: CurrentUser,
+    service: UserService = Depends(get_user_service),
+) -> ApiResponse[UserResponse]:
+    """
+    PUT /profile/me
+    """
+    updated_user = await service.update_profile(current_user.id, profile_data)
+    return ApiResponse(
+        success=True,
+        message="Profile updated successfully",
+        data=updated_user,
+    )

--- a/services/api/src/users/schemas.py
+++ b/services/api/src/users/schemas.py
@@ -1,14 +1,7 @@
 from pydantic import BaseModel, EmailStr, Field
 from datetime import datetime
 from typing import Optional
-from enum import Enum
-
-
-class UserRole(str, Enum):
-    """Current allowed user roles in the system."""
-
-    USER = "user"
-    ADMIN = "admin"
+from src.db.models import UserRole
 
 
 class UserCreate(BaseModel):
@@ -22,9 +15,9 @@ class UserCreate(BaseModel):
 
 class AdminUserUpdate(BaseModel):
     name: Optional[str] = Field(None, min_length=3, max_length=40)
-    email: Optional[EmailStr]
+    email: Optional[EmailStr] = None
     role: Optional[UserRole] = None
-    is_active: Optional[bool]
+    is_active: Optional[bool] = None
 
 
 class ProfileUpdate(BaseModel):


### PR DESCRIPTION
**Role-based API restructuring:**

* Split the user routes into `admin_router` for admin-only user management actions and `profile_router` for user self-service profile actions; updated imports and router registration in `app.py` and added an `__init__.py` to expose routers. 
* Renamed `users/router.py` to `users/routers/admin.py`, removed profile-related endpoints from the admin router, and enforced admin-only access using a new dependency (`get_current_admin`) applied to all admin routes.
* Added a new `users/routers/profile.py` with endpoints for users to get and update their own profile, previously handled in the user router.

**Authorization improvements:**

* Updated JWT token creation and decoding to include the user's role, enabling more robust authorization checks throughout the system. 
* Centralized the `UserRole` enum definition in `db.models` and updated references in user schemas for consistency.
Closes #82 