### PR TITLE
feat(web): add once-in-a-lifetime admin visibility warning for users

### DIFF
--- a/apps/web/src/components/auth/AdminVisibilityModal.tsx
+++ b/apps/web/src/components/auth/AdminVisibilityModal.tsx
@@ -1,0 +1,52 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { useAuth } from "@/lib/auth";
+
+const STORAGE_KEY_PREFIX = "admin_visibility_confirmed_";
+
+export function AdminVisibilityModal() {
+  const [open, setOpen] = useState(false);
+  const { state } = useAuth();
+  
+  // Create a user-specific storage key
+  const storageKey = state.user?.id ? `${STORAGE_KEY_PREFIX}${state.user.id}` : null;
+
+  useEffect(() => {
+    // Determine if user is not loaded or is an admin
+    if (!state.user || state.user.role === "admin" || !storageKey) {
+      return;
+    }
+
+    // Only access localStorage on the client to avoid hydration mismatch
+    const hasConfirmed = localStorage.getItem(storageKey);
+    if (!hasConfirmed) {
+      setOpen(true);
+    }
+  }, [state.user, storageKey]);
+
+  const handleConfirm = () => {
+    if (storageKey) {
+      localStorage.setItem(storageKey, "true");
+    }
+    setOpen(false);
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogContent className="sm:max-w-[425px]">
+        <DialogHeader>
+          <DialogTitle>Admin Visibility Notice</DialogTitle>
+          <DialogDescription>
+            Organization administrators can view your workflows, credentials, and data.
+          </DialogDescription>
+        </DialogHeader>
+        <DialogFooter>
+          <Button onClick={handleConfirm}>I understand</Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/web/src/components/auth/AdminVisibilityModal.tsx
+++ b/apps/web/src/components/auth/AdminVisibilityModal.tsx
@@ -41,8 +41,16 @@ export function AdminVisibilityModal() {
     setOpen(false);
   };
 
+  const handleOpenChange = (newOpen: boolean) => {
+    if (!newOpen) {
+      handleConfirm();
+    } else {
+      setOpen(true);
+    }
+  };
+
   return (
-    <Dialog open={open} onOpenChange={setOpen}>
+    <Dialog open={open} onOpenChange={handleOpenChange}>
       <DialogContent className="sm:max-w-[425px]">
         <DialogHeader>
           <DialogTitle>Admin Visibility Notice</DialogTitle>

--- a/apps/web/src/components/auth/AdminVisibilityModal.tsx
+++ b/apps/web/src/components/auth/AdminVisibilityModal.tsx
@@ -1,7 +1,14 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from "@/components/ui/dialog";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
 import { Button } from "@/components/ui/button";
 import { useAuth } from "@/lib/auth";
 
@@ -10,7 +17,7 @@ const STORAGE_KEY_PREFIX = "admin_visibility_confirmed_";
 export function AdminVisibilityModal() {
   const [open, setOpen] = useState(false);
   const { state } = useAuth();
-  
+
   // Create a user-specific storage key
   const storageKey = state.user?.id ? `${STORAGE_KEY_PREFIX}${state.user.id}` : null;
 

--- a/apps/web/src/components/auth/AdminVisibilityModal.tsx
+++ b/apps/web/src/components/auth/AdminVisibilityModal.tsx
@@ -12,6 +12,8 @@ import {
 import { Button } from "@/components/ui/button";
 import { useAuth } from "@/lib/auth";
 
+// TODO: Move this flag to the backend (User model) in the future to avoid
+// the modal re-triggering if the user logs in from a different browser or device.
 const STORAGE_KEY_PREFIX = "admin_visibility_confirmed_";
 
 export function AdminVisibilityModal() {

--- a/apps/web/src/components/layout/AppShell.tsx
+++ b/apps/web/src/components/layout/AppShell.tsx
@@ -2,6 +2,7 @@ import type { ReactNode } from "react";
 
 import { Footer } from "@/components/layout/Footer";
 import { AppSidebar } from "@/components/layout/AppSidebar";
+import { AdminVisibilityModal } from "@/components/auth/AdminVisibilityModal";
 
 interface AppShellProps {
   children: ReactNode;
@@ -17,6 +18,7 @@ export function AppShell({ children }: AppShellProps) {
         </main>
         <Footer />
       </div>
+      <AdminVisibilityModal />
     </div>
   );
 }


### PR DESCRIPTION
I've finished implementing the admin visibility warning modal.

I took a frontend approach using `[localStorage]`. It's a "once in a lifetime" that appears the first time a user signs in after they change their temporary password and included a couple of safeguards:

The logic checks the user's role, so it strictly targets regular users and bypasses admins.
The storage key is tied to the specific user ID. This ensures that if multiple people sign in from the same pc and browser, they will each properly receive the notice on their respective accounts.
<img width="1919" height="858" alt="image" src="https://github.com/user-attachments/assets/051aa32a-2c57-44ce-ac34-5fdf6ac8d099" />

resolves #508