### PR TITLE
fix(canvas): improve node copy/paste reliability

### DIFF
--- a/apps/web/src/features/canvas/FlowCanvas.tsx
+++ b/apps/web/src/features/canvas/FlowCanvas.tsx
@@ -287,7 +287,6 @@ function FlowCanvasInner({
     setNodes,
     setEdges,
     setSelectedNodeId,
-    containerRef,
   });
 
   const persistGraph = useCallback(() => {

--- a/apps/web/src/features/canvas/hooks/useGraphClipboard.ts
+++ b/apps/web/src/features/canvas/hooks/useGraphClipboard.ts
@@ -18,7 +18,6 @@ export type UseGraphClipboardOptions = {
   setNodes: React.Dispatch<React.SetStateAction<CanvasNode[]>>;
   setEdges: React.Dispatch<React.SetStateAction<Edge[]>>;
   setSelectedNodeId: (id: string | null) => void;
-  containerRef: React.RefObject<HTMLDivElement | null>;
 };
 
 function notifyPasteShortcut() {
@@ -35,7 +34,6 @@ export function useGraphClipboard(opts: UseGraphClipboardOptions) {
     setNodes,
     setEdges,
     setSelectedNodeId,
-    containerRef,
   } = opts;
 
   const [isSaveTemplateOpen, setIsSaveTemplateOpen] = useState(false);
@@ -311,10 +309,9 @@ export function useGraphClipboard(opts: UseGraphClipboardOptions) {
       setEdges(parsed.edges as Edge[]);
       toast.success("Imported workflow from clipboard");
     };
-    const el = containerRef.current ?? window;
-    el.addEventListener("paste", handler as EventListener);
-    return () => el.removeEventListener("paste", handler as EventListener);
-  }, [readOnly, pushHistory, setEdges, setNodes, setSelectedNodeId, containerRef]);
+    window.addEventListener("paste", handler);
+    return () => window.removeEventListener("paste", handler);
+  }, [readOnly, pushHistory, setEdges, setNodes, setSelectedNodeId]);
 
   return {
     copySelection,

--- a/apps/web/src/features/canvas/hooks/useVariableInput.ts
+++ b/apps/web/src/features/canvas/hooks/useVariableInput.ts
@@ -13,10 +13,14 @@ export type VariableMatch = {
   end: number;
 };
 
-const ZERO_WIDTH_CHAR_REGEX = /[\u200B\uFEFF]/g;
+// Strip zero-width markers and non-breaking spaces. Chrome injects NBSP around
+// contenteditable="false" pill elements as a rendering artifact; users never
+// type these intentionally, so we drop them entirely instead of converting to
+// regular spaces (which would leak leading/trailing whitespace into node data).
+const RAW_TEXT_STRIP_REGEX = /[\u200B\uFEFF\u00A0]/g;
 
 function normalizeRawText(text: string): string {
-  return text.replace(ZERO_WIDTH_CHAR_REGEX, "").replace(/\u00A0/g, " ");
+  return text.replace(RAW_TEXT_STRIP_REGEX, "");
 }
 
 function isBlockElement(node: Node): node is HTMLElement {
@@ -44,12 +48,15 @@ function blockPrefixLength(child: Node, childIndex: number): number {
   return childIndex > 0 && isBlockElement(child) ? 1 : 0;
 }
 
+function isStrippedChar(ch: string): boolean {
+  return ch === "\u200B" || ch === "\uFEFF" || ch === "\u00A0";
+}
+
 function rawLengthOfTextPrefix(text: string, endOffset: number): number {
   const safeEnd = Math.max(0, Math.min(endOffset, text.length));
   let length = 0;
   for (let i = 0; i < safeEnd; i++) {
-    const ch = text[i];
-    if (ch === "\u200B" || ch === "\uFEFF") continue;
+    if (isStrippedChar(text[i])) continue;
     length += 1;
   }
   return length;
@@ -61,8 +68,7 @@ function domOffsetFromRawTextOffset(text: string, rawOffset: number): number {
 
   let seen = 0;
   for (let i = 0; i < text.length; i++) {
-    const ch = text[i];
-    if (ch === "\u200B" || ch === "\uFEFF") continue;
+    if (isStrippedChar(text[i])) continue;
     seen += 1;
     if (seen >= target) {
       return i + 1;


### PR DESCRIPTION
Ctrl+V silently did nothing when nothing inside the canvas was focused. The paste listener was attached to the canvas container div, but paste events fire on the focused element (often document.body) and bubble through document/window. 

Moved the listener to window so it reliably catches pastes; existing readOnly and dialog-target guards still apply.