### PR TITLE
fix(worker): smtp node parsing

### DIFF
--- a/services/rune-worker/pkg/nodes/custom/smtp/smtp_node.go
+++ b/services/rune-worker/pkg/nodes/custom/smtp/smtp_node.go
@@ -102,16 +102,18 @@ func NewSMTPNode(execCtx plugin.ExecutionContext) *SMTPNode {
 		}
 	}
 
-	// Parse subject
-	if subject, ok := execCtx.Parameters["subject"].(string); ok {
-		node.subject = subject
+	// Parse subject (accept any value)
+	if subject := execCtx.Parameters["subject"]; subject != nil {
+		node.subject = fmt.Sprintf("%v", subject)
 	}
 
 	// Parse body
-	if body, ok := execCtx.Parameters["body"].(string); ok {
-		node.body = body
+	if body := execCtx.Parameters["body"]; body != nil {
+		node.body = fmt.Sprintf("%v", body) // We need the body to accept any value not just strings, instead of being resolved prematurely
 	}
 
+	// TODO(worker): update parsing logic for the other fields if needed to match the parsing logic of subject and body
+	
 	return node
 }
 


### PR DESCRIPTION
This pull request updates the parsing logic for the `subject` and `body` fields in the `NewSMTPNode` constructor to accept any value, not just strings. This change increases flexibility for these fields and includes a note to potentially update parsing for other fields in the future.