### PR TITLE
perf: separate providers to skip auth bootstrap on docs

### DIFF
--- a/apps/web/src/app/(app)/layout.tsx
+++ b/apps/web/src/app/(app)/layout.tsx
@@ -1,6 +1,7 @@
 import type { ReactNode } from "react";
 
 import { AppShell } from "@/components/layout/AppShell";
+import { AppProviders } from "@/components/providers/ClientProviders";
 import { RequireAuth } from "@/components/auth/RequireAuth";
 
 interface AppLayoutProps {
@@ -9,8 +10,10 @@ interface AppLayoutProps {
 
 export default function AppLayout({ children }: AppLayoutProps) {
   return (
-    <RequireAuth>
-      <AppShell>{children}</AppShell>
-    </RequireAuth>
+    <AppProviders>
+      <RequireAuth>
+        <AppShell>{children}</AppShell>
+      </RequireAuth>
+    </AppProviders>
   );
 }

--- a/apps/web/src/app/(canvas)/layout.tsx
+++ b/apps/web/src/app/(canvas)/layout.tsx
@@ -1,6 +1,12 @@
 import type { ReactNode } from "react";
+
 import { RequireAuth } from "@/components/auth/RequireAuth";
+import { AppProviders } from "@/components/providers/ClientProviders";
 
 export default function CanvasLayout({ children }: { children: ReactNode }) {
-  return <RequireAuth>{children}</RequireAuth>;
+  return (
+    <AppProviders>
+      <RequireAuth>{children}</RequireAuth>
+    </AppProviders>
+  );
 }

--- a/apps/web/src/app/(home)/layout.tsx
+++ b/apps/web/src/app/(home)/layout.tsx
@@ -2,6 +2,7 @@ import type { ReactNode } from "react";
 
 import { Footer } from "@/components/layout/Footer";
 import { TopNav } from "@/components/layout/TopNav";
+import { AppProviders } from "@/components/providers/ClientProviders";
 
 interface HomeLayoutProps {
   children: ReactNode;
@@ -9,10 +10,12 @@ interface HomeLayoutProps {
 
 export default function HomeLayout({ children }: HomeLayoutProps) {
   return (
-    <div className="flex min-h-screen flex-col bg-background">
-      <TopNav />
-      <main className="flex-1">{children}</main>
-      <Footer />
-    </div>
+    <AppProviders>
+      <div className="flex min-h-screen flex-col bg-background">
+        <TopNav />
+        <main className="flex-1">{children}</main>
+        <Footer />
+      </div>
+    </AppProviders>
   );
 }

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -1,7 +1,7 @@
 import type { Metadata } from "next";
 import { Noto_Sans, Playfair_Display, Cinzel } from "next/font/google";
 import { Toaster } from "@/components/ui/toast";
-import { ClientProviders } from "@/components/providers/ClientProviders";
+import { RootProviders } from "@/components/providers/ClientProviders";
 
 import "./globals.css";
 
@@ -42,7 +42,7 @@ export default function RootLayout({
       <body
         className={`${fontSans.variable} ${fontDisplay.variable} ${fontRune.variable} antialiased bg-background text-foreground min-h-screen`}
       >
-        <ClientProviders>{children}</ClientProviders>
+        <RootProviders>{children}</RootProviders>
         <Toaster />
       </body>
     </html>

--- a/apps/web/src/components/providers/ClientProviders.tsx
+++ b/apps/web/src/components/providers/ClientProviders.tsx
@@ -1,25 +1,30 @@
 "use client";
 
 import type { ReactNode } from "react";
+import { useEffect } from "react";
+
+import { ThemeProvider } from "@/components/providers/ThemeProvider";
+import { TooltipProvider } from "@/components/ui/tooltip";
 import { AppStateProvider } from "@/lib/state";
 import { AuthProvider } from "@/lib/auth";
-import { useEffect } from "react";
 import { setupClientInterceptors } from "@/lib/api/setupClientInterceptors";
-import { TooltipProvider } from "@/components/ui/tooltip";
-import { ThemeProvider } from "@/components/providers/ThemeProvider";
 
-export function ClientProviders({ children }: { children: ReactNode }) {
+export function RootProviders({ children }: { children: ReactNode }) {
+  return (
+    <ThemeProvider>
+      <TooltipProvider>{children}</TooltipProvider>
+    </ThemeProvider>
+  );
+}
+
+export function AppProviders({ children }: { children: ReactNode }) {
   useEffect(() => {
     setupClientInterceptors();
   }, []);
 
   return (
-    <ThemeProvider>
-      <AuthProvider>
-        <AppStateProvider>
-          <TooltipProvider>{children}</TooltipProvider>
-        </AppStateProvider>
-      </AuthProvider>
-    </ThemeProvider>
+    <AuthProvider>
+      <AppStateProvider>{children}</AppStateProvider>
+    </AuthProvider>
   );
 }


### PR DESCRIPTION
Splits `ClientProviders` into `RootProviders` (theme + tooltip) at the root and `AppProviders` (auth + app-state + interceptors) wrapped around `(app)`, `(canvas)`, and `(home)`. The Nextra docs route sits outside all route groups, so it was needlessly running auth and app-state bootstrapping. Now public docs pages only get theme/tooltip, while authed routes keep identical coverage.