### PR TITLE
fix(worker): preserve full node output map in accumulated context

### DIFF
--- a/services/rune-worker/integration/http_split_aggregate_test.go
+++ b/services/rune-worker/integration/http_split_aggregate_test.go
@@ -192,9 +192,14 @@ func TestHTTPSplitAggregateWorkflow(t *testing.T) {
 			t.Fatalf("Final context missing $Aggregate_Users output. Context keys: %v", getKeys(completion.FinalContext))
 		}
 
-		aggregated, ok := aggOutput.([]interface{})
+		aggMap, ok := aggOutput.(map[string]interface{})
 		if !ok {
-			t.Fatalf("Aggregate output missing 'aggregated' field: %v", aggOutput)
+			t.Fatalf("Expected $Aggregate_Users to be a map, got %T: %v", aggOutput, aggOutput)
+		}
+
+		aggregated, ok := aggMap["aggregated"].([]interface{})
+		if !ok {
+			t.Fatalf("Aggregate output missing 'aggregated' field: %v", aggMap)
 		}
 
 		if len(aggregated) != len(users) {

--- a/services/rune-worker/integration/split_aggregate_test.go
+++ b/services/rune-worker/integration/split_aggregate_test.go
@@ -146,9 +146,14 @@ func TestSplitAggregateWorkflow(t *testing.T) {
 			t.Fatalf("Final context missing $Collector output. Context: %v", completion.FinalContext)
 		}
 
-		aggregated, ok := collectorOutput.([]interface{})
+		collectorMap, ok := collectorOutput.(map[string]interface{})
 		if !ok {
-			t.Fatalf("Collector output missing 'aggregated' field or wrong type: %v", collectorOutput)
+			t.Fatalf("Expected $Collector to be a map, got %T: %v", collectorOutput, collectorOutput)
+		}
+
+		aggregated, ok := collectorMap["aggregated"].([]interface{})
+		if !ok {
+			t.Fatalf("Collector output missing 'aggregated' field or wrong type: %v", collectorMap)
 		}
 
 		if len(aggregated) != 3 {

--- a/services/rune-worker/pkg/executor/execution_context.go
+++ b/services/rune-worker/pkg/executor/execution_context.go
@@ -72,16 +72,12 @@ func (e *Executor) filterUsedInputs(input map[string]any, usedKeys []string) map
 }
 
 // accumulateContext adds the node output to the accumulated context with $<node_name> key.
+// The full output map is always stored as-is so that path references like
+// $NodeName.field resolve uniformly regardless of how many fields the node returned
 func (e *Executor) accumulateContext(currentContext map[string]interface{}, nodeName string, output map[string]any) map[string]interface{} {
 	updated := make(map[string]interface{}, len(currentContext)+1)
 	for k, v := range currentContext {
 		updated[k] = v
-	}
-	if len(output) == 1 {
-		for _, v := range output {
-			updated[fmt.Sprintf("$%s", nodeName)] = v
-			return updated
-		}
 	}
 	updated[fmt.Sprintf("$%s", nodeName)] = output
 	return updated


### PR DESCRIPTION
`accumulateContext` was unwrapping single-key node outputs - if a node returned `{"k": v}`, only v was stored under `$<NodeName>` instead of the full map. This silently broke path-based references for any node that happened to return one field:

- Split (`{"_split_items": [...]}) - $Split._split_items` in a Log message [resolved to the literal string](https://github.com/rune-org/rune/issues/494) because `$Split` was the array, and
navigating `._split_items` on an array fails. Meanwhile attempting to resolve on just `$item` worked because it's written directly into the per-branch context.
- Aggregator (`{"aggregated": [...]}`) - picker-generated `$Agg.aggregated` pills failed the same way.
- Merge `wait_for_any` path - `$Merge.merged_context.foo` similarly unresolvable.

The bug was especially confusing because the frontend variable picker builds pills from the raw node output (`useVariableTree` → `jsonToVariableTree(execData.output, …)`), always producing `$Node.field.path` strings which is fundamentally incompatible with the unwrap.

This PR changes the behaviour of accumulated context to always store the full output map under `$<NodeName>`. Path references now resolve uniformly whether the node returned one field or many, and runtime state matches what the picker shows.

Fixes #494 