### PR TITLE
fix(canvas): correct switch node fallback handle position

### DIFF
--- a/apps/web/src/features/canvas/nodes/SwitchNode.tsx
+++ b/apps/web/src/features/canvas/nodes/SwitchNode.tsx
@@ -91,16 +91,22 @@ export const SwitchNode = memo(function SwitchNode({
       </div>
 
       <Handle type="target" position={Position.Left} className="!bg-ring" />
-      {handleLayout.map((h) => (
-        <Handle
-          key={h.id}
-          id={h.id}
-          type="source"
-          position={Position.Right}
-          className="!bg-ring"
-          style={{ top: h.top }}
-        />
-      ))}
+      {handleLayout.map((h, idx) => {
+        // The fallback handle (last item) needs a dynamic key that includes rules.length
+        // to force React to remount it when rules change. This ensures React Flow
+        // registers the handle at its new position.
+        const isFallback = idx === handleLayout.length - 1;
+        return (
+          <Handle
+            key={isFallback ? `${h.id}-${rules.length}` : h.id}
+            id={h.id}
+            type="source"
+            position={Position.Right}
+            className="!bg-ring"
+            style={{ top: h.top }}
+          />
+        );
+      })}
     </div>
   );
 });


### PR DESCRIPTION
**Issue:** The Switch node's fallback handle edge was rendering from the wrong position after adding/removing rules. The edge label showed "fallback" correctly, but the visual connection line originated from a position above where it should be (typically where the last case handle was). A page reload would fix the visual issue.

**Root Cause**: React Flow caches handle positions internally. When rules are added/removed on a Switch node, case handles maintain their array indices (case-0 stays at index 0, etc.), but the fallback handle's position shifts. Because the fallback handle kept the same React key (switch-fallback), React reused the existing DOM element rather than remounting it, causing React Flow to use stale cached position data.

**Fix**: Fallback handle now uses a dynamic key that includes `rules.length`. This forces React to unmount and remount the fallback handle whenever the number of rules changes, which causes React Flow to register the handle fresh at its correct position.