### PR TITLE
fix(web): tone down toast colors to match app's dark theme

### DIFF
--- a/apps/web/src/styles/toast.css
+++ b/apps/web/src/styles/toast.css
@@ -2,80 +2,71 @@
 
 /* Base toast styling - override Sonner's default backgrounds */
 [data-sonner-toast] {
-  background-color: transparent !important;
+  color: var(--foreground) !important;
   padding: 10px 14px !important;
   min-height: unset !important;
   font-size: 0.875rem !important;
   line-height: 1.4 !important;
-  backdrop-filter: blur(8px) !important;
+  border-radius: var(--radius) !important;
+  box-shadow: 0 4px 24px hsl(220 55% 4% / 0.5) !important;
 }
 
-/* Success Toast - Green */
+/* Success Toast */
 [data-sonner-toast][data-type="success"] {
   background-color: var(--toast-success-bg) !important;
-  color: var(--toast-success-text) !important;
   border: 1px solid var(--toast-success-border) !important;
-  border-left-width: 4px !important;
 }
 
 [data-sonner-toast][data-type="success"] [data-icon],
 [data-sonner-toast][data-type="success"] .toast-icon {
-  color: var(--toast-success-icon) !important;
+  color: var(--toast-success-accent) !important;
 }
 
-/* Error Toast - Red */
+/* Error Toast */
 [data-sonner-toast][data-type="error"] {
   background-color: var(--toast-error-bg) !important;
-  color: var(--toast-error-text) !important;
   border: 1px solid var(--toast-error-border) !important;
-  border-left-width: 4px !important;
 }
 
 [data-sonner-toast][data-type="error"] [data-icon],
 [data-sonner-toast][data-type="error"] .toast-icon {
-  color: var(--toast-error-icon) !important;
+  color: var(--toast-error-accent) !important;
 }
 
-/* Warning Toast - Orange/Yellow */
+/* Warning Toast */
 [data-sonner-toast][data-type="warning"] {
   background-color: var(--toast-warning-bg) !important;
-  color: var(--toast-warning-text) !important;
   border: 1px solid var(--toast-warning-border) !important;
-  border-left-width: 4px !important;
 }
 
 [data-sonner-toast][data-type="warning"] [data-icon],
 [data-sonner-toast][data-type="warning"] .toast-icon {
-  color: var(--toast-warning-icon) !important;
+  color: var(--toast-warning-accent) !important;
 }
 
-/* Info Toast - Blue */
+/* Info Toast */
 [data-sonner-toast][data-type="info"] {
   background-color: var(--toast-info-bg) !important;
-  color: var(--toast-info-text) !important;
   border: 1px solid var(--toast-info-border) !important;
-  border-left-width: 4px !important;
 }
 
 [data-sonner-toast][data-type="info"] [data-icon],
 [data-sonner-toast][data-type="info"] .toast-icon {
-  color: var(--toast-info-icon) !important;
+  color: var(--toast-info-accent) !important;
 }
 
-/* Neutral/Default Toast - Gray */
+/* Neutral/Default Toast */
 [data-sonner-toast][data-type="default"],
 [data-sonner-toast]:not([data-type]) {
   background-color: var(--toast-neutral-bg) !important;
-  color: var(--toast-neutral-text) !important;
   border: 1px solid var(--toast-neutral-border) !important;
-  border-left-width: 4px !important;
 }
 
 [data-sonner-toast][data-type="default"] [data-icon],
 [data-sonner-toast]:not([data-type]) [data-icon],
 [data-sonner-toast][data-type="default"] .toast-icon,
 [data-sonner-toast]:not([data-type]) .toast-icon {
-  color: var(--toast-neutral-icon) !important;
+  color: var(--toast-neutral-accent) !important;
 }
 
 /* Toast Content Layout */

--- a/apps/web/src/styles/tokens.css
+++ b/apps/web/src/styles/tokens.css
@@ -56,31 +56,26 @@
   --node-agent-bg: hsl(189 85% 62% / 0.18);
   --node-agent-border: hsl(189 85% 62% / 0.35);
 
-  /* Toast notification colors - Dark Mode */
-  --toast-success-bg: hsl(145 92% 21% / 0.85);
-  --toast-success-border: hsl(145 92% 41%);
-  --toast-success-text: hsl(143 85% 96%);
-  --toast-success-icon: hsl(145 92% 41%);
+  /* Toast notification colors — dark tint of each variant's hue with glass */
+  --toast-success-bg: hsl(152 18% 14% );
+  --toast-success-border: hsl(152 22% 28%);
+  --toast-success-accent: hsl(152 45% 46%);
 
-  --toast-error-bg: hsl(0 84% 25% / 0.85);
-  --toast-error-border: hsl(0 84% 60%);
-  --toast-error-text: hsl(0 93% 94%);
-  --toast-error-icon: hsl(0 84% 60%);
+  --toast-error-bg: hsl(0 16% 15% );
+  --toast-error-border: hsl(0 20% 28%);
+  --toast-error-accent: hsl(0 50% 55%);
 
-  --toast-warning-bg: hsl(38 92% 20% / 0.85);
-  --toast-warning-border: hsl(38 92% 50%);
-  --toast-warning-text: hsl(48 100% 96%);
-  --toast-warning-icon: hsl(38 92% 50%);
+  --toast-warning-bg: hsl(38 16% 14% );
+  --toast-warning-border: hsl(38 20% 28%);
+  --toast-warning-accent: hsl(40 50% 52%);
 
-  --toast-info-bg: hsl(217 91% 25% / 0.85);
-  --toast-info-border: hsl(217 91% 60%);
-  --toast-info-text: hsl(214 100% 97%);
-  --toast-info-icon: hsl(217 91% 60%);
+  --toast-info-bg: hsl(217 22% 15% );
+  --toast-info-border: hsl(217 24% 28%);
+  --toast-info-accent: hsl(217 65% 58%);
 
-  --toast-neutral-bg: hsl(220 25% 20% / 0.85);
-  --toast-neutral-border: hsl(220 25% 45%);
-  --toast-neutral-text: hsl(210 20% 96%);
-  --toast-neutral-icon: hsl(215 16% 47%);
+  --toast-neutral-bg: hsl(220 16% 15% );
+  --toast-neutral-border: hsl(220 18% 26%);
+  --toast-neutral-accent: hsl(215 16% 48%);
 }
 
 * {


### PR DESCRIPTION
Replace vibrant, high-saturation toast backgrounds with muted, hue-matched dark surfaces.