### PR TITLE
feat(canvas): color-code node types

### DIFF
--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -22,6 +22,22 @@
   --color-input: var(--input);
   --color-ring: var(--ring);
 
+  --color-node-trigger: var(--node-trigger);
+  --color-node-trigger-bg: var(--node-trigger-bg);
+  --color-node-trigger-border: var(--node-trigger-border);
+  --color-node-core: var(--node-core);
+  --color-node-core-bg: var(--node-core-bg);
+  --color-node-core-border: var(--node-core-border);
+  --color-node-http: var(--node-http);
+  --color-node-http-bg: var(--node-http-bg);
+  --color-node-http-border: var(--node-http-border);
+  --color-node-email: var(--node-email);
+  --color-node-email-bg: var(--node-email-bg);
+  --color-node-email-border: var(--node-email-border);
+  --color-node-agent: var(--node-agent);
+  --color-node-agent-bg: var(--node-agent-bg);
+  --color-node-agent-border: var(--node-agent-border);
+
   --font-sans: var(--font-sans);
   --font-display: var(--font-display);
 

--- a/apps/web/src/features/canvas/components/LibraryGroups.tsx
+++ b/apps/web/src/features/canvas/components/LibraryGroups.tsx
@@ -135,16 +135,19 @@ export function LibraryGroups({ containerRef, onAdd }: LibraryProps) {
     title,
     icon: Icon,
     items,
+    colorClass,
   }: {
     title: string;
     icon: React.ComponentType<React.SVGProps<SVGSVGElement>>;
     items: { label: string; type: NodeKind }[];
+    colorClass: string;
   }) => (
     <details
       open
       className="rounded-[calc(var(--radius)-0.25rem)] border border-border/60 bg-muted/20 p-2"
     >
       <summary className="flex cursor-pointer items-center gap-2 text-xs font-medium text-muted-foreground">
+        <div className={`h-2 w-2 rounded-full ${colorClass}`} />
         <Icon className="h-3.5 w-3.5" />
         {title}
       </summary>
@@ -168,26 +171,31 @@ export function LibraryGroups({ containerRef, onAdd }: LibraryProps) {
         title="Triggers"
         icon={Play}
         items={[{ label: "Manual Trigger", type: "trigger" }]}
+        colorClass="bg-node-trigger"
       />
       <Group
         title="Core"
         icon={GitBranch}
         items={[{ label: "If", type: "if" }]}
+        colorClass="bg-node-core"
       />
       <Group
         title="HTTP"
         icon={Globe}
         items={[{ label: "HTTP Request", type: "http" }]}
+        colorClass="bg-node-http"
       />
       <Group
         title="Email"
         icon={Mail}
         items={[{ label: "SMTP Email", type: "smtp" }]}
+        colorClass="bg-node-email"
       />
       <Group
         title="Agents"
         icon={Bot}
         items={[{ label: "Agent", type: "agent" }]}
+        colorClass="bg-node-agent"
       />
     </div>
   );

--- a/apps/web/src/features/canvas/nodes/AgentNode.tsx
+++ b/apps/web/src/features/canvas/nodes/AgentNode.tsx
@@ -10,6 +10,8 @@ export function AgentNode({ data }: NodeProps<Node<AgentData>>) {
     <BaseNode
       icon={<Bot className="h-4 w-4 text-muted-foreground" />}
       label={data.label ?? "Agent"}
+      bgClassName="bg-node-agent-bg"
+      borderColor="--node-agent-border"
     >
       <div className="text-xs text-muted-foreground">
         Model • Tools • Limits

--- a/apps/web/src/features/canvas/nodes/BaseNode.tsx
+++ b/apps/web/src/features/canvas/nodes/BaseNode.tsx
@@ -5,11 +5,20 @@ type BaseNodeProps = {
   icon: React.ReactNode;
   label: string;
   children?: ReactNode;
+  bgClassName?: string;
+  borderColor?: string;
 };
 
-export function BaseNode({ icon, label, children }: BaseNodeProps) {
+export function BaseNode({ icon, label, children, bgClassName = "bg-card", borderColor }: BaseNodeProps) {
+  const borderStyle = borderColor
+    ? { borderColor: `var(${borderColor})`, borderWidth: '2px' }
+    : {};
+
   return (
-    <div className="rune-node min-w-[200px] rounded-[var(--radius)] border border-border/70 bg-card p-3 text-sm text-foreground shadow-sm">
+    <div
+      className={`rune-node min-w-[200px] rounded-[var(--radius)] border-2 ${bgClassName} p-3 text-sm text-foreground shadow-sm`}
+      style={borderStyle}
+    >
       <div className="flex items-center gap-2 font-medium">
         {icon}
         {label}

--- a/apps/web/src/features/canvas/nodes/HttpNode.tsx
+++ b/apps/web/src/features/canvas/nodes/HttpNode.tsx
@@ -10,6 +10,8 @@ export function HttpNode({ data }: NodeProps<Node<HttpData>>) {
     <BaseNode
       icon={<Globe className="h-4 w-4 text-muted-foreground" />}
       label={data.label ?? "HTTP"}
+      bgClassName="bg-node-http-bg"
+      borderColor="--node-http-border"
     >
       <div className="flex items-center justify-between">
         <span className="truncate text-xs text-muted-foreground">

--- a/apps/web/src/features/canvas/nodes/IfNode.tsx
+++ b/apps/web/src/features/canvas/nodes/IfNode.tsx
@@ -6,7 +6,10 @@ import type { IfData } from "../types";
 
 export function IfNode({ data }: NodeProps<Node<IfData>>) {
   return (
-    <div className="rune-node min-w-[180px] rounded-[var(--radius)] border border-border/70 bg-card p-3 text-sm text-foreground shadow-sm">
+    <div
+      className="rune-node min-w-[180px] rounded-[var(--radius)] border-2 bg-node-core-bg p-3 text-sm text-foreground shadow-sm"
+      style={{ borderColor: 'var(--node-core-border)' }}
+    >
       <div className="flex items-center gap-2 font-medium">
         <GitBranch className="h-4 w-4 text-muted-foreground" />
         {data.label ?? "If"}

--- a/apps/web/src/features/canvas/nodes/SmtpNode.tsx
+++ b/apps/web/src/features/canvas/nodes/SmtpNode.tsx
@@ -10,6 +10,8 @@ export function SmtpNode({ data }: NodeProps<Node<SmtpData>>) {
     <BaseNode
       icon={<Mail className="h-4 w-4 text-muted-foreground" />}
       label={data.label ?? "SMTP"}
+      bgClassName="bg-node-email-bg"
+      borderColor="--node-email-border"
     >
       <div className="truncate text-xs text-muted-foreground">
         To: {data.to ?? "user@example.com"}

--- a/apps/web/src/features/canvas/nodes/TriggerNode.tsx
+++ b/apps/web/src/features/canvas/nodes/TriggerNode.tsx
@@ -6,7 +6,10 @@ import type { TriggerData } from "../types";
 
 export function TriggerNode({ data }: NodeProps<Node<TriggerData>>) {
   return (
-    <div className="rune-node min-w-[120px] rounded-[var(--radius)] border border-border/70 bg-primary/10 p-2 text-sm">
+    <div
+      className="rune-node min-w-[120px] rounded-[var(--radius)] border-2 bg-node-trigger-bg p-2 text-sm"
+      style={{ borderColor: 'var(--node-trigger-border)' }}
+    >
       <div className="flex items-center gap-2 font-medium text-foreground">
         <Play className="h-4 w-4 text-muted-foreground" />
         {data.label ?? "Trigger"}

--- a/apps/web/src/styles/tokens.css
+++ b/apps/web/src/styles/tokens.css
@@ -35,6 +35,23 @@
 
   --shadow-sm: 0 4px 16px hsl(220 55% 6% / 0.45);
   --shadow-lg: 0 24px 48px hsl(220 55% 6% / 0.4);
+
+  /* Node group colors */
+  --node-trigger: hsl(217 91% 60%);
+  --node-trigger-bg: hsl(217 91% 60% / 0.18);
+  --node-trigger-border: hsl(217 91% 60% / 0.35);
+  --node-core: hsl(270 70% 65%);
+  --node-core-bg: hsl(270 70% 65% / 0.18);
+  --node-core-border: hsl(270 70% 65% / 0.35);
+  --node-http: hsl(142 76% 56%);
+  --node-http-bg: hsl(142 76% 56% / 0.18);
+  --node-http-border: hsl(142 76% 56% / 0.35);
+  --node-email: hsl(25 95% 63%);
+  --node-email-bg: hsl(25 95% 63% / 0.18);
+  --node-email-border: hsl(25 95% 63% / 0.35);
+  --node-agent: hsl(189 85% 62%);
+  --node-agent-bg: hsl(189 85% 62% / 0.18);
+  --node-agent-border: hsl(189 85% 62% / 0.35);
 }
 
 * {


### PR DESCRIPTION
Enhances canvas visual hierarchy by implementing color-coded node types. Each node category now has a distinct color scheme making workflows easier to scan and understand at a glance.

Closes #85 