### PR TITLE
fix(canvas): enable scroll panning

### DIFF
--- a/apps/web/src/features/canvas/components/FlowViewport.tsx
+++ b/apps/web/src/features/canvas/components/FlowViewport.tsx
@@ -14,6 +14,7 @@ import {
   type OnSelectionChangeParams,
   type ReactFlowProps,
   type ReactFlowInstance,
+  PanOnScrollMode,
 } from "@xyflow/react";
 import { nodeTypes } from "../nodes";
 import type { CanvasNode } from "../types";
@@ -85,6 +86,10 @@ export const FlowViewport = memo(function FlowViewport({
       onNodeDragStop={onNodeDragStop}
       onInit={onInit}
       onPaneClick={onPaneClick}
+      panOnScroll
+      panOnScrollMode={PanOnScrollMode.Free}
+      zoomOnScroll={false}
+      zoomOnPinch
       connectOnClick={!readOnly}
       nodesDraggable={!readOnly}
       nodesConnectable={!readOnly}


### PR DESCRIPTION
Scrolling now pans the canvas in both directions, and trackpad pinch zooms in/out. Left-click-drag panning still works as before. Zooming via scroll wheel is now done with Ctrl/Cmd + scroll. 

Fixes #503