### PR TITLE
fix(worker): complete execution on terminal split node

### DIFF
--- a/services/rune-worker/pkg/executor/node_handlers.go
+++ b/services/rune-worker/pkg/executor/node_handlers.go
@@ -196,7 +196,7 @@ func (e *Executor) handleNodeSuccess(ctx context.Context, msg *messages.NodeExec
 	nextNodes := e.determineNextNodes(&msg.WorkflowDefinition, node, output)
 
 	// Handle Split Node Fan-Out
-	if node.Type == "split" {
+	if node.Type == "split" && len(nextNodes) > 0 {
 		if items, ok := output["_split_items"].([]any); ok {
 			return e.handleSplitFanOut(ctx, msg, node, nextNodes, items, updatedContext)
 		}


### PR DESCRIPTION
When a Split node had no downstream edges, the workflow stayed stuck in "Running" forever even though Split had executed successfully.

`handleNodeSuccess` was unconditionally routing Split nodes into `handleSplitFanOut`, which loops over `_split_items` and publishes a message per-item to each downstream node. With zero downstream nodes, the inner loop ran zero times and the function returned nil without ever hitting the len(nextNodes) == 0 completion branch just below, so no `CompletionStatusCompleted` was published and RTES/UI never saw the execution finish.