### PR TITLE
feat(canvas): add incremental labeling for duplicate nodes

### DIFF
--- a/apps/web/src/features/canvas/hooks/useAddNode.ts
+++ b/apps/web/src/features/canvas/hooks/useAddNode.ts
@@ -79,14 +79,30 @@ export function useAddNode(
 
       const defaults = NODE_DEFAULTS[kind];
 
-      const newNode = {
-        id: createId(),
-        position,
-        type: defaults.type,
-        data: defaults.data,
-      } as CanvasNode;
+      setNodes((nodes) => {
+        const baseLabel = defaults.data.label ?? "Node";
+        const existingLabels = nodes
+          .filter((node) => node.type === kind)
+          .map((node) => node.data.label)
+          .filter((label): label is string => !!label);
 
-      setNodes((nodes) => nodes.concat(newNode));
+        let newLabel = baseLabel;
+        let counter = 2;
+
+        while (existingLabels.includes(newLabel)) {
+          newLabel = `${baseLabel} ${counter}`;
+          counter++;
+        }
+
+        const newNode = {
+          id: createId(),
+          position,
+          type: defaults.type,
+          data: { ...defaults.data, label: newLabel },
+        } as CanvasNode;
+
+        return nodes.concat(newNode);
+      });
     },
     [containerRef, rfInstanceRef, setNodes],
   );


### PR DESCRIPTION
Nodes now auto-increment their labels when added multiple times (e.g., "If", "If 2", "If 3") to prevent duplicate labels and improve clarity in the canvas.