### PR TITLE
fix(export): sanitize workflow data by stripping credentials before saving

### DIFF
--- a/apps/web/src/features/canvas/components/SaveTemplateDialog.tsx
+++ b/apps/web/src/features/canvas/components/SaveTemplateDialog.tsx
@@ -22,6 +22,7 @@ import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
 import { toast } from "@/components/ui/toast";
 import { createTemplate } from "@/lib/api/templates";
+import { stripCredentials } from "../lib/graphIO";
 import type { CanvasNode } from "../types";
 import type { Edge } from "@xyflow/react";
 
@@ -60,11 +61,14 @@ export function SaveTemplateDialog({
 
     setSaving(true);
     try {
+      // Strip credentials from workflow data before saving to prevent sensitive data from being exported
+      const sanitizedWorkflowData = stripCredentials(workflowData);
+      
       const response = await createTemplate({
         name: name.trim(),
         description: description.trim(),
         category,
-        workflow_data: workflowData,
+        workflow_data: sanitizedWorkflowData,
         is_public: isPublic,
       });
 

--- a/apps/web/src/features/canvas/lib/graphIO.ts
+++ b/apps/web/src/features/canvas/lib/graphIO.ts
@@ -10,6 +10,24 @@ import {
 
 export type RFGraph = { nodes: RFNode[]; edges: RFEdge[] };
 
+/**
+ * Strips credential data from nodes to prevent sensitive data from being exported.
+ * Returns a new graph with credentials cleared from all nodes.
+ */
+export function stripCredentials(graph: RFGraph): RFGraph {
+  const nodes = graph.nodes.map((node) => {
+    if (node.data && typeof node.data === "object" && "credential" in node.data) {
+      const { credential: _, ...restData } = node.data as Record<string, unknown>;
+      return {
+        ...node,
+        data: restData,
+      };
+    }
+    return node;
+  });
+  return { nodes, edges: graph.edges };
+}
+
 type EdgeMeta = {
   sourceHandle?: string;
   label?: string;
@@ -119,7 +137,8 @@ export function sanitizeGraph(
 }
 
 export function stringifyGraph(graph: RFGraph): string {
-  return JSON.stringify(graph, null, 2);
+  const sanitized = stripCredentials(graph);
+  return JSON.stringify(sanitized, null, 2);
 }
 
 export function tryParseGraphFromText(text: string): RFGraph | null {


### PR DESCRIPTION
## Clear credentials from exported workflows

- Closes #145 