### PR TITLE
fix(canvas): warn before deleting nodes with variable references

### DIFF
--- a/apps/web/src/features/canvas/FlowCanvas.tsx
+++ b/apps/web/src/features/canvas/FlowCanvas.tsx
@@ -15,10 +15,13 @@ import { toast } from "@/components/ui/toast";
 import type { CanvasNode, NodeKind } from "./types";
 import {
   scanVariableReferences,
+  scanReferencesToDeleted,
   replaceVariableReferences,
+  clearVariableReferences,
   type ScanResult,
 } from "./lib/variableRefUpdate";
 import { RenameRefDialog, type RenameChoice } from "./components/RenameRefDialog";
+import { DeleteRefDialog, type DeleteChoice } from "./components/DeleteRefDialog";
 import { Toolbar } from "./components/Toolbar";
 import { RightPanelStack } from "./components/RightPanelStack";
 import { Library } from "./components/Library";
@@ -112,6 +115,12 @@ function FlowCanvasInner({
     newName: string;
     nodeId: string;
     nodeType: NodeKind;
+    scanResult: ScanResult;
+  } | null>(null);
+  const [deleteDialog, setDeleteDialog] = useState<{
+    nodeIds: Set<string>;
+    edgeIds: Set<string>;
+    nodeNames: string[];
     scanResult: ScanResult;
   } | null>(null);
 
@@ -340,14 +349,68 @@ function FlowCanvasInner({
     }
   }, [redo, setNodes, setEdges]);
 
+  const performDelete = useCallback(
+    (nodeIds: Set<string>, edgeIds: Set<string>, clearRefs: boolean) => {
+      pushHistory();
+      setNodes((ns) => {
+        let next = ns.filter((n) => !nodeIds.has(n.id));
+        if (clearRefs) {
+          const deletedNames = new Set<string>();
+          for (const n of ns) {
+            if (nodeIds.has(n.id) && n.data.label) deletedNames.add(n.data.label);
+          }
+          next = clearVariableReferences(next, deletedNames);
+        }
+        return next;
+      });
+      setEdges((es) =>
+        es.filter(
+          (ed) => !edgeIds.has(ed.id) && !nodeIds.has(ed.source) && !nodeIds.has(ed.target),
+        ),
+      );
+    },
+    [pushHistory, setNodes, setEdges],
+  );
+
+  const requestDelete = useCallback(
+    (nodeIds: Set<string>, edgeIds: Set<string>) => {
+      if (nodeIds.size === 0 && edgeIds.size === 0) return;
+      if (nodeIds.size === 0) {
+        performDelete(nodeIds, edgeIds, false);
+        return;
+      }
+      const scan = scanReferencesToDeleted(nodesRef.current, nodeIds);
+      if (scan.totalRefs === 0) {
+        performDelete(nodeIds, edgeIds, false);
+        return;
+      }
+      const nodeNames = nodesRef.current
+        .filter((n) => nodeIds.has(n.id))
+        .map((n) => n.data.label || n.id.slice(0, 6));
+      setDeleteDialog({ nodeIds, edgeIds, nodeNames, scanResult: scan });
+    },
+    [performDelete],
+  );
+
+  const handleDeleteChoice = useCallback(
+    (choice: DeleteChoice) => {
+      if (!deleteDialog) return;
+      const { nodeIds, edgeIds } = deleteDialog;
+      setDeleteDialog(null);
+      if (choice === "cancel") return;
+      performDelete(nodeIds, edgeIds, choice === "clear");
+    },
+    [deleteDialog, performDelete],
+  );
+
   const deleteSelectedElements = useCallback(() => {
-    pushHistory();
     const selectedNodeIds = new Set(nodesRef.current.filter((n) => n.selected).map((n) => n.id));
-    setNodes((ns) => ns.filter((n) => !selectedNodeIds.has(n.id)));
-    setEdges((es) =>
-      es.filter((e) => !selectedNodeIds.has(e.source) && !selectedNodeIds.has(e.target)),
-    );
-  }, [pushHistory, setNodes, setEdges]);
+    if (selectedNodeIds.size === 0 && selectedNodeId) {
+      selectedNodeIds.add(selectedNodeId);
+    }
+    const selectedEdgeIds = new Set(edgesRef.current.filter((e) => e.selected).map((e) => e.id));
+    requestDelete(selectedNodeIds, selectedEdgeIds);
+  }, [selectedNodeId, requestDelete]);
 
   const selectedNode = useMemo(
     () => nodes.find((n) => n.id === selectedNodeId) || null,
@@ -480,11 +543,8 @@ function FlowCanvasInner({
 
   useCanvasShortcuts({
     nodes,
-    edges,
     readOnly: isViewingSnapshot,
-    selectedNodeId,
     setNodes,
-    setEdges,
     onDelete: deleteSelectedElements,
     onSave: () => {
       void persistGraph();
@@ -496,7 +556,6 @@ function FlowCanvasInner({
       void copySelection();
     },
     onSelectAll: (firstId) => setSelectedNodeId(firstId),
-    onPushHistory: pushHistory,
     shortcutsRef,
     onNodeShortcut: (kind) => {
       pushHistory();
@@ -675,6 +734,15 @@ function FlowCanvasInner({
             newName={renameDialog.newName}
             scanResult={renameDialog.scanResult}
             onChoice={handleRenameChoice}
+          />
+        )}
+
+        {deleteDialog && (
+          <DeleteRefDialog
+            open={true}
+            nodeNames={deleteDialog.nodeNames}
+            scanResult={deleteDialog.scanResult}
+            onChoice={handleDeleteChoice}
           />
         )}
       </div>

--- a/apps/web/src/features/canvas/FlowCanvas.tsx
+++ b/apps/web/src/features/canvas/FlowCanvas.tsx
@@ -121,6 +121,7 @@ function FlowCanvasInner({
     nodeIds: Set<string>;
     edgeIds: Set<string>;
     nodeNames: string[];
+    orphanedNames: Set<string>;
     scanResult: ScanResult;
   } | null>(null);
 
@@ -350,18 +351,11 @@ function FlowCanvasInner({
   }, [redo, setNodes, setEdges]);
 
   const performDelete = useCallback(
-    (nodeIds: Set<string>, edgeIds: Set<string>, clearRefs: boolean) => {
+    (nodeIds: Set<string>, edgeIds: Set<string>, clearNames?: Set<string>) => {
       pushHistory();
       setNodes((ns) => {
-        let next = ns.filter((n) => !nodeIds.has(n.id));
-        if (clearRefs) {
-          const deletedNames = new Set<string>();
-          for (const n of ns) {
-            if (nodeIds.has(n.id) && n.data.label) deletedNames.add(n.data.label);
-          }
-          next = clearVariableReferences(next, deletedNames);
-        }
-        return next;
+        const next = ns.filter((n) => !nodeIds.has(n.id));
+        return clearNames && clearNames.size > 0 ? clearVariableReferences(next, clearNames) : next;
       });
       setEdges((es) =>
         es.filter(
@@ -376,18 +370,19 @@ function FlowCanvasInner({
     (nodeIds: Set<string>, edgeIds: Set<string>) => {
       if (nodeIds.size === 0 && edgeIds.size === 0) return;
       if (nodeIds.size === 0) {
-        performDelete(nodeIds, edgeIds, false);
+        performDelete(nodeIds, edgeIds);
         return;
       }
       const scan = scanReferencesToDeleted(nodesRef.current, nodeIds);
       if (scan.totalRefs === 0) {
-        performDelete(nodeIds, edgeIds, false);
+        performDelete(nodeIds, edgeIds);
         return;
       }
+      const { orphanedNames, ...scanResult } = scan;
       const nodeNames = nodesRef.current
         .filter((n) => nodeIds.has(n.id))
         .map((n) => n.data.label || n.id.slice(0, 6));
-      setDeleteDialog({ nodeIds, edgeIds, nodeNames, scanResult: scan });
+      setDeleteDialog({ nodeIds, edgeIds, nodeNames, orphanedNames, scanResult });
     },
     [performDelete],
   );
@@ -395,10 +390,10 @@ function FlowCanvasInner({
   const handleDeleteChoice = useCallback(
     (choice: DeleteChoice) => {
       if (!deleteDialog) return;
-      const { nodeIds, edgeIds } = deleteDialog;
+      const { nodeIds, edgeIds, orphanedNames } = deleteDialog;
       setDeleteDialog(null);
       if (choice === "cancel") return;
-      performDelete(nodeIds, edgeIds, choice === "clear");
+      performDelete(nodeIds, edgeIds, choice === "clear" ? orphanedNames : undefined);
     },
     [deleteDialog, performDelete],
   );

--- a/apps/web/src/features/canvas/components/DeleteRefDialog.tsx
+++ b/apps/web/src/features/canvas/components/DeleteRefDialog.tsx
@@ -13,37 +13,33 @@ import {
 import { plural } from "@/lib/plural";
 import type { ScanResult } from "../lib/variableRefUpdate";
 
-export type RenameChoice = "update" | "skip" | "cancel";
+export type DeleteChoice = "delete" | "clear" | "cancel";
 
-type RenameRefDialogProps = {
+type DeleteRefDialogProps = {
   open: boolean;
-  oldName: string;
-  newName: string;
+  nodeNames: string[];
   scanResult: ScanResult;
-  onChoice: (choice: RenameChoice) => void;
+  onChoice: (choice: DeleteChoice) => void;
 };
 
-export function RenameRefDialog({
-  open,
-  oldName,
-  newName,
-  scanResult,
-  onChoice,
-}: RenameRefDialogProps) {
+const nameListFormat = new Intl.ListFormat("en", { type: "conjunction" });
+
+export function DeleteRefDialog({ open, nodeNames, scanResult, onChoice }: DeleteRefDialogProps) {
   function handleOpenChange(isOpen: boolean): void {
     if (!isOpen) onChoice("cancel");
   }
+
+  const nodeWord = nodeNames.length === 1 ? "node" : "nodes";
 
   return (
     <AlertDialog open={open} onOpenChange={handleOpenChange}>
       <AlertDialogContent className="sm:max-w-lg">
         <AlertDialogHeader>
-          <AlertDialogTitle>Update variable references?</AlertDialogTitle>
+          <AlertDialogTitle>Delete referenced {nodeWord}?</AlertDialogTitle>
           <AlertDialogDescription className="wrap-break-word">
-            Renaming <strong className="break-all">{oldName}</strong> to{" "}
-            <strong className="break-all">{newName}</strong> will affect{" "}
-            <strong>{plural(scanResult.totalRefs, "reference")}</strong> in{" "}
-            <strong>{plural(scanResult.affectedNodes.length, "node")}</strong>.
+            Deleting <strong className="break-all">{nameListFormat.format(nodeNames)}</strong> will
+            leave <strong>{plural(scanResult.totalRefs, "stale reference")}</strong> in{" "}
+            <strong>{plural(scanResult.affectedNodes.length, "other node")}</strong>.
           </AlertDialogDescription>
         </AlertDialogHeader>
         <AlertDialogFooter className="flex-row items-center gap-2 sm:justify-between">
@@ -53,12 +49,15 @@ export function RenameRefDialog({
           <div className="flex items-center gap-2">
             <AlertDialogAction
               className="border border-input bg-background text-foreground shadow-sm hover:bg-accent hover:text-accent-foreground"
-              onClick={() => onChoice("skip")}
+              onClick={() => onChoice("delete")}
             >
-              Skip
+              Delete anyway
             </AlertDialogAction>
-            <AlertDialogAction onClick={() => onChoice("update")}>
-              Update references
+            <AlertDialogAction
+              className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+              onClick={() => onChoice("clear")}
+            >
+              Delete and clear references
             </AlertDialogAction>
           </div>
         </AlertDialogFooter>

--- a/apps/web/src/features/canvas/components/FlowViewport.tsx
+++ b/apps/web/src/features/canvas/components/FlowViewport.tsx
@@ -93,6 +93,7 @@ export const FlowViewport = memo(function FlowViewport({
       connectOnClick={!readOnly}
       nodesDraggable={!readOnly}
       nodesConnectable={!readOnly}
+      deleteKeyCode={null}
     >
       {!readOnly ? <ClickConnectBridge /> : null}
       <Background />

--- a/apps/web/src/features/canvas/hooks/useCanvasShortcuts.ts
+++ b/apps/web/src/features/canvas/hooks/useCanvasShortcuts.ts
@@ -2,22 +2,17 @@
 
 import { useEffect, useRef } from "react";
 import type { CanvasNode, NodeKind } from "../types";
-import type { Edge } from "@xyflow/react";
 
 type CanvasShortcutsProps = {
   nodes: CanvasNode[];
-  edges: Edge[];
   readOnly?: boolean;
-  selectedNodeId: string | null;
   setNodes: (updater: (nodes: CanvasNode[]) => CanvasNode[] | CanvasNode[]) => void;
-  setEdges: (updater: (edges: Edge[]) => Edge[] | Edge[]) => void;
   onSave: () => void;
   onSaveWithMessage?: () => void;
   onUndo: () => void;
   onRedo: () => void;
   onCopy?: () => void;
   onSelectAll?: (firstId: string | null) => void;
-  onPushHistory: () => void;
   onDelete: () => void;
   shortcutsRef?: React.RefObject<Record<string, NodeKind>>;
   onNodeShortcut?: (kind: NodeKind) => void;
@@ -33,20 +28,8 @@ export function useCanvasShortcuts(opts: CanvasShortcutsProps) {
 
   useEffect(() => {
     const handler = (e: KeyboardEvent) => {
-      const {
-        nodes,
-        edges,
-        readOnly,
-        selectedNodeId,
-        setNodes,
-        setEdges,
-        onSave,
-        onUndo,
-        onRedo,
-        onCopy,
-        onSelectAll,
-        onPushHistory,
-      } = latestPropsRef.current;
+      const { nodes, readOnly, setNodes, onSave, onUndo, onRedo, onCopy, onSelectAll, onDelete } =
+        latestPropsRef.current;
 
       const target = e.target as Element | null;
 
@@ -61,32 +44,12 @@ export function useCanvasShortcuts(opts: CanvasShortcutsProps) {
 
       if (isEditable) return;
 
-      // delete selected node(s)/edge(s)
       if (e.key === "Delete" || e.key === "Backspace") {
         if (readOnly) {
           e.preventDefault();
           return;
         }
-
-        const selectedNodeIds = new Set(nodes.filter((n) => n.selected).map((n) => n.id));
-        const selectedEdgeIds = new Set(edges.filter((e) => e.selected).map((e) => e.id));
-
-        if (selectedNodeIds.size === 0 && selectedEdgeIds.size === 0 && selectedNodeId) {
-          selectedNodeIds.add(selectedNodeId);
-        }
-
-        if (selectedNodeIds.size > 0 || selectedEdgeIds.size > 0) {
-          onPushHistory();
-          setNodes((ns) => ns.filter((n) => !selectedNodeIds.has(n.id)));
-          setEdges((es) =>
-            es.filter(
-              (ed) =>
-                !selectedEdgeIds.has(ed.id) &&
-                !selectedNodeIds.has(ed.source) &&
-                !selectedNodeIds.has(ed.target),
-            ),
-          );
-        }
+        onDelete();
         return;
       }
 

--- a/apps/web/src/features/canvas/lib/variableRefUpdate.ts
+++ b/apps/web/src/features/canvas/lib/variableRefUpdate.ts
@@ -78,24 +78,45 @@ function scanVariableReferencesTo(
   };
 }
 
+export type DeleteScanResult = ScanResult & { orphanedNames: Set<string> };
+
 /**
- * Scan non-deleted nodes for variable references pointing at any of the nodes
- * about to be deleted. Returns an empty result if no deleted node has a label.
+ * Collect labels carried by deleted nodes that no remaining node still holds.
+ * Duplicate labels remain valid while any surviving node continues to carry
+ * them, so only orphaned labels warrant a stale-reference warning or cleanup.
+ */
+function collectOrphanedLabels(allNodes: CanvasNode[], deletedNodeIds: Set<string>): Set<string> {
+  const survivingLabels = new Set<string>();
+  for (const node of allNodes) {
+    if (!deletedNodeIds.has(node.id) && node.data.label) {
+      survivingLabels.add(node.data.label);
+    }
+  }
+  const orphaned = new Set<string>();
+  for (const node of allNodes) {
+    const label = node.data.label;
+    if (deletedNodeIds.has(node.id) && label && !survivingLabels.has(label)) {
+      orphaned.add(label);
+    }
+  }
+  return orphaned;
+}
+
+/**
+ * Scan non-deleted nodes for variable references pointing at labels that will
+ * no longer resolve after the deletion. Duplicate-labeled survivors keep their
+ * references valid and are excluded from the result.
  */
 export function scanReferencesToDeleted(
   allNodes: CanvasNode[],
   deletedNodeIds: Set<string>,
-): ScanResult {
-  const deletedNames = new Set<string>();
-  for (const node of allNodes) {
-    if (deletedNodeIds.has(node.id) && node.data.label) {
-      deletedNames.add(node.data.label);
-    }
+): DeleteScanResult {
+  const orphanedNames = collectOrphanedLabels(allNodes, deletedNodeIds);
+  if (orphanedNames.size === 0) {
+    return { totalRefs: 0, affectedNodes: [], references: [], orphanedNames };
   }
-  if (deletedNames.size === 0) {
-    return { totalRefs: 0, affectedNodes: [], references: [] };
-  }
-  return scanVariableReferencesTo(allNodes, deletedNames, deletedNodeIds);
+  const scan = scanVariableReferencesTo(allNodes, orphanedNames, deletedNodeIds);
+  return { ...scan, orphanedNames };
 }
 
 /** Recursively walk a node-data value, applying `transformString` to every string. */

--- a/apps/web/src/features/canvas/lib/variableRefUpdate.ts
+++ b/apps/web/src/features/canvas/lib/variableRefUpdate.ts
@@ -36,10 +36,19 @@ function visitValue(path: string, value: unknown, visitor: Visitor): void {
  * Scan all nodes (except the one being renamed) for `$oldName` variable references.
  */
 export function scanVariableReferences(nodes: CanvasNode[], oldName: string): ScanResult {
+  return scanVariableReferencesTo(nodes, new Set([oldName]));
+}
+
+function scanVariableReferencesTo(
+  nodes: CanvasNode[],
+  names: Set<string>,
+  excludeIds?: Set<string>,
+): ScanResult {
   const references: AffectedReference[] = [];
   const affectedNodeIds = new Set<string>();
 
   for (const node of nodes) {
+    if (excludeIds?.has(node.id)) continue;
     const data = node.data as Record<string, unknown>;
 
     for (const [key, val] of Object.entries(data)) {
@@ -48,7 +57,7 @@ export function scanVariableReferences(nodes: CanvasNode[], oldName: string): Sc
       visitValue(key, val, (path, str) => {
         const matches = parseVariableReferences(str);
         for (const m of matches) {
-          if (m.nodeName === oldName) {
+          if (names.has(m.nodeName)) {
             affectedNodeIds.add(node.id);
             references.push({
               nodeId: node.id,
@@ -69,39 +78,37 @@ export function scanVariableReferences(nodes: CanvasNode[], oldName: string): Sc
   };
 }
 
-function replaceInValue<T>(value: T, oldName: string, newName: string): T {
-  if (typeof value === "string") {
-    let result = "";
-    let i = 0;
-    while (i < value.length) {
-      if (value[i] === "\\" && i + 1 < value.length && value[i + 1] === "$") {
-        result += "\\$";
-        i += 2;
-        continue;
-      }
-
-      if (value[i] === "$") {
-        const rest = value.slice(i + 1);
-        if (
-          rest.startsWith(oldName) &&
-          (rest.length === oldName.length || !/[a-zA-Z0-9_-]/.test(rest[oldName.length]))
-        ) {
-          result += `$${newName}`;
-          i += 1 + oldName.length;
-          continue;
-        }
-      }
-
-      result += value[i];
-      i++;
+/**
+ * Scan non-deleted nodes for variable references pointing at any of the nodes
+ * about to be deleted. Returns an empty result if no deleted node has a label.
+ */
+export function scanReferencesToDeleted(
+  allNodes: CanvasNode[],
+  deletedNodeIds: Set<string>,
+): ScanResult {
+  const deletedNames = new Set<string>();
+  for (const node of allNodes) {
+    if (deletedNodeIds.has(node.id) && node.data.label) {
+      deletedNames.add(node.data.label);
     }
-    return result as T;
+  }
+  if (deletedNames.size === 0) {
+    return { totalRefs: 0, affectedNodes: [], references: [] };
+  }
+  return scanVariableReferencesTo(allNodes, deletedNames, deletedNodeIds);
+}
+
+/** Recursively walk a node-data value, applying `transformString` to every string. */
+function transformValue<T>(value: T, transformString: (s: string) => string): T {
+  if (typeof value === "string") {
+    const next = transformString(value);
+    return (next === value ? value : next) as T;
   }
 
   if (Array.isArray(value)) {
     let changed = false;
     const newArr = value.map((item) => {
-      const replaced = replaceInValue(item, oldName, newName);
+      const replaced = transformValue(item, transformString);
       if (replaced !== item) changed = true;
       return replaced;
     });
@@ -116,7 +123,7 @@ function replaceInValue<T>(value: T, oldName: string, newName: string): T {
         newObj[key] = v;
         continue;
       }
-      const replaced = replaceInValue(v, oldName, newName);
+      const replaced = transformValue(v, transformString);
       if (replaced !== v) changed = true;
       newObj[key] = replaced;
     }
@@ -126,13 +133,67 @@ function replaceInValue<T>(value: T, oldName: string, newName: string): T {
   return value;
 }
 
+function renameInString(value: string, oldName: string, newName: string): string {
+  let result = "";
+  let i = 0;
+  while (i < value.length) {
+    if (value[i] === "\\" && i + 1 < value.length && value[i + 1] === "$") {
+      result += "\\$";
+      i += 2;
+      continue;
+    }
+
+    if (value[i] === "$") {
+      const rest = value.slice(i + 1);
+      if (
+        rest.startsWith(oldName) &&
+        (rest.length === oldName.length || !/[a-zA-Z0-9_-]/.test(rest[oldName.length]))
+      ) {
+        result += `$${newName}`;
+        i += 1 + oldName.length;
+        continue;
+      }
+    }
+
+    result += value[i];
+    i++;
+  }
+  return result;
+}
+
+function clearInString(value: string, names: Set<string>): string {
+  const matches = parseVariableReferences(value);
+  if (matches.length === 0) return value;
+
+  let result = "";
+  let lastEnd = 0;
+  let changed = false;
+  for (const m of matches) {
+    if (!names.has(m.nodeName)) continue;
+    result += value.slice(lastEnd, m.start);
+    lastEnd = m.end;
+    changed = true;
+  }
+  if (!changed) return value;
+  return result + value.slice(lastEnd);
+}
+
 export function replaceVariableReferences(
   nodes: CanvasNode[],
   oldName: string,
   newName: string,
 ): CanvasNode[] {
   return nodes.map((node) => {
-    const newData = replaceInValue(node.data, oldName, newName);
+    const newData = transformValue(node.data, (s) => renameInString(s, oldName, newName));
+    if (newData === node.data) return node;
+    return { ...node, data: newData } as CanvasNode;
+  });
+}
+
+export function clearVariableReferences(nodes: CanvasNode[], names: Set<string>): CanvasNode[] {
+  if (names.size === 0) return nodes;
+  return nodes.map((node) => {
+    const newData = transformValue(node.data, (s) => clearInString(s, names));
     if (newData === node.data) return node;
     return { ...node, data: newData } as CanvasNode;
   });

--- a/apps/web/src/lib/plural.ts
+++ b/apps/web/src/lib/plural.ts
@@ -1,0 +1,3 @@
+export function plural(count: number, word: string): string {
+  return `${count} ${word}${count === 1 ? "" : "s"}`;
+}


### PR DESCRIPTION
Deleting a node silently left $-references in other nodes stale (white- highlighted). Scan remaining nodes on delete; if any reference the target, show a confirmation dialog offering Cancel, Delete anyway, or Delete and clear references. 
Applies to both the Inspector delete button and the Delete/Backspace shortcut.

Fixes #484