### PR TITLE
fix(dev): align app config with dev Postgres settings

### DIFF
--- a/services/api/src/core/config.py
+++ b/services/api/src/core/config.py
@@ -26,11 +26,11 @@ class Settings(BaseSettings):
     )
 
     # Database Settings
-    postgres_user: str = "postgres"
-    postgres_password: str = "postgres"
+    postgres_user: str = "rune"
+    postgres_password: str = "rune_password"
     postgres_host: str = "localhost"
     postgres_port: int = 5432
-    postgres_db: str = "rune"
+    postgres_db: str = "rune_db"
     database_url: str | None = None
 
     # JWT Settings


### PR DESCRIPTION
Summary

This PR fixes a mismatch between the development Postgres settings in
services/api/docker-compose-dev.yml and the database configuration used by the application in
services/api/src/core/config.py.

What Was Wrong

The dev database container was initialized with:

```
POSTGRES_USER=rune
POSTGRES_PASSWORD=rune_password
POSTGRES_DB=rune_db
```

But the app was attempting to connect using:

```
postgres_user="postgres"
postgres_password="postgres"
postgres_db="rune"
```

This caused the API to fail during startup because it was connecting with credentials that did not exist in the dev Postgres instance.

What This PR Changes

Updates config.py to use the correct development database credentials:
rune as the user
rune_password as the password
rune_db as the database