### PR TITLE
fix(canvas): validate label uniqueness across all nodes

### DIFF
--- a/apps/web/src/features/canvas/hooks/useAddNode.ts
+++ b/apps/web/src/features/canvas/hooks/useAddNode.ts
@@ -82,7 +82,6 @@ export function useAddNode(
       setNodes((nodes) => {
         const baseLabel = defaults.data.label ?? "Node";
         const existingLabels = nodes
-          .filter((node) => node.type === kind)
           .map((node) => node.data.label)
           .filter((label): label is string => !!label);
 


### PR DESCRIPTION
Ensures all node labels are unique canvas-wide by validating against all existing labels (not just same type) when adding nodes.