### PR TITLE
fix(canvas): prevent API calls on http node drag

### DIFF
--- a/apps/web/src/features/canvas/components/inspectors/HttpInspector.tsx
+++ b/apps/web/src/features/canvas/components/inspectors/HttpInspector.tsx
@@ -12,6 +12,14 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 
+const HTTP_CREDENTIAL_TYPES: ("basic_auth" | "header" | "api_key" | "oauth2" | "token")[] = [
+  "basic_auth",
+  "header",
+  "api_key",
+  "oauth2",
+  "token",
+];
+
 type HttpInspectorProps = {
   node: Node<HttpData>;
   updateData: ReturnType<typeof useUpdateNodeData>;
@@ -37,7 +45,7 @@ export function HttpInspector({
   return (
     <div className="space-y-3">
       <CredentialSelector
-        credentialType={["basic_auth", "header", "api_key", "oauth2", "token"]}
+        credentialType={HTTP_CREDENTIAL_TYPES}
         value={node.data.credential}
         onChange={handleCredentialChange}
         label="Authentication"


### PR DESCRIPTION
Memoizes credential type array in HttpInspector to prevent CredentialSelector from refetching credentials on every node position change. The inline array was creating a new reference on each render, triggering the useEffect dependency on every action.