### PR TITLE
feat(auth): implement OAuth2 Bearer token authentication

### DIFF
--- a/services/api/src/core/dependencies.py
+++ b/services/api/src/core/dependencies.py
@@ -1,5 +1,6 @@
 from typing import Annotated
 from fastapi import Depends, Request
+from fastapi.security import OAuth2PasswordBearer
 from redis.asyncio import Redis
 from sqlmodel.ext.asyncio.session import AsyncSession
 
@@ -25,9 +26,32 @@ Usage:
         return result.all()
 """
 
+# OAuth2 scheme for Bearer token authentication (API/script clients)
+# auto_error=False allows cookie authentication to take precedence
+oauth2_scheme = OAuth2PasswordBearer(tokenUrl="auth/login", auto_error=False)
 
-async def get_current_user(request: Request) -> User:
+
+async def get_current_user(
+    request: Request,
+    token: str | None = Depends(oauth2_scheme),
+) -> User:
+    """
+    Extract and validate the current user from the request.
+
+    Supports two authentication methods:
+    1. HTTP-only cookie (preferred for browser clients)
+    2. OAuth2 Bearer token (for API/script clients)
+
+    The cookie is checked first, then the OAuth2 bearer token as a fallback.
+    """
+    access_token = None
+
+    # First, try to get token from HTTP-only cookie (browser clients)
     access_token = request.cookies.get("access_token", None)
+
+    # If no cookie, use OAuth2 bearer token (API/script clients)
+    if not access_token and token:
+        access_token = token
 
     if not access_token:
         raise Unauthorized(detail="Not authenticated")
@@ -36,7 +60,7 @@ async def get_current_user(request: Request) -> User:
         user = decode_access_token(access_token)
         return user
     except Exception as e:
-        # Re-raise token-specific errors as it  is, wrap others in Unauthorized
+        # Re-raise token-specific errors as is, wrap others in Unauthorized
         if isinstance(e, (Unauthorized,)):
             raise
         raise Unauthorized(detail="Invalid access token")

--- a/services/api/test/auth/test_bearer_auth.py
+++ b/services/api/test/auth/test_bearer_auth.py
@@ -1,0 +1,131 @@
+import pytest
+import jwt
+from datetime import datetime, timezone, timedelta
+from httpx import AsyncClient
+from src.core.config import get_settings
+
+
+# ============================================================================
+# BEARER TOKEN AUTHENTICATION TESTS
+# ============================================================================
+
+
+@pytest.mark.asyncio
+async def test_bearer_token_auth_success(client: AsyncClient, test_user):
+    """Test that Bearer token authentication works for protected endpoints."""
+    # First, login to get access token
+    login_response = await client.post(
+        "/auth/login",
+        json={"email": "test@example.com", "password": "testpassword123"},
+    )
+    assert login_response.status_code == 200
+    access_token = login_response.json()["data"]["access_token"]
+
+    # Clear cookies to ensure we're testing Bearer token only
+    client.cookies.clear()
+
+    # Make request with Bearer token
+    response = await client.get(
+        "/profile/me",
+        headers={"Authorization": f"Bearer {access_token}"},
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert data["success"] is True
+    assert data["data"]["email"] == "test@example.com"
+
+
+@pytest.mark.asyncio
+async def test_bearer_token_auth_invalid(client: AsyncClient, test_user):
+    """Test that invalid Bearer token returns 401."""
+    response = await client.get(
+        "/profile/me",
+        headers={"Authorization": "Bearer invalid_token_here"},
+    )
+    assert response.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_bearer_token_auth_expired(client: AsyncClient, test_user):
+    """Test that expired Bearer token returns 401."""
+    settings = get_settings()
+
+    # Create an expired token
+    past_time = datetime.now(timezone.utc) - timedelta(hours=2)
+    expired_payload = {
+        "sub": str(test_user.id),
+        "email": test_user.email,
+        "name": test_user.name,
+        "role": test_user.role,
+        "must_change_password": test_user.must_change_password,
+        "iat": past_time,
+        "exp": past_time + timedelta(minutes=30),  # Expired 1.5 hours ago
+        "created_at": test_user.created_at.isoformat(),
+        "updated_at": test_user.updated_at.isoformat(),
+    }
+    expired_token = jwt.encode(
+        expired_payload,
+        settings.jwt_secret_key,
+        algorithm=settings.jwt_algorithm,
+    )
+
+    response = await client.get(
+        "/profile/me",
+        headers={"Authorization": f"Bearer {expired_token}"},
+    )
+    assert response.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_cookie_takes_precedence_over_bearer(client: AsyncClient, test_user):
+    """Test that cookie authentication takes precedence over Bearer token."""
+    # Login to get access token and set cookie
+    login_response = await client.post(
+        "/auth/login",
+        json={"email": "test@example.com", "password": "testpassword123"},
+    )
+    assert login_response.status_code == 200
+
+    # Make request with both cookie (already set from login) and invalid Bearer token
+    # Cookie should take precedence, so request should succeed
+    response = await client.get(
+        "/profile/me",
+        headers={"Authorization": "Bearer invalid_token"},
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert data["data"]["email"] == "test@example.com"
+
+
+@pytest.mark.asyncio
+async def test_no_auth_returns_401(client: AsyncClient, test_user):
+    """Test that missing authentication returns 401."""
+    # Clear any existing cookies
+    client.cookies.clear()
+
+    response = await client.get("/profile/me")
+    assert response.status_code == 401
+    data = response.json()
+    assert data["message"] == "Not authenticated"
+
+
+@pytest.mark.asyncio
+async def test_bearer_token_without_bearer_prefix(client: AsyncClient, test_user):
+    """Test that Authorization header without 'Bearer ' prefix fails."""
+    # Login to get access token
+    login_response = await client.post(
+        "/auth/login",
+        json={"email": "test@example.com", "password": "testpassword123"},
+    )
+    assert login_response.status_code == 200
+    access_token = login_response.json()["data"]["access_token"]
+
+    # Clear cookies
+    client.cookies.clear()
+
+    # Make request without 'Bearer ' prefix - should fail
+    response = await client.get(
+        "/profile/me",
+        headers={"Authorization": access_token},
+    )
+    assert response.status_code == 401


### PR DESCRIPTION
This pull request adds OAuth2 Bearer token authentication support for API and script clients, alongside the existing HTTP-only cookie authentication for browser clients. The authentication logic now checks for a cookie first, then falls back to a Bearer token if no cookie is present. Comprehensive tests are included to verify correct behavior for various authentication scenarios.

**Authentication enhancements:**

* Added OAuth2 Bearer token authentication using FastAPI's `OAuth2PasswordBearer`, allowing API and script clients to authenticate via the `Authorization: Bearer <token>` header. The authentication logic in `get_current_user` now prioritizes cookies but uses the Bearer token as a fallback. [[1]](diffhunk://#diff-ef06a606f3a68840a7f36f40612600db55734e1b73044a20a18ccef9a19474d3R3) [[2]](diffhunk://#diff-ef06a606f3a68840a7f36f40612600db55734e1b73044a20a18ccef9a19474d3R29-R63)

**Testing improvements:**

* Introduced a new test suite `test_bearer_auth.py` with tests that cover successful Bearer token authentication, invalid and expired tokens, cookie vs. Bearer precedence, missing authentication, and improper Authorization header formats.

Closes #268 