### PR TITLE
fix(worker): embed IANA tzdata

### DIFF
--- a/services/rune-worker/cmd/worker/main.go
+++ b/services/rune-worker/cmd/worker/main.go
@@ -7,7 +7,7 @@ import (
 	"os"
 	"os/signal"
 	"syscall"
-	_ "time/tzdata" // embed IANA tzdata so LoadLocation works on scratch images
+	_ "time/tzdata" // embed IANA tzdata
 
 	"rune-worker/pkg/messaging"
 	"rune-worker/pkg/platform/config"

--- a/services/rune-worker/cmd/worker/main.go
+++ b/services/rune-worker/cmd/worker/main.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"os/signal"
 	"syscall"
+	_ "time/tzdata" // embed IANA tzdata so LoadLocation works on scratch images
 
 	"rune-worker/pkg/messaging"
 	"rune-worker/pkg/platform/config"


### PR DESCRIPTION
`time.LoadLocation` reads timezone rules from the OS (`/usr/share/zoneinfo`) at runtime. Environments without that database could only resolve UTC/Local, so any datetime node configured with an IANA zone (e.g. Europe/London) failed with unknown time zone.

This is apparently the root cause of issue #525 