### PR TITLE
docs(rfcs): add RFCs for split, merge, wait, and edit nodes

### DIFF
--- a/services/rune-worker/rfcs/README.md
+++ b/services/rune-worker/rfcs/README.md
@@ -47,6 +47,67 @@ Complete specification of the JSON-based Domain-Specific Language for defining w
 
 ---
 
+### [RFC-003-switch-node.md](./RFC-003-switch-node.md)
+**Status**: Implemented  
+**Created**: 2025-11-21  
+**Title**: Switch Node Implementation
+
+Definition of the Switch Node for multi-path conditional routing:
+- Rule-based routing logic
+- Support for multiple comparison operators
+- Fallback path mechanism
+- Integration with workflow executor
+
+---
+
+### [RFC-004-split-aggregate.md](./RFC-004-split-aggregate.md)
+**Status**: Proposed  
+**Created**: 2025-11-28  
+**Title**: Distributed Fan-Out/Fan-In Execution Pattern
+
+Architecture for Data Parallelism using Split and Aggregator nodes:
+- Split Node for scattering execution
+- Aggregator Node for gathering results
+- Lineage Stack for nested context tracking
+
+---
+
+### [RFC-005-merge.md](./RFC-005-merge.md)
+**Status**: Proposed  
+**Created**: 2025-11-28  
+**Title**: Merge Node Architecture
+
+Specification for synchronizing distributed execution paths:
+- Wait for All (Barrier Synchronization)
+- Wait for Any (Race Condition Handling)
+- Timeout handling mechanisms
+
+---
+
+### [RFC-006-wait.md](./RFC-006-wait.md)
+**Status**: Proposed  
+**Created**: 2025-11-28  
+**Title**: Distributed Wait Node & Scheduler Architecture
+
+Architecture for pausing workflow execution:
+- Timerless architecture using Redis Sorted Sets
+- Decoupled Scheduler for polling
+- Support for resuming specific parallel branches
+
+---
+
+### [RFC-007-edit.md](./RFC-007-edit.md)
+**Status**: Proposed  
+**Created**: 2025-05-01  
+**Title**: Edit Node Architecture (Data Transformation)
+
+Specification for the Edit Node for data manipulation:
+- Stateless execution model
+- JavaScript Sandbox (Goja) for dynamic expressions
+- Support for projection, enrichment, and transformation
+
+---
+
 ### [ISSUE_RECURSIVE_EXECUTOR.md](./ISSUE_RECURSIVE_EXECUTOR.md)
 **Status**: Superseded by RFC-001  
 **Title**: Implement Recursive Node-by-Node Executor with RabbitMQ

--- a/services/rune-worker/rfcs/RFC-003-switch-node.md
+++ b/services/rune-worker/rfcs/RFC-003-switch-node.md
@@ -24,7 +24,7 @@ Each rule in the `rules` list is an object with:
 
 | Field | Type | Description |
 | :--- | :--- | :--- |
-| `value` | `string` | The left-hand side value to check. Supports dynamic references (e.g., `$input.status`). |
+| `value` | `string` | The left-hand side value to check. Supports dynamic references (e.g., `$input.status`). Resolved values (e.g. numbers) are automatically converted to strings. |
 | `operator` | `string` | The comparison operator. Supported: `==`, `!=`, `>`, `<`, `>=`, `<=`, `contains`. |
 | `compare` | `string` | The right-hand side value to compare against. Supports literals and references. |
 

--- a/services/rune-worker/rfcs/RFC-004-split-aggregate.md
+++ b/services/rune-worker/rfcs/RFC-004-split-aggregate.md
@@ -1,0 +1,241 @@
+# **RFC 004: Distributed Fan-Out/Fan-In Execution Pattern**
+
+## **1\. Abstract**
+
+This document specifies the architecture for **Data Parallelism** within the Rune engine. It introduces two infrastructure-level nodes:
+
+1. **Split Node (split):** Implements the "Fan-Out" pattern, splitting array data into independent execution threads ("Mini-Workflows").  
+2. **Aggregator Node (aggregator):** Implements the "Fan-In" pattern, acting as a distributed synchronization barrier to recombine parallel threads.
+
+To support complex scenarios like nested loops (e.g., "For every User, iterate their Orders"), this RFC introduces a **Lineage Stack** protocol. This ensures that child branches execute in isolation but maintain the ancestral context required to merge correctly at the right level.
+
+## **2\. Motivation**
+
+The current recursive executor (RFC-001) processes workflows linearly. If a node outputs an array of 10,000 items, the subsequent node receives the entire array as a single payload. This creates two problems:
+
+1. **Performance:** A single worker must process all 10,000 items sequentially.  
+2. **Reliability:** If item \#9,999 fails, the entire batch might fail or require complex checkpointing.
+
+By "exploding" the array into 10,000 discrete RabbitMQ messages, we achieve:
+
+* **Horizontal Scaling:** 50 workers can process the batch simultaneously.  
+* **Fault Isolation:** Item \#5 failing does not stop Item \#6.  
+* **Granular Retry:** Only failed items are retried.
+
+## **3\. Data Structures & Protocol Updates**
+
+### **3.1 The Lineage Stack**
+
+To manage nested splits, we cannot use a simple "Parent ID". We must track the full hierarchy of splits. We extend the NodeExecutionMessage envelope.
+
+**New Field:** lineage\_stack (Array of Objects)
+
+Each entry in the stack represents an active split context.
+
+type StackFrame struct {  
+    SplitNodeID string \`json:"split\_node\_id"\` // The node that generated this split  
+    BranchID    string \`json:"branch\_id"\`     // Unique ID: {exec\_id}\_{split\_node}\_{index}  
+    ItemIndex   int    \`json:"item\_index"\`    // 0-based index of this item  
+    TotalItems  int    \`json:"total\_items"\`   // Total count in this batch  
+}
+
+**Message JSON Example (Nested Context):**
+
+{  
+  "execution\_id": "exec\_123",  
+  "current\_node": "process\_order\_item",  
+  "accumulated\_context": { ... },   
+  "lineage\_stack": \[  
+    // Bottom: Outer Loop (Users)  
+    { "split\_node\_id": "split\_users", "item\_index": 5, "total\_items": 100, ... },  
+    // Top: Inner Loop (Orders)  
+    { "split\_node\_id": "split\_orders", "item\_index": 2, "total\_items": 5, ... }  
+  \]  
+}
+
+**Worker Middleware Requirement:** All standard workers (HTTP, SMTP, etc.) **MUST** blindly copy the lineage\_stack from their input message to their output message. They are stateless regarding the stack.
+
+## **4\. Node Specifications**
+
+### **4.1 Split Node (split)**
+
+**Role:** The "Scatter" mechanism.
+
+Parameters:  
+| Parameter | Type | Description |  
+| :--- | :--- | :--- |  
+| input\_array | string | Dynamic reference to the array (e.g., {{ $node.Http.body.users }}). |  
+**Execution Logic:**
+
+1. **Resolution:** Evaluate input\_array. Validates result is a Slice/Array. Let $N$ be the length.  
+   * *Edge Case:* If Array is empty ($N=0$), see Section 6.1.  
+2. **State Initialization:**  
+   * Set exec:{id}:split:{my\_id}:expected \= $N$ in Redis.  
+   * *TTL:* Set to 24h or Workflow Timeout.  
+3. **Fan-Out (Publishing Loop):**  
+   * Iterate $i$ from $0$ to $N-1$.  
+   * **Context Isolation:** Create a new accumulated\_context. This new context usually promotes the specific item to a top-level key (e.g., $input or $item) so downstream nodes don't need to know the index.  
+   * **Stack Manipulation:** \* Clone incoming lineage\_stack.  
+     * Push new Frame: { SplitNodeID: my\_id, ItemIndex: i, TotalItems: N }.  
+   * **Publish:** Send NodeExecutionMessage to the next node(s).  
+4. **Termination:** The Split node **stops**. It does not publish a completion message for itself.
+
+### **4.2 Aggregator Node (aggregator)**
+
+**Role:** The "Gather" mechanism and Synchronization Barrier.
+
+Parameters:  
+| Parameter | Type | Default | Description |  
+| :--- | :--- | :--- | :--- |  
+| timeout | int | 300 | Seconds to wait for all items before failing. |  
+**Execution Logic:**
+
+1. **Context Resolution:**  
+   * Peek at lineage\_stack\[len-1\] (Top Frame).  
+   * *Validation:* If stack is empty, throw error (Aggregator placed outside a split).  
+   * Let SplitID \= frame.SplitNodeID.  
+2. **Atomic Synchronization (Lua):**  
+   * Call aggregate.lua with SplitID, frame.ItemIndex, and frame.TotalItems.  
+   * Pass the current accumulated\_context (or just the specific branch result) as the payload.  
+3. **Result Handling:**  
+   * **Barrier Pending:** \* Worker ACKs message.  
+     * Worker emits NodeStatusMessage (Status: "waiting", Summary: "Collected X/N").  
+     * Worker **Exits** (Stateless sleep).  
+   * **Barrier Complete:**  
+     * Lua script returns the full, sorted list of results.  
+     * **Stack Pop:** Remove the Top Frame from lineage\_stack.  
+     * **Context Merge:** Update accumulated\_context. Usually sets $node\_name \= \[Result\_0, Result\_1, ...\].  
+     * **Publish:** Send NodeExecutionMessage to the next node.
+
+## **5\. Technical Implementation Details**
+
+### **5.1 Redis Data Schema**
+
+All keys are scoped by ExecutionID and the SplitNodeID (from the stack). This ensures uniqueness even if multiple Aggregators exist.
+
+* exec:{id}:split:{split\_id}:results (**Hash**)  
+  * Field: item\_index (string)  
+  * Value: JSON payload  
+* exec:{id}:split:{split\_id}:count (**String/Counter**)  
+  * Value: integer (Number of items arrived)  
+* exec:{id}:split:{split\_id}:expected (**String**)  
+  * Value: integer (Total items expected \- set by Split)
+
+### **5.2 The Aggregation Lua Script**
+
+This script ensures atomicity. We cannot read/check/write in Go code due to race conditions.
+
+\-- script: aggregate.lua  
+\-- KEYS\[1\]: results\_hash\_key  
+\-- KEYS\[2\]: count\_key  
+\-- KEYS\[3\]: expected\_key  
+\-- ARGV\[1\]: item\_index  
+\-- ARGV\[2\]: item\_result\_json
+
+\-- 1\. Save the result for this specific item  
+redis.call('HSET', KEYS\[1\], ARGV\[1\], ARGV\[2\])
+
+\-- 2\. Increment the "Arrived" counter  
+local current \= redis.call('INCR', KEYS\[2\])
+
+\-- 3\. Fetch the target total (set by Split)  
+local total\_str \= redis.call('GET', KEYS\[3\])  
+if not total\_str then  
+    return redis.error\_reply("ERR\_MISSING\_TOTAL: Split did not initialize expected count")  
+end  
+local total \= tonumber(total\_str)
+
+\-- 4\. Check Barrier  
+if current \== total then  
+    \-- BARRIER OPEN\!  
+      
+    \-- Fetch all items in order 0..N-1  
+    local combined \= {}  
+    for i=0, (total-1) do  
+        local val \= redis.call('HGET', KEYS\[1\], tostring(i))  
+        if not val then   
+            \-- Should not happen in reliable messaging, but handle gracefully  
+            table.insert(combined, "null")   
+        else  
+            table.insert(combined, val)  
+        end  
+    end  
+      
+    \-- Cleanup Keys  
+    redis.call('DEL', KEYS\[1\], KEYS\[2\], KEYS\[3\])  
+      
+    \-- Return JSON array string  
+    return cjson.encode(combined)  
+else  
+    \-- Barrier still closed  
+    return nil  
+end
+
+### **5.3 Auto-Resolution (Ghost Signal)**
+
+If a user creates a branch that ends (e.g., Split \-\> If \-\> (False: End)) without merging, the Aggregator would hang.
+
+**Mechanism:**
+
+1. **Detection:** When Executor finishes a node and finds **0 outgoing edges**.  
+2. **Check:** Is lineage\_stack not empty?  
+3. **Action:**  
+   * Do **NOT** send CompletionMessage.  
+   * Identify the Top Frame (SplitID, Index).  
+   * **Ghost Commit:** Execute a variant of aggregate.lua that increments the counter but stores null (or a "skipped" marker) for that index.  
+   * **Recursive Check:** If this Ghost Commit triggers the barrier to open (i.e., this was the last item):  
+     * The "Virtual Aggregator" logic runs.  
+     * Pop the stack.  
+     * If stack is now empty \-\> Send CompletionMessage (Workflow Done).  
+     * If stack not empty \-\> Repeat Ghost Commit for the *next* parent frame.
+
+## **6\. Edge Cases**
+
+### **6.1 Empty Array (N=0)**
+
+If Split receives an empty list:
+
+* It cannot spawn children.  
+* **Action:** It must effectively "Jump" over the split scope.  
+* It creates a NodeExecutionMessage for the **next** node (or Aggregator) with an empty array payload immediately.  
+* *Note:* This requires the Split to know where the Aggregator is, or simpler: It publishes to the next node with lineage\_stack unchanged. If the next node is Aggregator, it handles empty input instantly.
+
+### **6.2 Partial Failures**
+
+If Item 5 panics or errors:
+
+* **Default:** The error is caught by Executor.  
+* **Policy:** The Executor sends an "Error Result" to the Aggregator (e.g., {"error": "timeout"}).  
+* **Result:** The Aggregator still finishes (Count reaches N). The output array contains 99 successes and 1 error object.
+
+### **6.3 Aggregator Timeout**
+
+If a worker crashes hard (RabbitMQ message lost before ACK) or logic hangs:
+
+* RabbitMQ DLX handles message retry.  
+* If purely logic timeout (e.g., item taking too long), the Aggregator's timeout parameter kicks in via a scheduled check (See RFC-005 Timeout Logic).
+
+## **7\. Observability & Status**
+
+### **7.1 Execution Graph**
+
+The UI needs to understand that one node is running 1,000 times.
+
+* NodeStatusMessage includes lineage\_stack.  
+* The UI groups these statuses by SplitNodeID.
+
+### **7.2 Progress Bars**
+
+The Aggregator emits waiting status updates on every arrival.
+
+* Payload: { "processed": 450, "total": 1000 }.  
+* Frontend: Uses this to show a live progress bar on the Aggregator node.
+
+## **8\. Implementation Checklist**
+
+* \[ \] **DSL:** Add split and aggregator to schema.  
+* \[ \] **Core:** Update MessageEnvelope struct.  
+* \[ \] **RabbitMQ:** Ensure prefetch counts are high enough for aggregators (or use standard 1 and rely on fast ACKs).  
+* \[ \] **Redis:** Deploy aggregate.lua.  
+* \[ \] **Executor:** Add logic to "Auto-Resolve" terminal nodes if stack is present.  
+* \[ \] **Tests:** Add integration test for Nested Loops (Split \-\> Split \-\> Agg \-\> Agg).

--- a/services/rune-worker/rfcs/RFC-005-merge.md
+++ b/services/rune-worker/rfcs/RFC-005-merge.md
@@ -1,0 +1,253 @@
+# **RFC 005: Merge Node Architecture**
+
+## **1\. Abstract**
+
+This document provides a comprehensive technical specification for the **Merge Node** within the Rune workflow engine. It addresses the challenge of synchronizing distributed, asynchronous execution paths. The design leverages **RabbitMQ** for message transport and **Redis** for atomic state management, barrier synchronization, and mutual exclusion locks. It details two distinct operational modes: wait\_for\_all (Barrier) and wait\_for\_any (Race), along with robust timeout handling mechanisms.
+
+## **2\. Motivation**
+
+In a distributed, event-driven architecture like Rune, workflow branches execute in isolation on separate worker instances. When execution paths split (e.g., via If nodes, parallel branches, or Switch nodes), they must often reconverge to aggregate data or continue a single unified process.
+
+A specialized **Merge Node** is essential to:
+
+1. **Synchronize Concurrent Execution:** Act as a barrier that halts downstream execution until all upstream dependencies are met (wait\_for\_all).  
+2. **Resolve Race Conditions:** Arbitrate scenarios where multiple branches could trigger the same downstream logic, ensuring mutual exclusion where only the first arrival wins (wait\_for\_any).  
+3. **Unify Data Contexts:** Intelligently merge the accumulated\_context from divergent branches back into a single source of truth.
+
+## **3\. Node Specification (DSL)**
+
+This new node type extends the DSL defined in RFC-002.
+
+**Type Identifier:** merge
+
+**Parameters:**
+
+| Parameter | Type | Default | Description |
+| :---- | :---- | :---- | :---- |
+| mode | enum | append | append: All incoming payloads are combined into an array. |
+| wait\_mode | enum | wait\_for\_all | wait\_for\_all: Synchronization barrier. Waits for *all* configured parent nodes to arrive. wait\_for\_any: First-past-the-post. The first parent to arrive triggers execution; others are ignored/discarded. |
+| timeout | integer | 300 | Safety timeout in seconds. If the condition is not met within this window, the node fails. |
+
+**Example JSON Definition:**
+
+{  
+  "id": "merge\_1",  
+  "type": "merge",  
+  "name": "Sync & Combine",  
+  "parameters": {  
+    "mode": "append",  
+    "wait\_mode": "wait\_for\_all",  
+    "timeout": 300  
+  },  
+  "output": {},  
+  "error": { "type": "halt" }  
+}
+
+## **4\. Architecture & Implementation**
+
+### **4.1 Message Flow & RabbitMQ**
+
+The Merge Node operates as a standard consumer on the workflow.execution queue but implements unique handler logic.
+
+* **Queue:** workflow.execution  
+* **Routing:** Standard round-robin distribution to stateless workers.
+
+**Lifecycle:**
+
+1. **Consumption:** Worker receives NodeExecutionMessage.  
+2. **Processing:** \* Unlike standard nodes that execute business logic immediately, the Merge Node executes **Infrastructure Logic** (Redis operations).  
+   * It checks the state of the barrier or lock.  
+3. **Resolution:**  
+   * **Condition Met:** The worker publishes a *new* NodeExecutionMessage for the child node(s) and ACKs the input.  
+   * **Condition Pending/Failed:** The worker ACKs the input message *without* publishing further execution messages. The execution path effectively "parks" or terminates at this worker.
+
+### **4.2 Redis Data Structures & Schema**
+
+Redis is used as the shared coordination backend. All keys are scoped by execution ID and node ID.
+
+**Key Prefix:** exec:{execution\_id}:node:{merge\_node\_id}
+
+#### **4.2.1 State Keys**
+
+* **Barrier Key (Hash):** {prefix}:barrier  
+  * Used for wait\_for\_all.  
+  * Stores partial results and arrival records.  
+* **Lock Key (String):** {prefix}:lock  
+  * Used for wait\_for\_any.  
+  * Acts as a mutual exclusion mutex.  
+* **Timeout Key (String):** {prefix}:timeout\_active  
+  * Flag to indicate if a timeout timer has already been scheduled.
+
+### **4.3 Detailed Execution Strategies**
+
+#### **4.3.1 Strategy A: Wait for All (Barrier Synchronization)**
+
+This mode implements a "Gather" pattern. It must wait for a specific set of parent nodes to complete.
+
+**Prerequisite:** The worker must identify the *expected* number of parents. This is derived statically from the workflow\_definition included in the message payload by inspecting the edges array.
+
+**Algorithm:**
+
+1. **Identify Sender:** Determine from\_node ID from the message envelope.  
+2. **Atomic Update (Lua):** Execute merge\_wait\_for\_all.lua.  
+   * Add from\_node to an arrived\_set in Redis.  
+   * Serialize and store the output from the incoming message into a context\_map in Redis.  
+   * Check if SCARD(arrived\_set) \== expected\_count.  
+3. **Result Handling:**  
+   * **Lua returns NIL:** Barrier is not full. ACK message. Stop.  
+   * **Lua returns Data:** Barrier is full.  
+     * Construct a new accumulated\_context merging the returned data.  
+     * Publish execution message to downstream nodes.  
+     * ACK message.
+
+**Lua Script (merge\_wait\_for\_all.lua):**
+
+\-- KEYS\[1\]: barrier\_key ({prefix}:barrier)  
+\-- ARGV\[1\]: incoming\_parent\_id  
+\-- ARGV\[2\]: incoming\_payload\_json  
+\-- ARGV\[3\]: expected\_parent\_count
+
+local barrier\_key \= KEYS\[1\]  
+local arrivals\_key \= barrier\_key .. ":arrivals"  
+local data\_key \= barrier\_key .. ":data"
+
+\-- 1\. Register Arrival  
+redis.call('SADD', arrivals\_key, ARGV\[1\])
+
+\-- 2\. Store Payload  
+\-- We prefix with '$' to distinguish node IDs in the map if needed,   
+\-- or simply use the ID as the field.  
+redis.call('HSET', data\_key, ARGV\[1\], ARGV\[2\])
+
+\-- 3\. Check Barrier Condition  
+local current\_count \= redis.call('SCARD', arrivals\_key)
+
+if tonumber(current\_count) \== tonumber(ARGV\[3\]) then  
+    \-- BARRIER OPEN: Retrieve all data  
+    local all\_payloads \= redis.call('HGETALL', data\_key)  
+      
+    \-- Cleanup Keys  
+    redis.call('DEL', arrivals\_key, data\_key, barrier\_key)  
+      
+    return all\_payloads   
+else  
+    \-- BARRIER PENDING  
+    return nil  
+end
+
+#### **4.3.2 Strategy B: Wait for Any (Race Condition Handling)**
+
+This mode implements a "First-Past-The-Post" pattern. Only the first branch to reach the node triggers downstream execution.
+
+**Algorithm:**
+
+1. **Atomic Lock Attempt:** Attempt to set the lock key using SETNX.  
+2. **Result Handling:**  
+   * **Success (1):** This is the winner.  
+     * Forward the payload to downstream nodes.  
+     * ACK message.  
+   * **Failure (0):** The node has already been executed by another branch.  
+     * ACK message.  
+     * Drop the payload (do nothing).
+
+Redis Command:  
+SET {prefix}:lock "executed" NX EX 86400  
+(NX \= Only set if not exists, EX \= Expire in 24h to prevent leaks)
+
+## **5\. Timeout Handling Mechanism**
+
+Timeouts are critical to prevent workflows from hanging indefinitely (zombie executions) if a branch fails silently or a message is lost.
+
+### **5.1 Architecture: The "Self-Destruct" Message**
+
+We utilize RabbitMQ's **Dead Letter Exchange (DLX)** capabilities to implement server-side delayed messaging without needing a dedicated scheduler service.
+
+**Components:**
+
+1. **Timeout Queue (workflow.timeout):** A queue with no consumers. Messages sent here sit for a specific TTL.  
+2. **DLX Configuration:** The workflow.timeout queue is configured to dead-letter messages to the workflow.timeout.process queue upon expiration.  
+3. **Process Queue (workflow.timeout.process):** A standard queue consumed by workers to handle expired timeouts.
+
+### **5.2 Setting the Timeout**
+
+When the Merge Node receives its **first** input (regardless of mode):
+
+1. **Check Active Flag:** Use SETNX {prefix}:timeout\_active "1".  
+2. **If New (Result 1):** \* Construct a TimeoutMessage payload: { "exec\_id": "...", "node\_id": "..." }.  
+   * Publish to workflow.timeout queue.  
+   * Set expiration header to parameters.timeout \* 1000 (ms).
+
+### **5.3 Handling the Timeout Event**
+
+A worker consumes from workflow.timeout.process.
+
+**Logic:**
+
+1. **Verify State:** Check Redis to see if the node is still pending.  
+   * *Wait for All:* Check if {prefix}:barrier exists.  
+   * *Wait for Any:* Check if {prefix}:lock exists (and if we want to fail on timeout even if successful, though usually wait\_for\_any doesn't strictly timeout if one succeeded. For wait\_for\_any, the timeout is usually relevant if *no one* arrives).
+
+   *Refined Logic:* \* For wait\_for\_all: If barrier keys exist, the merge is incomplete \-\> **FAIL**.
+
+   * For wait\_for\_any: If lock key does *not* exist, no one arrived \-\> **FAIL**.  
+2. **Action:**  
+   * **If Failed:**  
+     * Publish NodeStatusMessage with status: failed, error: "Timeout exceeded".  
+     * Publish CompletionMessage (status: failed) if this halts the workflow.  
+     * **Cleanup:** Delete all Redis keys (barrier, lock, data) to prevent late arrivals from triggering execution.
+
+## **6\. Message Protocol Updates**
+
+### **6.1 NodeExecutionMessage (Input)**
+
+We extend the envelope to support parent identification.
+
+**New Field:** from\_node (string, optional)
+
+* **Description:** The ID of the node that generated this message.  
+* **Requirement:** The Publisher logic in workflow\_publisher.go must be updated to populate this field when sending messages to children.
+
+**Example Payload:**
+
+{  
+  "workflow\_id": "wf\_123",  
+  "execution\_id": "exec\_abc",  
+  "current\_node": "merge\_node\_1",  
+  "from\_node": "http\_request\_A",  
+  "accumulated\_context": { ... }  
+}
+
+### **6.2 NodeStatusMessage (Output)**
+
+The Merge Node emits status updates to provide visibility into the "black box" of waiting.
+
+* **State: Waiting**  
+  * Trigger: Input received but barrier closed.  
+  * Payload: status: "waiting", details: { "arrived": 1, "expected": 2 }.  
+  * UI Behavior: Shows node in a "Pending" or "Yellow" state.  
+* **State: Success**  
+  * Trigger: Barrier opens or Lock acquired.  
+  * Payload: status: "success", output: { ...merged\_data... }.  
+  * UI Behavior: Shows node in "Green" state.  
+* **State: Timeout**  
+  * Trigger: Timeout message processed while pending.  
+  * Payload: status: "failed", error: "Operation timed out".  
+  * UI Behavior: Shows node in "Red" state.
+
+## **7\. Migration & Implementation Checklist**
+
+### **7.1 Infrastructure**
+
+* \[ \] Create workflow.timeout queue with DLX configuration pointing to workflow.timeout.process.  
+* \[ \] Create workflow.timeout.process queue.
+
+### **7.2 Worker Code (rune-worker)**
+
+* \[ \] **Publisher:** Update PublishExecution to accept and set fromNode.  
+* \[ \] **Consumer:** Add logic to handle merge node type separately (infrastructure logic vs business logic).  
+* \[ \] **Lua Scripts:** Implement and load merge\_wait\_for\_all.lua.  
+* \[ \] **Timeout Handler:** Create new consumer for workflow.timeout.process.
+
+### **7.3 DSL (rune-dsl)**
+
+* \[ \] Update JSON Schema to include merge node type and parameters.

--- a/services/rune-worker/rfcs/RFC-006-wait.md
+++ b/services/rune-worker/rfcs/RFC-006-wait.md
@@ -1,0 +1,220 @@
+# **RFC 006: Distributed Wait Node & Scheduler Architecture**
+
+## **1\. Abstract**
+
+This document specifies the architecture for the **Wait Node**, enabling workflows to pause execution for a specified duration or until a specific timestamp. The implementation utilizes a **Timerless Architecture** where compute resources are released immediately upon suspension.
+
+It leverages:
+
+1. **Redis Sorted Sets:** For high-performance scheduling of millions of timers.  
+2. **Decoupled Scheduler:** A background worker (Poller) that moves due tasks from Redis.  
+3. **Unified Execution Queue:** Resumed tasks are published back to the main workflow.execution queue, ensuring a consistent execution path and simplifying the worker consumer logic.  
+4. **Branch-Aware Context:** Full support for pausing/resuming specific parallel branches (Fan-Out) without blocking the main workflow, integrated with the Lineage Stack from RFC-004.
+
+## **2\. Motivation**
+
+In a distributed workflow engine, "waiting" poses specific challenges that cannot be solved with simple sleep() calls:
+
+* **Resource Efficiency:** Blocking a Go routine for "3 days" is not viable. State must be serialized and the thread released to the pool.  
+* **Concurrency:** If a workflow splits into 100 items (Fan-Out), and Item \#5 waits for 1 hour while Item \#6 finishes instantly, the engine must handle this heterogeneous state without stalling the entire workflow.  
+* **Resilience:** Timers must survive service restarts. A crash during a wait should not result in a lost resume event.
+
+## **3\. Node Specification (DSL)**
+
+**Type Identifier:** wait
+
+**Parameters:**
+
+| Parameter | Type | Default | Description |
+| :---- | :---- | :---- | :---- |
+| resume | enum | time\_interval | Options: time\_interval |
+| amount | integer | 1 | Quantity of time (for time\_interval). |
+| unit | enum | seconds | Unit of time. Options: seconds, minutes, hours, days. |
+
+**Example JSON:**
+
+{  
+  "id": "wait\_node\_1",  
+  "type": "wait",  
+  "name": "Wait for Approval",  
+  "parameters": {  
+    "resume": "time\_interval",  
+    "amount": 2,  
+    "unit": "hours"  
+  },  
+  "output": {},  
+  "error": { "type": "ignore" }  
+}
+
+## **4\. Architecture & Data Flow**
+
+### **4.1 System Components**
+
+1. **Executor (Worker):** Consumes workflow.execution. Handles the "Suspend" phase (calculating time, freezing state).  
+2. **Redis (Scheduler Store):**  
+   * **Priority Queue (ZSET):** Orders timers by epoch milliseconds.  
+   * **Payload Store (HASH):** Stores the "Frozen" execution message (Context \+ Lineage) indexed by a unique Timer ID.  
+3. **Scheduler (Poller):** A dedicated loop that polls Redis for expired timers and publishes execution messages directly to the main workflow.execution queue.
+
+### **4.2 Redis Data Schema**
+
+To support **RFC-004 (Parallelism)**, we cannot just store execution\_id. We must store a unique **Timer ID** that maps to the specific branch state (Execution ID \+ Node ID \+ Branch/Item Index).
+
+1. **The Schedule (ZSET):** scheduler:timers  
+   * **Score:** resume\_at\_epoch\_ms (int64)  
+   * **Member:** timer\_id (UUID)  
+2. **The Frozen State (HASH):** scheduler:payloads  
+   * **Field:** timer\_id  
+   * **Value:** JSON(NodeExecutionMessage)  
+   * *Note:* This payload contains the full execution\_id, lineage\_stack, accumulated\_context, etc., exactly as it was when the wait started.
+
+### **4.3 Execution Flow Diagram**
+
+sequenceDiagram  
+    participant Worker  
+    participant Redis  
+    participant Scheduler  
+    participant RabbitMQ
+
+    Note over Worker: Phase 1: Suspend  
+    Worker-\>\>Worker: Calculate resume\_at  
+    Worker-\>\>Worker: Serialize Message (Frozen State)  
+    Worker-\>\>Redis: HSET scheduler:payloads \<UUID\> \<MsgJSON\>  
+    Worker-\>\>Redis: ZADD scheduler:timers \<Time\> \<UUID\>  
+    Worker-\>\>RabbitMQ: ACK Execution Message  
+    Note over Worker: Worker Exits (Resource Freed)
+
+    Note over Scheduler: Phase 2: Poll (Async Loop)  
+    Scheduler-\>\>Redis: ZRANGEBYSCORE (Lua)  
+    Redis--\>\>Scheduler: Returns \[UUID\_1, UUID\_2\]  
+    Scheduler-\>\>Redis: HGET scheduler:payloads \<UUID\>  
+    Scheduler-\>\>Worker: Resolve Next Node (Graph Traversal)  
+    Scheduler-\>\>RabbitMQ: Publish to workflow.execution  
+    Scheduler-\>\>Redis: DEL payload & timer
+
+    Note over Worker: Phase 3: Resume  
+    RabbitMQ-\>\>Worker: Consume Execution Message  
+    Worker-\>\>Worker: Normal Execution Logic (Unaware of Wait)  
+    Worker-\>\>RabbitMQ: Publish Next Node (workflow.execution)
+
+## **5\. Detailed Execution Logic**
+
+### **5.1 Phase 1: Scheduling (The "Suspend")**
+
+**Context:** Worker consumes NodeExecutionMessage for a wait node.
+
+**Algorithm:**
+
+1. **Time Calculation:**  
+   * Compute resume\_at based on amount/unit or date\_time.  
+2. **Payload Construction (The "Freeze"):**  
+   * Create a struct FrozenState (or reuse NodeExecutionMessage) containing the *current* message data.  
+   * **Crucial:** This preserves lineage\_stack (RFC-004) and accumulated\_context. This ensures that when we wake up, we know exactly which parallel branch we are in.  
+   * Generate timer\_id \= UUID().  
+3. **Atomic Persistence (Redis Pipeline):**  
+   * HSET scheduler:payloads {timer\_id} {json\_string}  
+   * ZADD scheduler:timers {resume\_at} {timer\_id}  
+4. **Status Update:**  
+   * Publish NodeStatusMessage (status: "waiting", resume\_at: ...).  
+5. **Termination:**  
+   * **ACK** the original RabbitMQ message.  
+   * **Stop.** Do *not* execute the next node. The execution path for this branch ends here.
+
+### **5.2 Phase 2: The Tick (The "Scheduler")**
+
+**Context:** A standalone Scheduler service/goroutine running a time.Ticker (e.g., 500ms).
+
+**Algorithm:**
+
+1. **Poll (Lua):** Call poll\_timers.lua with now\_ms.  
+   * This script fetches timer\_ids where score \<= now.  
+   * It **removes** them from the ZSET (claiming the task) to prevent race conditions if multiple schedulers are running.  
+   * It returns the claimed timer\_ids.  
+2. **Fetch & Dispatch:**  
+   * For each timer\_id:  
+     * Retrieve payload: HGET scheduler:payloads {timer\_id}.  
+     * **Deserialization:** Parse the JSON into NodeExecutionMessage.  
+     * **Graph Traversal:**  
+       * Identify current\_node (the Wait node).  
+       * Find the **Next Node(s)** from the workflow\_definition (edges).  
+       * *Note:* If multiple edges exist, we must Fan-Out here (publish multiple messages).  
+     * **Publish:** \* Update the message current\_node to the ID of the *next* node.  
+       * Publish the message(s) to the workflow.execution queue.  
+     * **Cleanup:** HDEL scheduler:payloads {timer\_id} (Ideally, only after successful publish confirmation).
+
+**Lua Script (poll\_timers.lua):**
+
+\-- KEYS\[1\]: scheduler:timers  
+\-- ARGV\[1\]: current\_epoch\_ms  
+\-- ARGV\[2\]: batch\_size (e.g., 50\)
+
+\-- 1\. Find due items  
+local ids \= redis.call('ZRANGEBYSCORE', KEYS\[1\], '-inf', ARGV\[1\], 'LIMIT', 0, ARGV\[2\])
+
+if \#ids \> 0 then  
+    \-- 2\. Remove from schedule (Claim them)  
+    redis.call('ZREM', KEYS\[1\], unpack(ids))  
+end
+
+return ids
+
+### **5.3 Phase 3: Resumption (The "Wake")**
+
+**Context:** A standard Worker consumes from workflow.execution.
+
+**Algorithm:**
+
+1. **Standard Execution:** The worker receives a message. It sees current\_node is (e.g.) http\_request\_2.  
+2. **Transparency:** The worker is completely unaware that this message was "sleeping" for 3 days. It processes it as a normal execution step.  
+3. **Lineage Continuity:** Because the lineage\_stack was preserved in the frozen payload and passed to this new message, the worker correctly participates in any parent Aggregation barriers (RFC-004) further down the line.
+
+## **6\. Message Type Handling Strategy**
+
+### **6.1 NodeExecutionMessage**
+
+* **Input (Phase 1):** Triggers the Suspend logic. The worker identifies type: "wait" and executes the scheduling logic instead of business logic.  
+* **Output (Phase 2 \- Scheduler):** The Scheduler acts as a pseudo-worker. It generates the *next* NodeExecutionMessage pointing to the successor node and injects it back into the stream.
+
+### **6.2 NodeStatusMessage**
+
+* **Phase 1 (Sleep):** Emits waiting. Used by UI to show a "Pause" icon or timer countdown.  
+  * Payload: { "node\_id": "wait\_1", "status": "waiting", "metadata": { "resume\_at": 171693... } }  
+* **Phase 2 (Scheduler \- Wake):** \* The Scheduler should emit a NodeStatusMessage for the *Wait Node* itself: { "node\_id": "wait\_1", "status": "success" }.  
+  * *Why?* To turn the Wait Node "Green" in the UI before the next node starts.
+
+### **6.3 CompletionMessage**
+
+* **Phase 1:** Never sent.  
+* **Phase 3:** \* Handled naturally by the subsequent nodes.  
+  * **Edge Case:** If the Wait Node is the **Last Node** (no outgoing edges):  
+    * The Scheduler (Phase 2\) detects no next nodes.  
+    * Instead of publishing an Execution Message, it must trigger the **Auto-Resolution** logic (RFC-004) or publish a CompletionMessage directly if the lineage\_stack is empty.
+
+## **7\. Resilience & Edge Cases**
+
+### **7.1 "The Lost Resume" (Scheduler Crash)**
+
+* **Scenario:** Scheduler pops from ZSET, crashes before publishing to RabbitMQ.  
+* **Mitigation:**  
+  * **Atomic Pop-Push:** Ideally, move the item from scheduler:timers to a scheduler:processing ZSET in the Lua script.  
+  * **Ack:** Only remove from scheduler:processing after RabbitMQ confirms publish.  
+  * **Recovery:** On boot, the Scheduler checks scheduler:processing for items with score \< (now \- timeout) and re-processes them.
+
+### **7.3 High Concurrency**
+
+* Redis ZSET operations are $O(\\log(N))$. With 1 million timers, ZADD and ZRANGE are still sub-millisecond.  
+* The bottleneck is the Go Scheduler loop.  
+* **Scaling:** Run multiple Scheduler instances. The Lua script guarantees only one instance claims a specific batch of tasks (competing consumers pattern on the ZSET).
+
+## **8\. Implementation Checklist**
+
+* \[ \] **Infrastructure:**  
+  * \[ \] Redis instance ready and configured.  
+* \[ \] **Data Types:**  
+  * \[ \] Define FrozenState struct (wraps NodeExecutionMessage).  
+* \[ \] **Worker (Wait Node):**  
+  * \[ \] Implement Execute (Phase 1\) in WaitNode handler.  
+  * \[ \] Ensure lineage\_stack serialization works correctly.  
+* \[ \] **Scheduler:**  
+  * \[ \] Implement poll\_timers.lua.  
+  * \[ \] Implement Ticker Loop with configurable interval.

--- a/services/rune-worker/rfcs/RFC-007-edit.md
+++ b/services/rune-worker/rfcs/RFC-007-edit.md
@@ -1,0 +1,304 @@
+# **RFC 007: Edit Node Architecture (Data Transformation)**
+
+**Author:** Seif Elwarwary
+
+**Status:** PROPOSED
+
+**Created:** 2025-05-01
+
+**Depends On:** RFC-001, RFC-002, RFC-004
+
+## **1\. Abstract**
+
+This document specifies the architecture for the **Edit Node** (also known as the "Set" or "Transform" node). This node serves as the primary mechanism for data manipulation within a workflow. It allows users to modify the JSON payload of an item as it moves through the graph, supporting operations like adding new fields, renaming keys, keeping only specific fields, and executing dynamic expressions (e.g., calculations or string concatenation).
+
+The implementation relies on a **Stateless Execution Model** combined with a secure **JavaScript Sandbox (Goja)** for evaluating dynamic expressions, ensuring high performance and security.
+
+## **2\. Motivation**
+
+Workflows rarely consist of simple data passing. Data from an HTTP request often needs to be reshaped before being sent to a downstream service (e.g., a CRM that requires a specific format).
+
+Common scenarios include:
+
+* **Projection:** "Keep only id and email from this large user object."  
+* **Enrichment:** "Add a processed\_at timestamp field."  
+* **Transformation:** "Combine first\_name and last\_name into full\_name."  
+* **Calculation:** "Calculate total\_price as quantity \* unit\_price."  
+* **Renaming:** Change user\_id to externalId to match a target schema.
+
+The Edit Node provides a declarative interface for these operations, powered by a robust expression engine.
+
+## **3\. Node Specification (DSL)**
+
+This node type extends the DSL defined in RFC-002.
+
+**Type Identifier:** edit
+
+**Parameters:**
+
+| Parameter | Type | Default | Description |
+| :---- | :---- | :---- | :---- |
+| mode | enum | assignments | Transformation mode. assignments: Add or overwrite specific fields while keeping others (based on keep\_others implicit behavior). keep\_only: Discard all fields *except* those explicitly listed in assignments. |
+| assignments | array | \[\] | List of field operations. |
+| assignments\[\].name | string | \- | The key to set (e.g., user.address.city). Supports dot-notation for nested objects. |
+| assignments\[\].value | string | \- | The value to assign. Supports dynamic expressions (e.g., {{ $json.price \* 1.2 }}). |
+| assignments\[\].type | enum | string | Target type casting: string, number, boolean, json. |
+
+**Example JSON:**
+
+{  
+  "id": "edit\_node\_1",  
+  "type": "edit",  
+  "name": "Format User Data",  
+  "parameters": {  
+    "mode": "assignments",  
+    "assignments": \[  
+      {  
+        "name": "full\_name",  
+        "value": "{{ $json.first\_name \+ ' ' \+ $json.last\_name }}",  
+        "type": "string"  
+      },  
+      {  
+        "name": "is\_active",  
+        "value": "true",  
+        "type": "boolean"  
+      },  
+      {  
+        "name": "metadata.source",  
+        "value": "api\_v2",  
+        "type": "string"  
+      },  
+      {  
+        "name": "calculated\_tax",  
+        "value": "{{ $json.subtotal \* 0.2 }}",  
+        "type": "number"  
+      }  
+    \]  
+  },  
+  "output": {},  
+  "error": { "type": "halt" }  
+}
+
+## **4\. Architecture & Implementation**
+
+### **4.1 Stateless Execution**
+
+Unlike the Wait or Merge nodes, the Edit Node is **purely functional** and **stateless**.
+
+* **Input:** NodeExecutionMessage containing a payload (and context).  
+* **Process:** Apply transformations in memory using the Go worker's CPU.  
+* **Output:** New NodeExecutionMessage with the transformed payload.
+
+It does **not** require Redis or external state persistence, making it highly scalable. It can be horizontally scaled across as many workers as needed.
+
+### **4.2 The Execution Pipeline**
+
+When a worker receives a message for an Edit Node, it follows this strict sequence:
+
+1. **Deep Copy:** Create a deep copy of the input payload ($json). This ensures immutability and prevents side effects if the context is theoretically shared (though in our RabbitMQ architecture, messages are distinct).  
+2. **Mode Initialization:**  
+   * If mode \== keep\_only: Initialize a new, empty map outputMap \= {}.  
+   * If mode \== assignments: Initialize outputMap as the cloned input payload.  
+3. **Assignment Iteration:** Loop through the configured assignments array sequentially.  
+4. **Resolution Logic:** For each assignment:  
+   * **Evaluate Expression:** Resolve the value string using the Expression Engine (Section 4.3). This might return a Go primitive (string, float64, bool, nil) or a complex type.  
+   * **Type Cast:** Convert the resolved value to the target type defined in the assignment (Section 5.2).  
+   * **Set Operation:** Write the value to outputMap at the path specified by name.  
+     * *Deep Set:* If name contains dots (e.g., address.city), the engine must strictly parse the path, create nested maps if they don't exist, and set the leaf value.  
+5. **Publish:** Wrap the final outputMap in a new execution message and publish to the next node.
+
+### **4.3 Expression Resolution Engine**
+
+The core capabilities of the Edit Node rely on evaluating dynamic expressions enclosed in {{ ... }}.
+
+* **Syntax:** Double curly braces {{ expression }}.  
+* **Engine:** We use **Goja** (a pure Go implementation of ECMAScript 5.1/JavaScript). This avoids the overhead and complexity of cgo or managing external Node.js processes.
+
+**Context Injection:**
+
+The JS environment is pre-populated with variables representing the current workflow state:
+
+| Variable | Description | Example Access |
+| :---- | :---- | :---- |
+| $json | The JSON payload of the item currently being processed. | $json.user.id |
+| $prevNode | Access to the output of the immediately preceding node (often alias for $json). | $prevNode.status |
+| $\<node\_name\> | Access to the output of **any** specific previous node in the accumulated context. | $http1.body.user.name |
+
+**Security Constraints:**
+
+* **No I/O:** The Goja sandbox must be initialized without access to the standard library's I/O capabilities. No fs (file system), net (network), or os access is permitted.  
+* **Timeout:** Script execution must be wrapped in a context with a strict timeout (e.g., 100ms) to prevent infinite loops (e.g., while(true){}) from hanging the worker.  
+* **Memory Limit:** While Goja manages memory within the Go heap, extreme allocation patterns should be monitored.
+
+## **5\. Technical Details**
+
+### **5.1 Dot Notation Handling (SetNested)**
+
+The Set operation must handle nested paths intelligently to support structured data manipulation.
+
+**Function Signature:** func SetNested(obj map\[string\]interface{}, path string, value interface{}) error
+
+**Algorithm:**
+
+1. Split path by . into keys: \["address", "geo", "lat"\].  
+2. Iterate through keys up to the second-to-last one (address, geo).  
+3. For each key:  
+   * Check if it exists in the current map level.  
+   * If it exists and is a map\[string\]interface{}, traverse into it.  
+   * If it exists but is *not* a map (e.g., a string), this is a conflict. Return an error (cannot set property of non-object).  
+   * If it does *not* exist, create a new map\[string\]interface{} and assign it to the key.  
+4. Set the final key (lat) to value in the deepest map found/created.
+
+### **5.2 Type Casting Table**
+
+The assignments\[\].type parameter dictates the final Go type stored in the JSON map. This ensures downstream nodes receive predictable types.
+
+| Source Value (Resolved) | Target Type | Logic/Result |
+| :---- | :---- | :---- |
+| "123" (string) | number | 123.0 (float64) via strconv.ParseFloat |
+| 123 (int) | string | "123" via fmt.Sprintf |
+| "true" (string) | boolean | true (bool) |
+| "yes" (string) | boolean | true (bool) |
+| 1 (int) | boolean | true (bool) |
+| "\[1, 2\]" (string) | json | \[1, 2\] (\[\]interface{}) via json.Unmarshal |
+| { "a": 1 } (map) | string | "{ \\"a\\": 1 }" (JSON String) |
+| Any | string | Default JSON String representation |
+
+**Error Handling:** If casting fails (e.g., attempting to cast "hello" to number), the node execution should fail and return an error, stopping the branch (unless error handling is set to ignore).
+
+## **6\. Message Handling & Integration**
+
+The Edit Node follows the standard protocol defined in RFC-001 and RFC-004.
+
+### **6.1 Lineage Stack (RFC-004 Compatibility)**
+
+The Edit Node is **"Lineage-Transparent"**.
+
+* **Input:** Receives lineage\_stack in the execution message envelope.  
+* **Behavior:** It **MUST** copy the lineage\_stack field from the input message to the output message verbatim.  
+* **Why:** The Edit Node does not split or merge execution flows. It processes 1 item and outputs 1 item (1:1 mapping). Therefore, it preserves the parallel context. This ensures that if the Edit Node is inside a "For Each" loop (Fan-Out), the subsequent Aggregator can still correctly identify which index this item belongs to.
+
+### **6.2 Status & Completion**
+
+* **Status:** Publishes NodeStatusMessage  
+  * status: running (on start)  
+  * status: success (on completion, potentially with a small snippet of the output for debugging visibility)  
+  * status: failed (on expression evaluation error or type cast failure)  
+* **Completion:** If the Edit Node is the **Final Node** in the workflow (no outgoing edges), it triggers the standard completion logic:  
+  * It checks the lineage\_stack.  
+  * If stack is empty \-\> Publishes CompletionMessage.  
+  * If stack is NOT empty \-\> Triggers the **Ghost Signal** (Auto-Resolution) to the parent Aggregator (as defined in RFC-004).
+
+## **7\. Implementation Checklist**
+
+* $$ $$  
+  **Core Logic:** Implement EditNode struct satisfying the Node interface.  
+* $$ $$  
+  **Expression Engine:**  
+  * $$ $$  
+    Integrate goja library.  
+  * $$ $$  
+    Implement Evaluate(expression, context) helper function.  
+  * $$ $$  
+    Add tests for context injection ($json, $http1, etc.).  
+  * $$ $$  
+    Implement execution timeout (context cancellation).  
+* $$ $$  
+  **Data Utils:**  
+  * $$ $$  
+    Implement SetNested(map, path, val).  
+  * $$ $$  
+    Implement DeepCopy(map).  
+  * $$ $$  
+    Implement TypeCast(val, type).  
+* $$ $$  
+  **Validation:**  
+  * $$ $$  
+    Ensure assignments types match valid enums.  
+  * $$ $$  
+    Validate mode is supported.  
+* $$ $$  
+  **Tests:**  
+  * $$ $$  
+    Unit tests for simple assignment (string \-\> string).  
+  * $$ $$  
+    Unit tests for keep\_only mode (filtering).  
+  * $$ $$  
+    Unit tests for nested dot notation setting.  
+  * $$ $$  
+    Integration test: Edit Node inside a loop (verifying Lineage Stack preservation).
+
+## **8\. Execution Example**
+
+Workflow Scenario:  
+We are processing a list of e-commerce orders. We have split the orders (Fan-Out). Now, for one specific order, we want to calculate the tax and format the shipping address using data from a previous HTTP node (http\_fetch\_rates).  
+**1\. Workflow Definition (Snippet):**
+
+{  
+  "id": "edit\_process\_order",  
+  "type": "edit",  
+  "parameters": {  
+    "mode": "assignments",  
+    "assignments": \[  
+      {  
+        "name": "tax\_amount",  
+        "value": "{{ $json.total \* $http\_fetch\_rates.body.tax\_rate }}", // Accessing previous node  
+        "type": "number"  
+      },  
+      {  
+        "name": "shipping.full\_address",  
+        "value": "{{ $json.shipping.street \+ ', ' \+ $json.shipping.city }}",  
+        "type": "string"  
+      }  
+    \]  
+  }  
+}
+
+**2\. Input Message (accumulated\_context for this branch):**
+
+{  
+  "$json": {  
+    "order\_id": "ORD-123",  
+    "total": 100.00,  
+    "shipping": {  
+      "street": "123 Main St",  
+      "city": "Cairo",  
+      "country": "EG"  
+    }  
+  },  
+  "$http\_fetch\_rates": {  
+    "body": {  
+      "tax\_rate": 0.15,  
+      "currency": "EGP"  
+    }  
+  }  
+}
+
+**3\. Execution Steps:**
+
+* **Step 1 (Deep Copy):** Worker clones $json. outputMap is now identical to input.  
+* **Step 2 (Assignment 1):**  
+  * Evaluate {{ $json.total \* $http\_fetch\_rates.body.tax\_rate }} \-\> 100.00 \* 0.15 \-\> 15.0.  
+  * Cast to number \-\> 15.0 (float64).  
+  * Set tax\_amount \-\> outputMap\["tax\_amount"\] \= 15.0.  
+* **Step 3 (Assignment 2):**  
+  * Evaluate {{ ... }} \-\> "123 Main St, Cairo".  
+  * Cast to string.  
+  * Set shipping.full\_address \-\>  
+    * Traverse shipping.  
+    * Set full\_address inside it.
+
+**4\. Resulting Output (accumulated\_context update):**
+
+{  
+  "order\_id": "ORD-123",  
+  "total": 100.00,  
+  "tax\_amount": 15.0, // New Field  
+  "shipping": {  
+    "street": "123 Main St",  
+    "city": "Cairo",  
+    "country": "EG",  
+    "full\_address": "123 Main St, Cairo" // New Nested Field  
+  }  
+}
+


### PR DESCRIPTION
Introduces comprehensive documentation for the new workflow nodes and execution patterns.

- **RFC-004 (Split/Aggregate)**: Defines the Distributed Fan-Out/Fan-In pattern for data parallelism.
- **RFC-005 (Merge)**: Specifies the architecture for synchronizing distributed execution paths (Wait for All/Any).
- **RFC-006 (Wait)**: Details the timerless distributed wait node and scheduler architecture.
- **RFC-007 (Edit)**: Describes the stateless Edit Node for data transformation and projection.
- **RFC-003 (Switch)**: Updates documentation to clarify rule value resolution behavior.
- **README**: Updates the RFC index with the new documents.