### PR TITLE
refactor(worker): add new node types and use constansts

### DIFF
--- a/services/rune-worker/pkg/core/constants.go
+++ b/services/rune-worker/pkg/core/constants.go
@@ -6,6 +6,15 @@ const (
 	NodeTypeSMTP          = "smtp"
 	NodeTypeConditional   = "conditional"
 	NodeTypeManualTrigger = "ManualTrigger"
+	NodeTypeEdit          = "edit"
+	NodeTypeSwitch        = "switch"
+	NodeTypeWait          = "wait"
+	NodeTypeSplit         = "split"
+	NodeTypeMerge         = "merge"
+	NodeTypeAggregator    = "aggregator"
+	// Test helper node types
+	NodeTypeMock       = "mock"
+	NodeTypeConcurrent = "concurrent"
 )
 
 // Constants for conditional operators

--- a/services/rune-worker/pkg/executor/executor_test.go
+++ b/services/rune-worker/pkg/executor/executor_test.go
@@ -62,7 +62,7 @@ func TestExecutor_SimpleLinearWorkflow(t *testing.T) {
 	reg := nodes.NewRegistry()
 
 	// Register mock node
-	reg.Register("mock", func(execCtx plugin.ExecutionContext) plugin.Node {
+	reg.Register(core.NodeTypeMock, func(execCtx plugin.ExecutionContext) plugin.Node {
 		return &MockNode{
 			output: map[string]any{"result": "success"},
 		}
@@ -76,13 +76,13 @@ func TestExecutor_SimpleLinearWorkflow(t *testing.T) {
 			{
 				ID:         "node1",
 				Name:       "Node 1",
-				Type:       "mock",
+				Type:       core.NodeTypeMock,
 				Parameters: map[string]interface{}{},
 			},
 			{
 				ID:         "node2",
 				Name:       "Node 2",
-				Type:       "mock",
+				Type:       core.NodeTypeMock,
 				Parameters: map[string]interface{}{},
 			},
 		},
@@ -139,7 +139,7 @@ func TestExecutor_EditNodeUpdatesJson(t *testing.T) {
 	pub := NewMockPublisher()
 	reg := nodes.NewRegistry()
 
-	reg.Register("edit", func(execCtx plugin.ExecutionContext) plugin.Node {
+	reg.Register(core.NodeTypeEdit, func(execCtx plugin.ExecutionContext) plugin.Node {
 		// Edit node returns output wrapped in $json, matching the real implementation
 		return &MockNode{output: map[string]any{"$json": map[string]any{"field": "value"}}}
 	})
@@ -148,7 +148,7 @@ func TestExecutor_EditNodeUpdatesJson(t *testing.T) {
 
 	workflow := core.Workflow{
 		Nodes: []core.Node{
-			{ID: "edit1", Name: "Edit", Type: "edit", Parameters: map[string]any{}},
+			{ID: "edit1", Name: "Edit", Type: core.NodeTypeEdit, Parameters: map[string]any{}},
 		},
 	}
 
@@ -187,7 +187,7 @@ func TestExecutor_WorkflowCompletion(t *testing.T) {
 	pub := NewMockPublisher()
 	reg := nodes.NewRegistry()
 
-	reg.Register("mock", func(execCtx plugin.ExecutionContext) plugin.Node {
+	reg.Register(core.NodeTypeMock, func(execCtx plugin.ExecutionContext) plugin.Node {
 		return &MockNode{
 			output: map[string]any{"result": "final"},
 		}
@@ -201,7 +201,7 @@ func TestExecutor_WorkflowCompletion(t *testing.T) {
 			{
 				ID:         "final_node",
 				Name:       "Final Node",
-				Type:       "mock",
+				Type:       core.NodeTypeMock,
 				Parameters: map[string]interface{}{},
 			},
 		},
@@ -247,7 +247,7 @@ func TestExecutor_NodeFailureHaltStrategy(t *testing.T) {
 	pub := NewMockPublisher()
 	reg := nodes.NewRegistry()
 
-	reg.Register("mock", func(execCtx plugin.ExecutionContext) plugin.Node {
+	reg.Register(core.NodeTypeMock, func(execCtx plugin.ExecutionContext) plugin.Node {
 		return &MockNode{
 			err: &NodeExecutionError{Message: "simulated failure"},
 		}
@@ -261,7 +261,7 @@ func TestExecutor_NodeFailureHaltStrategy(t *testing.T) {
 			{
 				ID:         "failing_node",
 				Name:       "Failing Node",
-				Type:       "mock",
+				Type:       core.NodeTypeMock,
 				Parameters: map[string]interface{}{},
 				Error: &core.ErrorHandling{
 					Type: "halt",
@@ -305,7 +305,7 @@ func TestExecutor_ContextAccumulation(t *testing.T) {
 	pub := NewMockPublisher()
 	reg := nodes.NewRegistry()
 
-	reg.Register("mock", func(execCtx plugin.ExecutionContext) plugin.Node {
+	reg.Register(core.NodeTypeMock, func(execCtx plugin.ExecutionContext) plugin.Node {
 		return &MockNode{
 			output: map[string]any{
 				"status": 200,
@@ -321,13 +321,13 @@ func TestExecutor_ContextAccumulation(t *testing.T) {
 			{
 				ID:         "node1",
 				Name:       "Test Node",
-				Type:       "mock",
+				Type:       core.NodeTypeMock,
 				Parameters: map[string]interface{}{},
 			},
 			{
 				ID:         "node2",
 				Name:       "Next Node",
-				Type:       "mock",
+				Type:       core.NodeTypeMock,
 				Parameters: map[string]interface{}{},
 			},
 		},
@@ -390,7 +390,7 @@ func TestExecutor_CredentialsHandling(t *testing.T) {
 
 	var receivedCredentials map[string]any
 
-	reg.Register("mock", func(execCtx plugin.ExecutionContext) plugin.Node {
+	reg.Register(core.NodeTypeMock, func(execCtx plugin.ExecutionContext) plugin.Node {
 		receivedCredentials = execCtx.GetCredentials()
 		return &MockNode{
 			output: map[string]any{"result": "ok"},
@@ -404,7 +404,7 @@ func TestExecutor_CredentialsHandling(t *testing.T) {
 			{
 				ID:         "node_with_creds",
 				Name:       "Node With Credentials",
-				Type:       "mock",
+				Type:       core.NodeTypeMock,
 				Parameters: map[string]interface{}{},
 				Credentials: &core.Credential{
 					ID:   "cred_123",

--- a/services/rune-worker/pkg/nodes/base_test.go
+++ b/services/rune-worker/pkg/nodes/base_test.go
@@ -5,6 +5,7 @@ import (
 	"sync"
 	"testing"
 
+	"rune-worker/pkg/core"
 	"rune-worker/pkg/nodes"
 	"rune-worker/plugin"
 )
@@ -23,8 +24,8 @@ func TestRegisterNode(t *testing.T) {
 	reg := nodes.NewRegistry()
 
 	// Register a mock node
-	reg.Register("mock", func(execCtx plugin.ExecutionContext) plugin.Node {
-		return &MockNode{Type: "mock"}
+	reg.Register(core.NodeTypeMock, func(execCtx plugin.ExecutionContext) plugin.Node {
+		return &MockNode{Type: core.NodeTypeMock}
 	})
 
 	// Create a node instance
@@ -33,7 +34,7 @@ func TestRegisterNode(t *testing.T) {
 		WorkflowID: "test-workflow",
 	}
 
-	node, err := reg.Create("mock", execCtx)
+	node, err := reg.Create(core.NodeTypeMock, execCtx)
 	if err != nil {
 		t.Fatalf("Failed to create node: %v", err)
 	}
@@ -48,8 +49,8 @@ func TestRegisterNode(t *testing.T) {
 		t.Fatalf("Failed to execute node: %v", err)
 	}
 
-	if result["type"] != "mock" {
-		t.Errorf("Expected type 'mock', got '%v'", result["type"])
+	if result["type"] != core.NodeTypeMock {
+		t.Errorf("Expected type '%s', got '%v'", core.NodeTypeMock, result["type"])
 	}
 }
 
@@ -92,8 +93,8 @@ func TestThreadSafeRetrieval(t *testing.T) {
 	reg := nodes.NewRegistry()
 
 	// Register a node
-	reg.Register("concurrent", func(execCtx plugin.ExecutionContext) plugin.Node {
-		return &MockNode{Type: "concurrent"}
+	reg.Register(core.NodeTypeConcurrent, func(execCtx plugin.ExecutionContext) plugin.Node {
+		return &MockNode{Type: core.NodeTypeConcurrent}
 	})
 
 	var wg sync.WaitGroup
@@ -104,7 +105,7 @@ func TestThreadSafeRetrieval(t *testing.T) {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			node, err := reg.Create("concurrent", execCtx)
+			node, err := reg.Create(core.NodeTypeConcurrent, execCtx)
 			if err != nil {
 				t.Errorf("Failed to create node: %v", err)
 				return
@@ -157,7 +158,7 @@ func TestGetAllTypes(t *testing.T) {
 	reg := nodes.NewRegistry()
 
 	// Register multiple node types
-	nodeTypes := []string{"http", "conditional", "log", "email"}
+	nodeTypes := []string{core.NodeTypeHTTP, core.NodeTypeConditional, "log", "email"}
 	for _, nodeType := range nodeTypes {
 		reg.Register(nodeType, func(execCtx plugin.ExecutionContext) plugin.Node {
 			return &MockNode{Type: nodeType}

--- a/services/rune-worker/pkg/nodes/custom/aggregator/aggregator_node.go
+++ b/services/rune-worker/pkg/nodes/custom/aggregator/aggregator_node.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"log/slog"
 
+	"rune-worker/pkg/core"
 	"rune-worker/pkg/messages"
 	"rune-worker/pkg/nodes"
 	"rune-worker/plugin"
@@ -125,7 +126,7 @@ func init() {
 
 // RegisterAggregator registers the aggregator node type.
 func RegisterAggregator(reg *nodes.Registry) {
-	reg.Register("aggregator", func(execCtx plugin.ExecutionContext) plugin.Node {
+	reg.Register(core.NodeTypeAggregator, func(execCtx plugin.ExecutionContext) plugin.Node {
 		return NewAggregatorNode(execCtx)
 	})
 }

--- a/services/rune-worker/pkg/nodes/custom/conditional/conditional_node.go
+++ b/services/rune-worker/pkg/nodes/custom/conditional/conditional_node.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	"rune-worker/pkg/core"
 	"rune-worker/pkg/nodes"
 	"rune-worker/plugin"
 )
@@ -58,7 +59,7 @@ func init() {
 
 // RegisterConditional registers the conditional node type with the registry.
 func RegisterConditional(reg *nodes.Registry) {
-	reg.Register("conditional", func(execCtx plugin.ExecutionContext) plugin.Node {
+	reg.Register(core.NodeTypeConditional, func(execCtx plugin.ExecutionContext) plugin.Node {
 		return NewConditionalNode(execCtx)
 	})
 }

--- a/services/rune-worker/pkg/nodes/custom/edit/edit_node.go
+++ b/services/rune-worker/pkg/nodes/custom/edit/edit_node.go
@@ -8,10 +8,11 @@ import (
 	"strings"
 	"time"
 
-	"github.com/dop251/goja"
-
+	"rune-worker/pkg/core"
 	"rune-worker/pkg/nodes"
 	"rune-worker/plugin"
+
+	"github.com/dop251/goja"
 )
 
 const (
@@ -167,7 +168,7 @@ func init() {
 
 // RegisterEdit registers the edit node type.
 func RegisterEdit(reg *nodes.Registry) {
-	reg.Register("edit", func(execCtx plugin.ExecutionContext) plugin.Node {
+	reg.Register(core.NodeTypeEdit, func(execCtx plugin.ExecutionContext) plugin.Node {
 		return NewEditNode(execCtx)
 	})
 }

--- a/services/rune-worker/pkg/nodes/custom/http/http_node.go
+++ b/services/rune-worker/pkg/nodes/custom/http/http_node.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 	"time"
 
+	"rune-worker/pkg/core"
 	"rune-worker/pkg/nodes"
 	"rune-worker/plugin"
 )
@@ -346,7 +347,7 @@ func init() {
 
 // RegisterHTTP registers the HTTP node type with the registry.
 func RegisterHTTP(reg *nodes.Registry) {
-	reg.Register("http", func(execCtx plugin.ExecutionContext) plugin.Node {
+	reg.Register(core.NodeTypeHTTP, func(execCtx plugin.ExecutionContext) plugin.Node {
 		return NewHTTPNode(execCtx)
 	})
 }

--- a/services/rune-worker/pkg/nodes/custom/merge/merge_node.go
+++ b/services/rune-worker/pkg/nodes/custom/merge/merge_node.go
@@ -226,7 +226,7 @@ func init() {
 
 // RegisterMerge registers the merge node type in the registry.
 func RegisterMerge(reg *nodes.Registry) {
-	reg.Register("merge", func(execCtx plugin.ExecutionContext) plugin.Node {
+	reg.Register(core.NodeTypeMerge, func(execCtx plugin.ExecutionContext) plugin.Node {
 		return NewMergeNode(execCtx)
 	})
 }

--- a/services/rune-worker/pkg/nodes/custom/split/split_node.go
+++ b/services/rune-worker/pkg/nodes/custom/split/split_node.go
@@ -6,6 +6,7 @@ import (
 	"log/slog"
 	"time"
 
+	"rune-worker/pkg/core"
 	"rune-worker/pkg/nodes"
 	"rune-worker/plugin"
 
@@ -97,7 +98,7 @@ func init() {
 
 // RegisterSplit registers the split node type.
 func RegisterSplit(reg *nodes.Registry) {
-	reg.Register("split", func(execCtx plugin.ExecutionContext) plugin.Node {
+	reg.Register(core.NodeTypeSplit, func(execCtx plugin.ExecutionContext) plugin.Node {
 		return NewSplitNode(execCtx)
 	})
 }

--- a/services/rune-worker/pkg/nodes/custom/switch/switch_node.go
+++ b/services/rune-worker/pkg/nodes/custom/switch/switch_node.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log/slog"
 
+	"rune-worker/pkg/core"
 	"rune-worker/pkg/nodes"
 	"rune-worker/plugin"
 )
@@ -88,7 +89,7 @@ func init() {
 
 // RegisterSwitch registers the switch node type.
 func RegisterSwitch(reg *nodes.Registry) {
-	reg.Register("switch", func(execCtx plugin.ExecutionContext) plugin.Node {
+	reg.Register(core.NodeTypeSwitch, func(execCtx plugin.ExecutionContext) plugin.Node {
 		return NewSwitchNode(execCtx)
 	})
 }

--- a/services/rune-worker/pkg/nodes/custom/wait/wait_node.go
+++ b/services/rune-worker/pkg/nodes/custom/wait/wait_node.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"time"
 
+	"rune-worker/pkg/core"
 	"rune-worker/pkg/messages"
 	"rune-worker/pkg/nodes"
 	"rune-worker/plugin"
@@ -128,7 +129,7 @@ func init() {
 
 // RegisterWait registers the wait node type.
 func RegisterWait(reg *nodes.Registry) {
-	reg.Register("wait", func(execCtx plugin.ExecutionContext) plugin.Node {
+	reg.Register(core.NodeTypeWait, func(execCtx plugin.ExecutionContext) plugin.Node {
 		return NewWaitNode(execCtx)
 	})
 }


### PR DESCRIPTION
This pull request introduces a standardized approach to node type strings by defining constants in `core/constants.go` and updating all usages throughout the codebase to reference these constants. This change improves maintainability, reduces risk of typos, and simplifies future updates to node type names. The updates affect node registration, workflow definitions, and related tests.
