### PR TITLE
feat(dx): add hivemind-based dev runner for single-command startup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -140,9 +140,30 @@ archivist-install:
 # Development targets
 # ======================
 
-dev: dev-infra-up
+dev: api-dev-infra-up dev-infra-wait
 	@echo "Starting all services in development mode..."
+ifeq ($(DETECTED_OS),Windows)
 	@$(MAKE) -j5 web-dev api-dev worker-dev rtes-dev archivist-dev
+else
+	go run github.com/DarthSim/hivemind@latest Procfile.dev
+endif
+
+dev-infra-wait:
+ifeq ($(DETECTED_OS),Windows)
+	@echo "Waiting for infrastructure to be ready..."
+	@timeout /t 5 /nobreak >nul
+	@echo "  ✓ Infrastructure ready (waited 5s)"
+else
+	@echo "Waiting for infrastructure to be ready..."
+	@until docker exec rune-api-postgres-dev pg_isready -U rune -q 2>/dev/null; do sleep 1; done
+	@echo "  ✓ PostgreSQL ready"
+	@until docker exec rune-api-redis-dev redis-cli ping 2>/dev/null | grep -q PONG; do sleep 1; done
+	@echo "  ✓ Redis ready"
+	@until docker exec rune-api-rabbitmq-dev rabbitmq-diagnostics -q check_port_connectivity >/dev/null 2>&1; do sleep 1; done
+	@echo "  ✓ RabbitMQ ready"
+	@until docker exec rune-mongodb-dev mongosh --quiet --eval "db.runCommand('ping').ok" 2>/dev/null | grep -q 1; do sleep 1; done
+	@echo "  ✓ MongoDB ready"
+endif
 
 dev-infra-up: api-dev-infra-up rtes-dev-infra-up
 	@echo "Dev infrastructure is up."

--- a/Procfile.dev
+++ b/Procfile.dev
@@ -1,0 +1,5 @@
+web: cd apps/web && PORT=3000 pnpm dev
+api: cd services/api && PORT=8000 uv run fastapi dev src/app.py --reload-dir src
+worker: cd services/rune-worker && go run cmd/worker/main.go
+rtes: cd services/rtes && PORT=3001 cargo run
+archivist: cd services/archivist && uv run python -m src.main


### PR DESCRIPTION
Adds support for [hivemind](https://github.com/DarthSim/hivemind) based running via `make dev`, this features better signal propagation and colored labels over the parallel job makefile command. This should make it smoother to run all dev services in parallel on all environments.

This only works on Unix based systems. No love for Windows users unfortunately.
(`make dev` will still work on Windows via the old `make -j5`) 