### PR TITLE
fix(ui): update homepage hero logo

### DIFF
--- a/apps/web/src/components/home/Hero.tsx
+++ b/apps/web/src/components/home/Hero.tsx
@@ -14,7 +14,7 @@ const playfair = Playfair_Display({
   variable: "--font-playfair",
 });
 
-const runeLogo = "/icons/Logo.svg"; 
+const runeLogo = "/icons/logo-white.svg"; 
 
 export function Hero() {
   return (
@@ -39,7 +39,6 @@ export function Hero() {
                src={runeLogo} 
                alt="Rune Logo" 
                fill 
-               className="object-contain dark:invert" 
                priority
              />
            </div>


### PR DESCRIPTION
Some browsers were failing to render the white mask over the base black logo. This updates the logo used to the white variant instead of relying on inverting color.