### PR TITLE
fix(auth): make login case-insensitive

### DIFF
--- a/services/api/src/auth/service.py
+++ b/services/api/src/auth/service.py
@@ -25,7 +25,7 @@ class AuthService:
         return await self.db.get(User, user_id)
 
     async def get_user_by_email(self, email: str) -> User | None:
-        statement = select(User).where(User.email == email)
+        statement = select(User).where(User.email == email.lower())
         result = await self.db.exec(statement)
         return result.first()
 


### PR DESCRIPTION
- Modified get_user_by_email in auth service to use email.lower()
- Ensures User@example.com and user@example.com are treated as same
- Fixes issue #75

Closes #75