### PR TITLE
fix(renovate): enable vulnerability alerts

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,14 +1,23 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["config:base", ":dependencyDashboard"],
-  
-  "enabled": false,
 
+  "enabled": true,
+  
   "vulnerabilityAlerts": {
     "enabled": true,
     "labels": ["security"],
+    "commitMessageTopic": "security fix",
     "assignees": ["ashmod"],
-    "commitMessageTopic": "security fix"
+    "schedule": ["at any time"]
   },
-  "osvVulnerabilityAlerts": true
+
+  "osvVulnerabilityAlerts": true,
+
+  "packageRules": [
+    {
+      "matchUpdateTypes": ["minor", "patch", "major", "pin", "digest"],
+      "enabled": false
+    }
+  ]
 }


### PR DESCRIPTION
This should allow renovate to access and fix security alerts triggered by Dependabot.