### PR TITLE
feat(wait-node): implement wait node functionality and related tests

### DIFF
--- a/services/rune-worker/e2e/wait_e2e_test.go
+++ b/services/rune-worker/e2e/wait_e2e_test.go
@@ -1,0 +1,129 @@
+//go:build integration
+// +build integration
+
+package e2e
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"rune-worker/pkg/core"
+	"rune-worker/pkg/messages"
+	"rune-worker/pkg/messaging"
+	"rune-worker/pkg/platform/config"
+	"rune-worker/pkg/platform/queue"
+	"rune-worker/pkg/scheduler"
+	testutils "rune-worker/test_utils"
+)
+
+func TestWaitNodeE2E(t *testing.T) {
+	env := setupE2ETest(t)
+	defer env.Cleanup(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	workflowID := "test-wait-workflow"
+	executionID := "exec-wait-001"
+
+	executionMsg := &messages.NodeExecutionMessage{
+		WorkflowID:  workflowID,
+		ExecutionID: executionID,
+		CurrentNode: "wait-node-1",
+		WorkflowDefinition: core.Workflow{
+			WorkflowID:  workflowID,
+			ExecutionID: executionID,
+			Nodes: []core.Node{
+				{
+					ID:   "wait-node-1",
+					Name: "Wait Node",
+					Type: "wait",
+					Parameters: map[string]interface{}{
+						"amount": 1,
+						"unit":   "seconds",
+					},
+				},
+			},
+			Edges: []core.Edge{},
+		},
+		AccumulatedContext: map[string]interface{}{},
+	}
+
+	msgBytes, _ := executionMsg.Encode()
+	if err := env.Publisher.Publish(ctx, "workflow.execution", msgBytes); err != nil {
+		t.Fatalf("Failed to publish: %v", err)
+	}
+
+	statusConsumer, _ := queue.NewRabbitMQConsumer(queue.Options{
+		URL:         env.RabbitMQURL,
+		QueueName:   "workflow.node.status",
+		Prefetch:    10,
+		Concurrency: 1,
+	})
+	defer statusConsumer.Close()
+
+	var statusMsgs []*messages.NodeStatusMessage
+	statusChan := make(chan *messages.NodeStatusMessage, 10)
+	statusCtx, statusCancel := context.WithTimeout(ctx, 15*time.Second)
+	defer statusCancel()
+
+	go func() {
+		_ = statusConsumer.Consume(statusCtx, func(ctx context.Context, payload []byte) error {
+			msg, _ := messages.DecodeNodeStatusMessage(payload)
+			if msg != nil && msg.WorkflowID == workflowID {
+				statusChan <- msg
+			}
+			return nil
+		})
+	}()
+
+	cfg := &config.WorkerConfig{
+		RabbitURL:   env.RabbitMQURL,
+		RedisURL:    "redis://" + testutils.DefaultRedisAddr + "/0",
+		QueueName:   "workflow.execution",
+		Prefetch:    1,
+		Concurrency: 1,
+	}
+
+	consumer, _ := messaging.NewWorkflowConsumer(cfg, env.RedisClient)
+	defer consumer.Close()
+
+	schedulerPub, _ := queue.NewRabbitMQPublisher(env.RabbitMQURL)
+	defer schedulerPub.Close()
+
+	sched := scheduler.NewScheduler(env.RedisClient, schedulerPub, scheduler.Options{
+		PollInterval: 100 * time.Millisecond,
+	})
+
+	resumeConsumer, _ := messaging.NewResumeConsumer(cfg, env.RedisClient)
+	defer resumeConsumer.Close()
+
+	consumerCtx, consumerCancel := context.WithTimeout(ctx, 10*time.Second)
+	defer consumerCancel()
+
+	go func() { _ = consumer.Run(consumerCtx) }()
+	go func() { _ = sched.Run(consumerCtx) }()
+	go func() { _ = resumeConsumer.Run(consumerCtx) }()
+
+	timeout := time.After(8 * time.Second)
+	waitingReceived := false
+loop:
+	for {
+		select {
+		case msg := <-statusChan:
+			statusMsgs = append(statusMsgs, msg)
+			if msg.Status == messages.StatusWaiting {
+				waitingReceived = true
+			}
+		case <-timeout:
+			break loop
+		}
+	}
+
+	if !waitingReceived {
+		t.Error("Expected waiting status")
+	}
+
+	t.Log("Wait node E2E test completed")
+}

--- a/services/rune-worker/go.mod
+++ b/services/rune-worker/go.mod
@@ -3,6 +3,7 @@ module rune-worker
 go 1.24
 
 require (
+	github.com/google/uuid v1.6.0
 	github.com/redis/go-redis/v9 v9.14.0
 	github.com/wagslane/go-rabbitmq v0.15.0
 )

--- a/services/rune-worker/go.sum
+++ b/services/rune-worker/go.sum
@@ -4,6 +4,8 @@ github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f h1:lO4WD4F/r
 github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f/go.mod h1:cuUVRXasLTGF7a8hSLbxyZXjz+1KgoB3wDUb6vlszIc=
 github.com/go-redis/redismock/v9 v9.2.0 h1:ZrMYQeKPECZPjOj5u9eyOjg8Nnb0BS9lkVIZ6IpsKLw=
 github.com/go-redis/redismock/v9 v9.2.0/go.mod h1:18KHfGDK4Y6c2R0H38EUGWAdc7ZQS9gfYxc94k7rWT0=
+github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
+github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/rabbitmq/amqp091-go v1.10.0 h1:STpn5XsHlHGcecLmMFCtg7mqq0RnD+zFr4uzukfVhBw=
 github.com/rabbitmq/amqp091-go v1.10.0/go.mod h1:Hy4jKW5kQART1u+JkDTF9YYOQUHXqMuhrgxOEeS7G4o=
 github.com/redis/go-redis/v9 v9.14.0 h1:u4tNCjXOyzfgeLN+vAZaW1xUooqWDqVEsZN0U01jfAE=

--- a/services/rune-worker/integration/wait_integration_test.go
+++ b/services/rune-worker/integration/wait_integration_test.go
@@ -1,0 +1,96 @@
+//go:build integration
+
+package integration
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"rune-worker/pkg/core"
+	"rune-worker/pkg/messages"
+	"rune-worker/pkg/platform/queue"
+	"rune-worker/pkg/scheduler"
+	testutils "rune-worker/test_utils"
+
+	"github.com/redis/go-redis/v9"
+)
+
+func TestWaitNodeIntegration(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	redisAddr := testutils.GetEnvOrDefault("REDIS_ADDR", testutils.DefaultRedisAddr)
+	redisClient := redis.NewClient(&redis.Options{
+		Addr: redisAddr,
+		DB:   15,
+	})
+	defer redisClient.Close()
+
+	if err := redisClient.Ping(ctx).Err(); err != nil {
+		t.Fatalf("Failed to connect to Redis: %v", err)
+	}
+
+	redisClient.Del(ctx, scheduler.TimersKey)
+	redisClient.Del(ctx, scheduler.PayloadsKey)
+	defer func() {
+		redisClient.Del(ctx, scheduler.TimersKey)
+		redisClient.Del(ctx, scheduler.PayloadsKey)
+	}()
+
+	rabbitmqURL := testutils.GetEnvOrDefault("RABBITMQ_URL", testutils.DefaultRabbitMQURL)
+	publisher, err := queue.NewRabbitMQPublisher(rabbitmqURL)
+	if err != nil {
+		t.Fatalf("Failed to create publisher: %v", err)
+	}
+	defer publisher.Close()
+
+	timerID := "integration-test-timer"
+	resumeTime := time.Now().Add(-time.Second).UnixMilli()
+
+	frozenMsg := &messages.NodeExecutionMessage{
+		WorkflowID:  "wf-integration",
+		ExecutionID: "exec-integration",
+		CurrentNode: "wait-1",
+		WorkflowDefinition: core.Workflow{
+			WorkflowID:  "wf-integration",
+			ExecutionID: "exec-integration",
+			Nodes: []core.Node{
+				{ID: "wait-1", Name: "Wait Node", Type: "wait"},
+			},
+			Edges: []core.Edge{},
+		},
+		AccumulatedContext: map[string]interface{}{},
+	}
+
+	payload, err := frozenMsg.Encode()
+	if err != nil {
+		t.Fatalf("Failed to encode message: %v", err)
+	}
+
+	pipe := redisClient.TxPipeline()
+	pipe.HSet(ctx, scheduler.PayloadsKey, timerID, payload)
+	pipe.ZAdd(ctx, scheduler.TimersKey, redis.Z{Score: float64(resumeTime), Member: timerID})
+	if _, err := pipe.Exec(ctx); err != nil {
+		t.Fatalf("Failed to store timer: %v", err)
+	}
+
+	sched := scheduler.NewScheduler(redisClient, publisher, scheduler.Options{
+		PollInterval: 100 * time.Millisecond,
+	})
+
+	schedCtx, schedCancel := context.WithTimeout(ctx, 2*time.Second)
+	defer schedCancel()
+	go func() {
+		_ = sched.Run(schedCtx)
+	}()
+
+	time.Sleep(500 * time.Millisecond)
+
+	_, err = redisClient.ZScore(ctx, scheduler.TimersKey, timerID).Result()
+	if err != redis.Nil {
+		t.Errorf("Timer should have been removed: %v", err)
+	}
+
+	t.Log("Wait node integration test passed")
+}

--- a/services/rune-worker/pkg/messages/node_status_message.go
+++ b/services/rune-worker/pkg/messages/node_status_message.go
@@ -40,6 +40,7 @@ const (
 	StatusRunning = "running"
 	StatusSuccess = "success"
 	StatusFailed  = "failed"
+	StatusWaiting = "waiting"
 
 	AggregatorStateWaiting  = "waiting"
 	AggregatorStateReleased = "released"
@@ -65,10 +66,10 @@ func (m *NodeStatusMessage) Validate() error {
 
 	// Validate status value
 	switch m.Status {
-	case StatusRunning, StatusSuccess, StatusFailed:
+	case StatusRunning, StatusSuccess, StatusFailed, StatusWaiting:
 		// valid status
 	default:
-		return fmt.Errorf("invalid status: %s (must be 'running', 'success', or 'failed')", m.Status)
+		return fmt.Errorf("invalid status: %s (must be 'running', 'success', 'failed', or 'waiting')", m.Status)
 	}
 
 	// Validate status-specific requirements

--- a/services/rune-worker/pkg/messaging/resume_consumer.go
+++ b/services/rune-worker/pkg/messaging/resume_consumer.go
@@ -1,0 +1,164 @@
+package messaging
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+
+	"rune-worker/pkg/core"
+	"rune-worker/pkg/dsl"
+	"rune-worker/pkg/executor"
+	"rune-worker/pkg/messages"
+	"rune-worker/pkg/platform/config"
+	"rune-worker/pkg/platform/queue"
+	"rune-worker/pkg/registry"
+
+	"github.com/redis/go-redis/v9"
+)
+
+// ResumeConsumer handles resumed workflow executions after wait timers fire.
+type ResumeConsumer struct {
+	queue     queue.Consumer
+	executor  *executor.Executor
+	publisher queue.Publisher
+}
+
+// NewResumeConsumer creates a consumer for the workflow.resume queue.
+func NewResumeConsumer(cfg *config.WorkerConfig, redisClient *redis.Client) (*ResumeConsumer, error) {
+	if cfg == nil {
+		return nil, errors.New("resume consumer: config is nil")
+	}
+
+	reg := registry.InitializeRegistry()
+
+	q, err := queue.NewRabbitMQConsumer(queue.Options{
+		URL:         cfg.RabbitURL,
+		QueueName:   "workflow.resume",
+		Prefetch:    cfg.Prefetch,
+		Concurrency: cfg.Concurrency,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	pub, err := queue.NewRabbitMQPublisher(cfg.RabbitURL)
+	if err != nil {
+		_ = q.Close()
+		return nil, err
+	}
+
+	return &ResumeConsumer{
+		queue:     q,
+		executor:  executor.NewExecutor(reg, pub, redisClient),
+		publisher: pub,
+	}, nil
+}
+
+// Run starts consuming resume messages until context is cancelled.
+func (c *ResumeConsumer) Run(ctx context.Context) error {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	slog.Info("resume consumer starting")
+	return c.queue.Consume(ctx, c.handleResume)
+}
+
+// Close releases underlying resources.
+func (c *ResumeConsumer) Close() error {
+	if c.queue != nil {
+		return c.queue.Close()
+	}
+	return nil
+}
+
+// handleResume processes a resumed wait node by determining next nodes and continuing execution.
+func (c *ResumeConsumer) handleResume(ctx context.Context, payload []byte) error {
+	msg, err := messages.DecodeNodeExecutionMessage(payload)
+	if err != nil {
+		slog.Error("failed to decode resume message",
+			"error", err,
+			"payload_size", len(payload))
+		return fmt.Errorf("decode resume message: %w", err)
+	}
+
+	slog.Info("processing resumed wait node",
+		"workflow_id", msg.WorkflowID,
+		"execution_id", msg.ExecutionID,
+		"node_id", msg.CurrentNode)
+
+	// Get the wait node details
+	node, found := msg.WorkflowDefinition.GetNodeByID(msg.CurrentNode)
+	if !found {
+		return fmt.Errorf("wait node %s not found in workflow", msg.CurrentNode)
+	}
+
+	// Determine next nodes after the wait node
+	nextNodes := c.determineNextNodes(&msg.WorkflowDefinition, &node)
+
+	if len(nextNodes) == 0 {
+		// No more nodes - workflow completed
+		slog.Info("workflow completed after wait",
+			"workflow_id", msg.WorkflowID,
+			"execution_id", msg.ExecutionID)
+		return c.publishCompletion(ctx, msg)
+	}
+
+	// Publish execution messages for next nodes
+	for _, nextNodeID := range nextNodes {
+		nextMsg := &messages.NodeExecutionMessage{
+			WorkflowID:         msg.WorkflowID,
+			ExecutionID:        msg.ExecutionID,
+			CurrentNode:        nextNodeID,
+			WorkflowDefinition: msg.WorkflowDefinition,
+			AccumulatedContext: msg.AccumulatedContext,
+			LineageStack:       msg.LineageStack,
+		}
+
+		msgBytes, err := nextMsg.Encode()
+		if err != nil {
+			slog.Error("failed to encode next node message",
+				"error", err,
+				"next_node", nextNodeID)
+			return err
+		}
+
+		if err := c.publisher.Publish(ctx, "workflow.execution", msgBytes); err != nil {
+			slog.Error("failed to publish next node message",
+				"error", err,
+				"next_node", nextNodeID)
+			return err
+		}
+
+		slog.Info("published next node after wait resume",
+			"workflow_id", msg.WorkflowID,
+			"execution_id", msg.ExecutionID,
+			"next_node", nextNodeID)
+	}
+
+	return nil
+}
+
+// determineNextNodes finds nodes connected after the wait node.
+func (c *ResumeConsumer) determineNextNodes(wf *core.Workflow, node *core.Node) []string {
+	graph := dsl.BuildGraph(wf)
+	return graph.GetNeighbors(node.ID)
+}
+
+// publishCompletion publishes a workflow completion message.
+func (c *ResumeConsumer) publishCompletion(ctx context.Context, msg *messages.NodeExecutionMessage) error {
+	completionMsg := messages.NewCompletedMessage(
+		msg.WorkflowID,
+		msg.ExecutionID,
+		msg.AccumulatedContext,
+		0, // Duration not tracked for resumed workflows
+	)
+
+	payload, err := completionMsg.Encode()
+	if err != nil {
+		return fmt.Errorf("encode completion message: %w", err)
+	}
+
+	return c.publisher.Publish(ctx, "workflow.completion", payload)
+}

--- a/services/rune-worker/pkg/nodes/custom/wait/wait_node.go
+++ b/services/rune-worker/pkg/nodes/custom/wait/wait_node.go
@@ -1,0 +1,133 @@
+package wait
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"rune-worker/pkg/messages"
+	"rune-worker/pkg/nodes"
+	"rune-worker/plugin"
+
+	"github.com/google/uuid"
+	"github.com/redis/go-redis/v9"
+)
+
+// WaitNode implements the suspend logic: persist frozen execution and schedule resume.
+// It does not emit output; it halts further execution for this branch.
+type WaitNode struct{}
+
+// NewWaitNode constructs a WaitNode.
+func NewWaitNode(execCtx plugin.ExecutionContext) *WaitNode {
+	return &WaitNode{}
+}
+
+// Execute stores the frozen execution in Redis and returns without publishing next nodes.
+func (n *WaitNode) Execute(ctx context.Context, execCtx plugin.ExecutionContext) (map[string]any, error) {
+	redisClient, ok := execCtx.RedisClient.(*redis.Client)
+	if !ok || redisClient == nil {
+		return nil, fmt.Errorf("wait node requires redis client")
+	}
+
+	amount, unit, err := parseInterval(execCtx.Parameters)
+	if err != nil {
+		return nil, err
+	}
+
+	resumeAt := time.Now().Add(convertToDuration(amount, unit)).UTC()
+
+	// Freeze current execution message
+	frozen := messages.NodeExecutionMessage{
+		WorkflowID:         execCtx.WorkflowID,
+		ExecutionID:        execCtx.ExecutionID,
+		CurrentNode:        execCtx.NodeID,
+		WorkflowDefinition: execCtx.WorkflowDefinition,
+		AccumulatedContext: execCtx.Input,
+		LineageStack:       execCtx.LineageStack,
+	}
+
+	payload, err := frozen.Encode()
+	if err != nil {
+		return nil, fmt.Errorf("encode frozen state: %w", err)
+	}
+
+	timerID := uuid.NewString()
+
+	// Atomic pipeline: store payload and schedule timer
+	pipe := redisClient.TxPipeline()
+	pipe.HSet(ctx, "scheduler:payloads", timerID, payload)
+	pipe.ZAdd(ctx, "scheduler:timers", redis.Z{Score: float64(resumeAt.UnixMilli()), Member: timerID})
+	if _, err := pipe.Exec(ctx); err != nil {
+		return nil, fmt.Errorf("schedule wait timer: %w", err)
+	}
+
+	// Emit waiting status
+	return map[string]any{
+		"resume_at": resumeAt.UnixMilli(),
+		"timer_id":  timerID,
+	}, nil
+}
+
+func parseInterval(params map[string]any) (int, string, error) {
+	// Defaults
+	amount := 1
+	unit := "seconds"
+
+	if v, ok := params["amount"]; ok {
+		switch t := v.(type) {
+		case int:
+			amount = t
+		case float64:
+			amount = int(t)
+		case json.Number:
+			if i, err := t.Int64(); err == nil {
+				amount = int(i)
+			}
+		default:
+			return 0, "", fmt.Errorf("invalid amount type %T", v)
+		}
+	}
+
+	if v, ok := params["unit"].(string); ok && v != "" {
+		unit = v
+	}
+
+	if amount < 0 {
+		return 0, "", fmt.Errorf("amount must be non-negative")
+	}
+
+	switch unit {
+	case "seconds", "minutes", "hours", "days":
+	default:
+		return 0, "", fmt.Errorf("invalid unit %s", unit)
+	}
+
+	return amount, unit, nil
+}
+
+func convertToDuration(amount int, unit string) time.Duration {
+	switch unit {
+	case "seconds":
+		return time.Duration(amount) * time.Second
+	case "minutes":
+		return time.Duration(amount) * time.Minute
+	case "hours":
+		return time.Duration(amount) * time.Hour
+	case "days":
+		return time.Duration(amount) * 24 * time.Hour
+	default:
+		return time.Duration(amount) * time.Second
+	}
+}
+
+func init() {
+	nodes.RegisterNodeType(RegisterWait)
+}
+
+// RegisterWait registers the wait node type.
+func RegisterWait(reg *nodes.Registry) {
+	reg.Register("wait", func(execCtx plugin.ExecutionContext) plugin.Node {
+		return NewWaitNode(execCtx)
+	})
+}

--- a/services/rune-worker/pkg/nodes/custom/wait/wait_node_test.go
+++ b/services/rune-worker/pkg/nodes/custom/wait/wait_node_test.go
@@ -1,0 +1,363 @@
+package wait
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"rune-worker/pkg/core"
+	"rune-worker/pkg/messages"
+	"rune-worker/plugin"
+
+	"github.com/redis/go-redis/v9"
+)
+
+func TestWaitNode_SchedulesTimer(t *testing.T) {
+	// Use real Redis for testing
+	redisClient := redis.NewClient(&redis.Options{
+		Addr: "localhost:6379",
+		DB:   15, // Use DB 15 for testing
+	})
+	defer redisClient.Close()
+
+	ctx := context.Background()
+	if err := redisClient.Ping(ctx).Err(); err != nil {
+		t.Skip("Redis not available, skipping test")
+	}
+
+	// Clean up
+	redisClient.Del(ctx, "scheduler:timers")
+	redisClient.Del(ctx, "scheduler:payloads")
+	defer func() {
+		redisClient.Del(ctx, "scheduler:timers")
+		redisClient.Del(ctx, "scheduler:payloads")
+	}()
+
+	execCtx := plugin.ExecutionContext{
+		ExecutionID: "exec-1",
+		WorkflowID:  "wf-1",
+		NodeID:      "wait-1",
+		Type:        "wait",
+		Parameters: map[string]any{
+			"amount": 2,
+			"unit":   "seconds",
+		},
+		Input:       map[string]any{"foo": "bar"},
+		RedisClient: redisClient,
+		WorkflowDefinition: core.Workflow{
+			WorkflowID:  "wf-1",
+			ExecutionID: "exec-1",
+			Nodes: []core.Node{
+				{ID: "wait-1", Name: "Wait Node", Type: "wait"},
+			},
+		},
+	}
+
+	node := NewWaitNode(execCtx)
+
+	output, err := node.Execute(ctx, execCtx)
+	if err != nil {
+		t.Fatalf("Expected no error, got %v", err)
+	}
+
+	// Verify output includes timer metadata
+	resumeAt, ok := output["resume_at"].(int64)
+	if !ok {
+		t.Fatalf("resume_at missing or wrong type: %v", output["resume_at"])
+	}
+
+	// Resume should be approximately 2 seconds in the future
+	expectedMin := time.Now().Add(time.Second).UnixMilli()
+	if resumeAt < expectedMin {
+		t.Errorf("resume_at %d should be at least %d", resumeAt, expectedMin)
+	}
+
+	timerID, ok := output["timer_id"].(string)
+	if !ok || timerID == "" {
+		t.Errorf("timer_id missing or empty: %v", output["timer_id"])
+	}
+
+	// Verify payload was stored
+	_, err = redisClient.HGet(ctx, "scheduler:payloads", timerID).Bytes()
+	if err != nil {
+		t.Errorf("payload should be stored in Redis: %v", err)
+	}
+
+	// Verify timer was scheduled
+	score, err := redisClient.ZScore(ctx, "scheduler:timers", timerID).Result()
+	if err != nil {
+		t.Errorf("timer should be scheduled in Redis: %v", err)
+	}
+	if int64(score) != resumeAt {
+		t.Errorf("timer score %v should match resume_at %v", int64(score), resumeAt)
+	}
+}
+
+func TestWaitNode_RequiresRedisClient(t *testing.T) {
+	execCtx := plugin.ExecutionContext{
+		ExecutionID: "exec-1",
+		WorkflowID:  "wf-1",
+		NodeID:      "wait-1",
+		Type:        "wait",
+		Parameters: map[string]any{
+			"amount": 1,
+			"unit":   "seconds",
+		},
+		RedisClient: nil, // No Redis client
+	}
+
+	node := NewWaitNode(execCtx)
+	_, err := node.Execute(context.Background(), execCtx)
+
+	if err == nil {
+		t.Error("Expected error when Redis client is nil")
+	}
+}
+
+func TestWaitNode_InvalidRedisClient(t *testing.T) {
+	execCtx := plugin.ExecutionContext{
+		ExecutionID: "exec-1",
+		WorkflowID:  "wf-1",
+		NodeID:      "wait-1",
+		Type:        "wait",
+		Parameters: map[string]any{
+			"amount": 1,
+			"unit":   "seconds",
+		},
+		RedisClient: "not a redis client", // Wrong type
+	}
+
+	node := NewWaitNode(execCtx)
+	_, err := node.Execute(context.Background(), execCtx)
+
+	if err == nil {
+		t.Error("Expected error when Redis client is wrong type")
+	}
+}
+
+func TestParseInterval_ValidInputs(t *testing.T) {
+	tests := []struct {
+		name       string
+		params     map[string]any
+		wantAmount int
+		wantUnit   string
+	}{
+		{
+			name:       "default values",
+			params:     map[string]any{},
+			wantAmount: 1,
+			wantUnit:   "seconds",
+		},
+		{
+			name:       "seconds",
+			params:     map[string]any{"amount": 5, "unit": "seconds"},
+			wantAmount: 5,
+			wantUnit:   "seconds",
+		},
+		{
+			name:       "minutes",
+			params:     map[string]any{"amount": 10, "unit": "minutes"},
+			wantAmount: 10,
+			wantUnit:   "minutes",
+		},
+		{
+			name:       "hours",
+			params:     map[string]any{"amount": 2, "unit": "hours"},
+			wantAmount: 2,
+			wantUnit:   "hours",
+		},
+		{
+			name:       "days",
+			params:     map[string]any{"amount": 1, "unit": "days"},
+			wantAmount: 1,
+			wantUnit:   "days",
+		},
+		{
+			name:       "float64 amount",
+			params:     map[string]any{"amount": float64(3), "unit": "seconds"},
+			wantAmount: 3,
+			wantUnit:   "seconds",
+		},
+		{
+			name:       "json.Number amount",
+			params:     map[string]any{"amount": json.Number("7"), "unit": "minutes"},
+			wantAmount: 7,
+			wantUnit:   "minutes",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			amount, unit, err := parseInterval(tt.params)
+			if err != nil {
+				t.Fatalf("Unexpected error: %v", err)
+			}
+			if amount != tt.wantAmount {
+				t.Errorf("amount = %d, want %d", amount, tt.wantAmount)
+			}
+			if unit != tt.wantUnit {
+				t.Errorf("unit = %s, want %s", unit, tt.wantUnit)
+			}
+		})
+	}
+}
+
+func TestParseInterval_InvalidInputs(t *testing.T) {
+	tests := []struct {
+		name   string
+		params map[string]any
+	}{
+		{
+			name:   "negative amount",
+			params: map[string]any{"amount": -1},
+		},
+		{
+			name:   "invalid unit",
+			params: map[string]any{"unit": "years"},
+		},
+		{
+			name:   "invalid amount type",
+			params: map[string]any{"amount": "not a number"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, _, err := parseInterval(tt.params)
+			if err == nil {
+				t.Error("Expected error, got nil")
+			}
+		})
+	}
+}
+
+func TestConvertToDuration(t *testing.T) {
+	tests := []struct {
+		amount   int
+		unit     string
+		expected time.Duration
+	}{
+		{1, "seconds", time.Second},
+		{5, "seconds", 5 * time.Second},
+		{1, "minutes", time.Minute},
+		{3, "minutes", 3 * time.Minute},
+		{1, "hours", time.Hour},
+		{2, "hours", 2 * time.Hour},
+		{1, "days", 24 * time.Hour},
+		{7, "days", 7 * 24 * time.Hour},
+		{1, "unknown", time.Second}, // defaults to seconds
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.unit, func(t *testing.T) {
+			result := convertToDuration(tt.amount, tt.unit)
+			if result != tt.expected {
+				t.Errorf("convertToDuration(%d, %s) = %v, want %v", tt.amount, tt.unit, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestWaitNode_FrozenStateIncludesContext(t *testing.T) {
+	// Use real Redis for this test to verify actual payload
+	redisClient := redis.NewClient(&redis.Options{
+		Addr: "localhost:6379",
+		DB:   15, // Use DB 15 for testing
+	})
+	defer redisClient.Close()
+
+	ctx := context.Background()
+	if err := redisClient.Ping(ctx).Err(); err != nil {
+		t.Skip("Redis not available, skipping integration test")
+	}
+
+	// Clean up
+	redisClient.Del(ctx, "scheduler:timers")
+	redisClient.Del(ctx, "scheduler:payloads")
+	defer func() {
+		redisClient.Del(ctx, "scheduler:timers")
+		redisClient.Del(ctx, "scheduler:payloads")
+	}()
+
+	inputContext := map[string]any{
+		"$http_node": map[string]any{
+			"status": 200,
+			"body":   "test response",
+		},
+	}
+
+	execCtx := plugin.ExecutionContext{
+		ExecutionID: "exec-frozen-test",
+		WorkflowID:  "wf-frozen-test",
+		NodeID:      "wait-frozen",
+		Type:        "wait",
+		Parameters: map[string]any{
+			"amount": 1,
+			"unit":   "seconds",
+		},
+		Input:       inputContext,
+		RedisClient: redisClient,
+		WorkflowDefinition: core.Workflow{
+			WorkflowID:  "wf-frozen-test",
+			ExecutionID: "exec-frozen-test",
+			Nodes: []core.Node{
+				{ID: "wait-frozen", Name: "Wait Node", Type: "wait"},
+				{ID: "next-node", Name: "Next Node", Type: "http"},
+			},
+			Edges: []core.Edge{
+				{ID: "edge-1", Src: "wait-frozen", Dst: "next-node"},
+			},
+		},
+		LineageStack: []messages.StackFrame{
+			{SplitNodeID: "split-1", BranchID: "branch-1", ItemIndex: 0, TotalItems: 3},
+		},
+	}
+
+	node := NewWaitNode(execCtx)
+	output, err := node.Execute(ctx, execCtx)
+	if err != nil {
+		t.Fatalf("Execute failed: %v", err)
+	}
+
+	timerID := output["timer_id"].(string)
+
+	// Retrieve and decode the frozen payload
+	payloadBytes, err := redisClient.HGet(ctx, "scheduler:payloads", timerID).Bytes()
+	if err != nil {
+		t.Fatalf("Failed to get payload: %v", err)
+	}
+
+	frozenMsg, err := messages.DecodeNodeExecutionMessage(payloadBytes)
+	if err != nil {
+		t.Fatalf("Failed to decode frozen message: %v", err)
+	}
+
+	// Verify frozen state preserves all context
+	if frozenMsg.WorkflowID != execCtx.WorkflowID {
+		t.Errorf("WorkflowID mismatch: got %s, want %s", frozenMsg.WorkflowID, execCtx.WorkflowID)
+	}
+	if frozenMsg.ExecutionID != execCtx.ExecutionID {
+		t.Errorf("ExecutionID mismatch: got %s, want %s", frozenMsg.ExecutionID, execCtx.ExecutionID)
+	}
+	if frozenMsg.CurrentNode != execCtx.NodeID {
+		t.Errorf("CurrentNode mismatch: got %s, want %s", frozenMsg.CurrentNode, execCtx.NodeID)
+	}
+	if len(frozenMsg.LineageStack) != 1 {
+		t.Errorf("LineageStack length mismatch: got %d, want 1", len(frozenMsg.LineageStack))
+	}
+	if frozenMsg.AccumulatedContext["$http_node"] == nil {
+		t.Error("AccumulatedContext should contain $http_node")
+	}
+
+	// Verify timer is scheduled
+	score, err := redisClient.ZScore(ctx, "scheduler:timers", timerID).Result()
+	if err != nil {
+		t.Fatalf("Failed to get timer score: %v", err)
+	}
+
+	resumeAt := output["resume_at"].(int64)
+	if int64(score) != resumeAt {
+		t.Errorf("Timer score mismatch: got %v, want %v", int64(score), resumeAt)
+	}
+}

--- a/services/rune-worker/pkg/registry/init_registry.go
+++ b/services/rune-worker/pkg/registry/init_registry.go
@@ -11,6 +11,7 @@ import (
 	_ "rune-worker/pkg/nodes/custom/smtp"
 	_ "rune-worker/pkg/nodes/custom/split"
 	_ "rune-worker/pkg/nodes/custom/switch"
+	_ "rune-worker/pkg/nodes/custom/wait"
 )
 
 // InitializeRegistry creates and populates the node registry with all available node types.

--- a/services/rune-worker/pkg/scheduler/scheduler.go
+++ b/services/rune-worker/pkg/scheduler/scheduler.go
@@ -1,0 +1,155 @@
+package scheduler
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"time"
+
+	"rune-worker/pkg/platform/queue"
+
+	"github.com/redis/go-redis/v9"
+)
+
+const (
+	// TimersKey is the Redis sorted set key for scheduled timers
+	TimersKey = "scheduler:timers"
+	// PayloadsKey is the Redis hash key for frozen payloads
+	PayloadsKey = "scheduler:payloads"
+	// DefaultPollInterval is the default interval between scheduler polls
+	DefaultPollInterval = 500 * time.Millisecond
+	// DefaultBatchSize is the number of due timers to process per poll
+	DefaultBatchSize = 100
+)
+
+// Scheduler polls Redis for due wait timers and publishes resume messages.
+type Scheduler struct {
+	redis        *redis.Client
+	publisher    queue.Publisher
+	pollInterval time.Duration
+	batchSize    int
+}
+
+// Options configures the scheduler.
+type Options struct {
+	PollInterval time.Duration
+	BatchSize    int
+}
+
+// NewScheduler creates a new scheduler instance.
+func NewScheduler(redisClient *redis.Client, publisher queue.Publisher, opts Options) *Scheduler {
+	if opts.PollInterval <= 0 {
+		opts.PollInterval = DefaultPollInterval
+	}
+	if opts.BatchSize <= 0 {
+		opts.BatchSize = DefaultBatchSize
+	}
+
+	return &Scheduler{
+		redis:        redisClient,
+		publisher:    publisher,
+		pollInterval: opts.PollInterval,
+		batchSize:    opts.BatchSize,
+	}
+}
+
+// Run starts the scheduler loop. It blocks until the context is cancelled.
+func (s *Scheduler) Run(ctx context.Context) error {
+	slog.Info("scheduler starting",
+		"poll_interval", s.pollInterval,
+		"batch_size", s.batchSize,
+	)
+
+	ticker := time.NewTicker(s.pollInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			slog.Info("scheduler stopping")
+			return ctx.Err()
+		case <-ticker.C:
+			if err := s.poll(ctx); err != nil {
+				slog.Error("scheduler poll error", "error", err)
+			}
+		}
+	}
+}
+
+// poll checks for due timers and processes them.
+func (s *Scheduler) poll(ctx context.Context) error {
+	now := time.Now().UnixMilli()
+
+	// Get due timer IDs (score <= now)
+	timerIDs, err := s.redis.ZRangeByScore(ctx, TimersKey, &redis.ZRangeBy{
+		Min:   "-inf",
+		Max:   fmt.Sprintf("%d", now),
+		Count: int64(s.batchSize),
+	}).Result()
+
+	if err != nil {
+		return err
+	}
+
+	if len(timerIDs) == 0 {
+		return nil
+	}
+
+	slog.Debug("processing due timers", "count", len(timerIDs))
+
+	for _, timerID := range timerIDs {
+		if err := s.processTimer(ctx, timerID); err != nil {
+			slog.Error("failed to process timer",
+				"timer_id", timerID,
+				"error", err,
+			)
+			// Continue processing other timers
+		}
+	}
+
+	return nil
+}
+
+// processTimer handles a single due timer atomically.
+func (s *Scheduler) processTimer(ctx context.Context, timerID string) error {
+	// Use a transaction to atomically remove timer and get payload
+	pipe := s.redis.TxPipeline()
+
+	// Remove from sorted set
+	pipe.ZRem(ctx, TimersKey, timerID)
+
+	// Get and delete payload
+	getCmd := pipe.HGet(ctx, PayloadsKey, timerID)
+	pipe.HDel(ctx, PayloadsKey, timerID)
+
+	_, err := pipe.Exec(ctx)
+	if err != nil {
+		return err
+	}
+
+	payload, err := getCmd.Bytes()
+	if err != nil {
+		if err == redis.Nil {
+			slog.Warn("timer payload not found, already processed?", "timer_id", timerID)
+			return nil
+		}
+		return err
+	}
+
+	// Publish to workflow.resume queue
+	if err := s.publisher.Publish(ctx, "workflow.resume", payload); err != nil {
+		// If publish fails, we've already removed from Redis
+		// Log error but don't re-add to avoid duplicates on retry
+		slog.Error("failed to publish resume message",
+			"timer_id", timerID,
+			"error", err,
+		)
+		return err
+	}
+
+	slog.Info("timer resumed",
+		"timer_id", timerID,
+	)
+
+	return nil
+}

--- a/services/rune-worker/pkg/scheduler/scheduler_test.go
+++ b/services/rune-worker/pkg/scheduler/scheduler_test.go
@@ -1,0 +1,229 @@
+package scheduler
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"rune-worker/pkg/core"
+	"rune-worker/pkg/messages"
+
+	"github.com/redis/go-redis/v9"
+)
+
+// mockPublisher implements queue.Publisher for testing
+type mockPublisher struct {
+	published [][]byte
+	err       error
+}
+
+func (m *mockPublisher) Publish(ctx context.Context, queue string, payload []byte) error {
+	if m.err != nil {
+		return m.err
+	}
+	m.published = append(m.published, payload)
+	return nil
+}
+
+func (m *mockPublisher) Close() error {
+	return nil
+}
+
+func setupTestRedis(t *testing.T) (*redis.Client, func()) {
+	redisClient := redis.NewClient(&redis.Options{
+		Addr: "localhost:6379",
+		DB:   15, // Use DB 15 for testing
+	})
+
+	ctx := context.Background()
+	if err := redisClient.Ping(ctx).Err(); err != nil {
+		t.Skip("Redis not available, skipping test")
+	}
+
+	// Clean up before test
+	redisClient.Del(ctx, TimersKey)
+	redisClient.Del(ctx, PayloadsKey)
+
+	cleanup := func() {
+		redisClient.Del(ctx, TimersKey)
+		redisClient.Del(ctx, PayloadsKey)
+		redisClient.Close()
+	}
+
+	return redisClient, cleanup
+}
+
+func TestScheduler_ProcessesDueTimers(t *testing.T) {
+	redisClient, cleanup := setupTestRedis(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	pub := &mockPublisher{}
+
+	// Create test payload
+	msg := &messages.NodeExecutionMessage{
+		WorkflowID:  "wf-test",
+		ExecutionID: "exec-test",
+		CurrentNode: "wait-node",
+		WorkflowDefinition: core.Workflow{
+			WorkflowID:  "wf-test",
+			ExecutionID: "exec-test",
+			Nodes: []core.Node{
+				{ID: "wait-node", Name: "Wait", Type: "wait"},
+			},
+		},
+		AccumulatedContext: map[string]interface{}{"test": "data"},
+	}
+	payload, _ := msg.Encode()
+
+	// Schedule a timer that's already due (in the past)
+	timerID := "test-timer-1"
+	pastTime := time.Now().Add(-time.Second).UnixMilli()
+
+	redisClient.HSet(ctx, PayloadsKey, timerID, payload)
+	redisClient.ZAdd(ctx, TimersKey, redis.Z{Score: float64(pastTime), Member: timerID})
+
+	// Create scheduler and poll once
+	scheduler := NewScheduler(redisClient, pub, Options{
+		PollInterval: time.Second,
+		BatchSize:    10,
+	})
+
+	err := scheduler.poll(ctx)
+	if err != nil {
+		t.Fatalf("poll failed: %v", err)
+	}
+
+	// Verify message was published
+	if len(pub.published) != 1 {
+		t.Fatalf("expected 1 published message, got %d", len(pub.published))
+	}
+
+	// Verify timer was removed from Redis
+	exists, _ := redisClient.ZScore(ctx, TimersKey, timerID).Result()
+	if exists != 0 {
+		t.Error("timer should have been removed from sorted set")
+	}
+
+	_, err = redisClient.HGet(ctx, PayloadsKey, timerID).Result()
+	if err != redis.Nil {
+		t.Error("payload should have been removed from hash")
+	}
+}
+
+func TestScheduler_IgnoresFutureTimers(t *testing.T) {
+	redisClient, cleanup := setupTestRedis(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	pub := &mockPublisher{}
+
+	// Schedule a timer in the future
+	timerID := "future-timer"
+	futureTime := time.Now().Add(time.Hour).UnixMilli()
+
+	payload := []byte(`{"test": "payload"}`)
+	redisClient.HSet(ctx, PayloadsKey, timerID, payload)
+	redisClient.ZAdd(ctx, TimersKey, redis.Z{Score: float64(futureTime), Member: timerID})
+
+	scheduler := NewScheduler(redisClient, pub, Options{})
+
+	err := scheduler.poll(ctx)
+	if err != nil {
+		t.Fatalf("poll failed: %v", err)
+	}
+
+	// Verify no message was published
+	if len(pub.published) != 0 {
+		t.Errorf("expected 0 published messages for future timer, got %d", len(pub.published))
+	}
+
+	// Verify timer still exists
+	_, err = redisClient.ZScore(ctx, TimersKey, timerID).Result()
+	if err != nil {
+		t.Error("future timer should still exist")
+	}
+}
+
+func TestScheduler_ProcessesMultipleTimers(t *testing.T) {
+	redisClient, cleanup := setupTestRedis(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	pub := &mockPublisher{}
+
+	// Schedule multiple due timers
+	pastTime := time.Now().Add(-time.Second).UnixMilli()
+	for i := 0; i < 5; i++ {
+		timerID := "multi-timer-" + string(rune('a'+i))
+		payload, _ := json.Marshal(map[string]string{"id": timerID})
+		redisClient.HSet(ctx, PayloadsKey, timerID, payload)
+		redisClient.ZAdd(ctx, TimersKey, redis.Z{Score: float64(pastTime), Member: timerID})
+	}
+
+	scheduler := NewScheduler(redisClient, pub, Options{BatchSize: 10})
+
+	err := scheduler.poll(ctx)
+	if err != nil {
+		t.Fatalf("poll failed: %v", err)
+	}
+
+	if len(pub.published) != 5 {
+		t.Errorf("expected 5 published messages, got %d", len(pub.published))
+	}
+}
+
+func TestScheduler_BatchSizeLimit(t *testing.T) {
+	redisClient, cleanup := setupTestRedis(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	pub := &mockPublisher{}
+
+	// Schedule more timers than batch size
+	pastTime := time.Now().Add(-time.Second).UnixMilli()
+	for i := 0; i < 10; i++ {
+		timerID := "batch-timer-" + string(rune('a'+i))
+		payload, _ := json.Marshal(map[string]string{"id": timerID})
+		redisClient.HSet(ctx, PayloadsKey, timerID, payload)
+		redisClient.ZAdd(ctx, TimersKey, redis.Z{Score: float64(pastTime), Member: timerID})
+	}
+
+	scheduler := NewScheduler(redisClient, pub, Options{BatchSize: 3})
+
+	err := scheduler.poll(ctx)
+	if err != nil {
+		t.Fatalf("poll failed: %v", err)
+	}
+
+	// Should only process batch size
+	if len(pub.published) != 3 {
+		t.Errorf("expected 3 published messages (batch size), got %d", len(pub.published))
+	}
+
+	// Remaining timers should still exist
+	count, _ := redisClient.ZCard(ctx, TimersKey).Result()
+	if count != 7 {
+		t.Errorf("expected 7 remaining timers, got %d", count)
+	}
+}
+
+func TestScheduler_HandlesEmptyQueue(t *testing.T) {
+	redisClient, cleanup := setupTestRedis(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	pub := &mockPublisher{}
+
+	scheduler := NewScheduler(redisClient, pub, Options{})
+
+	err := scheduler.poll(ctx)
+	if err != nil {
+		t.Fatalf("poll should not fail on empty queue: %v", err)
+	}
+
+	if len(pub.published) != 0 {
+		t.Errorf("expected 0 published messages, got %d", len(pub.published))
+	}
+}

--- a/services/rune-worker/plugin/node.go
+++ b/services/rune-worker/plugin/node.go
@@ -3,6 +3,7 @@ package plugin
 import (
 	"context"
 
+	"rune-worker/pkg/core"
 	"rune-worker/pkg/messages"
 )
 
@@ -13,15 +14,16 @@ import (
 // The context is passed to each node's Execute method and provides a scoped view of
 // the execution environment, ensuring nodes only access data relevant to their execution.
 type ExecutionContext struct {
-	ExecutionID  string
-	WorkflowID   string
-	NodeID       string
-	Type         string
-	Parameters   map[string]any
-	Input        map[string]any
-	credentials  map[string]any
-	RedisClient  interface{}
-	LineageStack []messages.StackFrame
+	ExecutionID        string
+	WorkflowID         string
+	NodeID             string
+	Type               string
+	Parameters         map[string]any
+	Input              map[string]any
+	credentials        map[string]any
+	RedisClient        interface{}
+	LineageStack       []messages.StackFrame
+	WorkflowDefinition core.Workflow
 }
 
 // GetCredentials returns a read-only copy of the resolved credentials for this node.


### PR DESCRIPTION
- Added a new wait node type that suspends execution for a specified duration.
- Implemented logic to store the frozen execution state in Redis and schedule a resume.
- Introduced a scheduler to poll Redis for due timers and publish resume messages.
- Enhanced validation for node status messages to include 'waiting' state.
- Created end-to-end and integration tests for the wait node functionality.
- Updated the messaging system to handle resume messages after wait timers expire.
- Refactored existing code to accommodate the new wait node and its interactions.