### PR TITLE
fix(nginx): redirect to https

### DIFF
--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -19,73 +19,8 @@ http {
         listen 80;
         server_name localhost;
 
-        # API routes - proxy to backend
-        location /api/ {
-            proxy_pass http://api/;
-            proxy_http_version 1.1;
-            proxy_set_header Host $host;
-            proxy_set_header X-Real-IP $remote_addr;
-            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-            proxy_set_header X-Forwarded-Proto $scheme;
-            proxy_set_header X-Forwarded-Prefix /api;
-
-            # WebSocket support (if needed)
-            proxy_set_header Upgrade $http_upgrade;
-            proxy_set_header Connection "upgrade";
-
-            # Timeouts
-            proxy_connect_timeout 60s;
-            proxy_send_timeout 60s;
-            proxy_read_timeout 60s;
-        }
-
-        # RTES WebSocket route
-        location /rtes/rt {
-            proxy_pass http://rtes/rt;
-            proxy_http_version 1.1;
-            proxy_set_header Host $host;
-            proxy_set_header X-Real-IP $remote_addr;
-            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-            proxy_set_header X-Forwarded-Proto $scheme;
-
-            # WebSocket support
-            proxy_set_header Upgrade $http_upgrade;
-            proxy_set_header Connection "upgrade";
-
-            # Longer timeouts for WebSocket
-            proxy_connect_timeout 60s;
-            proxy_send_timeout 300s;
-            proxy_read_timeout 300s;
-        }
-
-        # RTES HTTP routes - execution history API
-        location /rtes/ {
-            proxy_pass http://rtes/;
-            proxy_http_version 1.1;
-            proxy_set_header Host $host;
-            proxy_set_header X-Real-IP $remote_addr;
-            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-            proxy_set_header X-Forwarded-Proto $scheme;
-
-            # Timeouts
-            proxy_connect_timeout 60s;
-            proxy_send_timeout 60s;
-            proxy_read_timeout 60s;
-        }
-
-        # Frontend routes - proxy to Next.js
-        location / {
-            proxy_pass http://frontend;
-            proxy_http_version 1.1;
-            proxy_set_header Host $host;
-            proxy_set_header X-Real-IP $remote_addr;
-            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-            proxy_set_header X-Forwarded-Proto $scheme;
-            
-            # WebSocket support for Next.js HMR
-            proxy_set_header Upgrade $http_upgrade;
-            proxy_set_header Connection "upgrade";
-        }
+        # Redirect all HTTP requests to HTTPS
+        return 301 https://$host$request_uri;
     }
 
     server {


### PR DESCRIPTION
This pull request makes a major change to the Nginx configuration by removing all proxy route definitions and replacing them with a redirect for all HTTP traffic to HTTPS. This simplifies the server's HTTP handling and enforces secure connections.

Security and routing changes:

* Removed all proxy route definitions for `/api/`, `/rtes/rt`, `/rtes/`, and `/` from the `http` block in `nginx/nginx.conf`, eliminating backend and WebSocket routing over HTTP.
* Added a single rule to redirect all HTTP requests to HTTPS using a 301 redirect, enforcing secure access.