### PR TITLE
fix: surface node execution errors to frontend

### DIFF
--- a/apps/web/src/features/canvas/context/ExecutionContext.tsx
+++ b/apps/web/src/features/canvas/context/ExecutionContext.tsx
@@ -77,6 +77,7 @@ function executionReducer(state: ExecutionState, action: ExecutionAction): Execu
         input: nodeData.input ?? existingNode?.input,
         output: nodeData.output ?? existingNode?.output,
         parameters: nodeData.parameters ?? existingNode?.parameters,
+        error: nodeData.status === "failed" ? (nodeData.error ?? existingNode?.error) : nodeData.error,
         executedAt: new Date().toISOString(),
       });
 
@@ -108,6 +109,7 @@ function executionReducer(state: ExecutionState, action: ExecutionAction): Execu
           input: nodeData.input ?? existingNode?.input,
           output: nodeData.output ?? existingNode?.output,
           parameters: nodeData.parameters ?? existingNode?.parameters,
+          error: nodeData.status === "failed" ? (nodeData.error ?? existingNode?.error) : nodeData.error,
           executedAt: new Date().toISOString(),
         });
       }

--- a/apps/web/src/features/canvas/context/ExecutionContext.tsx
+++ b/apps/web/src/features/canvas/context/ExecutionContext.tsx
@@ -77,7 +77,8 @@ function executionReducer(state: ExecutionState, action: ExecutionAction): Execu
         input: nodeData.input ?? existingNode?.input,
         output: nodeData.output ?? existingNode?.output,
         parameters: nodeData.parameters ?? existingNode?.parameters,
-        error: nodeData.status === "failed" ? (nodeData.error ?? existingNode?.error) : nodeData.error,
+        error:
+          nodeData.status === "failed" ? (nodeData.error ?? existingNode?.error) : nodeData.error,
         executedAt: new Date().toISOString(),
       });
 
@@ -109,7 +110,8 @@ function executionReducer(state: ExecutionState, action: ExecutionAction): Execu
           input: nodeData.input ?? existingNode?.input,
           output: nodeData.output ?? existingNode?.output,
           parameters: nodeData.parameters ?? existingNode?.parameters,
-          error: nodeData.status === "failed" ? (nodeData.error ?? existingNode?.error) : nodeData.error,
+          error:
+            nodeData.status === "failed" ? (nodeData.error ?? existingNode?.error) : nodeData.error,
           executedAt: new Date().toISOString(),
         });
       }

--- a/apps/web/src/features/canvas/types/execution.ts
+++ b/apps/web/src/features/canvas/types/execution.ts
@@ -73,12 +73,19 @@ export interface ExecutionSnapshot {
  * RTES WebSocket message types.
  * These match the WsNodeUpdateDto from services/rtes/src/api/ws.rs
  */
+export interface RtesNodeError {
+  message: string;
+  code: string;
+  details?: unknown;
+}
+
 export interface RtesNodeUpdate {
   node_id?: string | null;
   status?: string | null;
   input?: unknown;
   params?: unknown;
   output?: unknown;
+  error?: RtesNodeError | null;
   lineage_hash?: string | null;
   lineage_stack?: RtesStackFrame[] | null;
   split_node_id?: string | null;
@@ -156,6 +163,9 @@ export function rtesUpdateToNodeData(update: RtesNodeUpdate): NodeExecutionData 
     input: update.input,
     output: update.output,
     parameters: update.params,
+    error: update.error
+      ? { message: update.error.message, code: update.error.code, details: update.error.details }
+      : undefined,
     lineageHash: update.lineage_hash ?? undefined,
     branchId: update.branch_id ?? undefined,
     itemIndex: update.item_index ?? undefined,

--- a/services/rtes/src/api/ws.rs
+++ b/services/rtes/src/api/ws.rs
@@ -15,7 +15,7 @@ use tracing::{error, info, warn};
 
 use crate::{
     api::state::AppState,
-    domain::models::{NodeExecutionInstance, StackFrame, WorkerMessage},
+    domain::models::{NodeError, NodeExecutionInstance, StackFrame, WorkerMessage},
 };
 
 #[derive(Debug, Serialize, Clone, PartialEq)]
@@ -24,6 +24,7 @@ pub(crate) struct WsNodeUpdateDto {
     pub(crate) input:            Option<Value>,
     pub(crate) params:           Option<Value>,
     pub(crate) output:           Option<Value>,
+    pub(crate) error:            Option<NodeError>,
     pub(crate) status:           Option<String>,
     pub(crate) lineage_hash:     Option<String>,
     pub(crate) lineage_stack:    Option<Vec<StackFrame>>,
@@ -44,6 +45,7 @@ impl From<&WorkerMessage> for WsNodeUpdateDto {
                 input:            s.input.clone(),
                 params:           s.parameters.clone(),
                 output:           s.output.clone(),
+                error:            s.error.clone(),
                 status:           Some(s.status.clone()),
                 lineage_hash:     s.lineage_hash.clone(),
                 lineage_stack:    s.lineage_stack.clone(),
@@ -60,6 +62,7 @@ impl From<&WorkerMessage> for WsNodeUpdateDto {
                 input:            None,
                 params:           None,
                 output:           None,
+                error:            None,
                 status:           Some("completed".to_string()),
                 lineage_hash:     None,
                 lineage_stack:    None,
@@ -76,6 +79,7 @@ impl From<&WorkerMessage> for WsNodeUpdateDto {
                 input:            None,
                 params:           None,
                 output:           None,
+                error:            None,
                 status:           Some("unknown error".to_string()),
                 lineage_hash:     None,
                 lineage_stack:    None,
@@ -97,6 +101,7 @@ fn dto_from_execution_instance(node_id: String, exec: NodeExecutionInstance) -> 
         input:            exec.input,
         params:           exec.parameters,
         output:           exec.output,
+        error:            exec.error,
         status:           exec.status,
         lineage_hash:     exec.lineage_hash,
         lineage_stack:    exec.lineage_stack,
@@ -110,12 +115,13 @@ fn dto_from_execution_instance(node_id: String, exec: NodeExecutionInstance) -> 
     }
 }
 
-const fn dto_with_status(status: String) -> WsNodeUpdateDto {
+fn dto_with_status(status: String) -> WsNodeUpdateDto {
     WsNodeUpdateDto {
         node_id:          None,
         input:            None,
         params:           None,
         output:           None,
+        error:            None,
         status:           Some(status),
         lineage_hash:     None,
         lineage_stack:    None,

--- a/services/rtes/src/api/ws.rs
+++ b/services/rtes/src/api/ws.rs
@@ -115,7 +115,7 @@ fn dto_from_execution_instance(node_id: String, exec: NodeExecutionInstance) -> 
     }
 }
 
-fn dto_with_status(status: String) -> WsNodeUpdateDto {
+const fn dto_with_status(status: String) -> WsNodeUpdateDto {
     WsNodeUpdateDto {
         node_id:          None,
         input:            None,


### PR DESCRIPTION
The `WsNodeUpdateDto` was missing the `error` field, so node failure details were silently dropped before reaching the WebSocket clients. Frontend already had the `ErrorDisplay` component wired up and waiting.

Fixes #434 