### PR TITLE
fix: improve footer behavior

### DIFF
--- a/apps/web/src/components/layout/AppShell.tsx
+++ b/apps/web/src/components/layout/AppShell.tsx
@@ -12,7 +12,7 @@ export function AppShell({ children }: AppShellProps) {
     <div className="flex min-h-screen bg-background text-foreground">
       <AppSidebar />
       <div className="flex flex-1 flex-col">
-        <main className="flex-1 overflow-x-hidden bg-background/80 pb-16">
+        <main className="flex-1 overflow-x-hidden bg-background/80 pb-16 min-h-screen">
           {children}
         </main>
         <Footer />


### PR DESCRIPTION
Footer behaviour now for:
1- Short content: Footer sticks to the bottom of the viewport 2- Long content: Footer moves down with the content 3- Table/extended content: Footer scrolls naturally below all content