### PR TITLE
feat(canvas): add variable picker to http node inspector

### DIFF
--- a/apps/web/src/features/canvas/components/KeyValueVariableEditor.tsx
+++ b/apps/web/src/features/canvas/components/KeyValueVariableEditor.tsx
@@ -1,0 +1,163 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import { Plus, Trash2 } from "lucide-react";
+import { VariableInput } from "./variable-picker/VariableInput";
+
+type Entry = {
+  id: string;
+  key: string;
+  value: string;
+};
+
+type KeyValueVariableEditorProps = {
+  value?: Record<string, unknown>;
+  onChange: (next: Record<string, unknown>) => void;
+  nodeId: string;
+  keyPlaceholder?: string;
+  valuePlaceholder?: string;
+  addLabel?: string;
+  emptyLabel?: string;
+};
+
+function entriesFromRecord(record: Record<string, unknown> | undefined, seed: number): Entry[] {
+  if (!record) return [];
+  return Object.entries(record).map(([key, value], i) => ({
+    id: `entry-${seed}-${i}`,
+    key,
+    value: typeof value === "string" ? value : value == null ? "" : JSON.stringify(value),
+  }));
+}
+
+function recordFromEntries(entries: Entry[]): Record<string, unknown> {
+  const out: Record<string, unknown> = {};
+  for (const { key, value } of entries) {
+    const trimmed = key.trim();
+    if (!trimmed) continue;
+    out[trimmed] = value;
+  }
+  return out;
+}
+
+function recordsEqual(a: Record<string, unknown>, b: Record<string, unknown>): boolean {
+  const aKeys = Object.keys(a);
+  const bKeys = Object.keys(b);
+  if (aKeys.length !== bKeys.length) return false;
+  for (const k of aKeys) {
+    if (a[k] !== b[k]) return false;
+  }
+  return true;
+}
+
+export function KeyValueVariableEditor({
+  value,
+  onChange,
+  nodeId,
+  keyPlaceholder = "Name",
+  valuePlaceholder = "Value",
+  addLabel = "Add",
+  emptyLabel = "No entries defined.",
+}: KeyValueVariableEditorProps) {
+  const idCounter = useRef(0);
+  const nextId = useCallback(() => {
+    idCounter.current += 1;
+    return `entry-new-${idCounter.current}`;
+  }, []);
+
+  const [entries, setEntries] = useState<Entry[]>(() => entriesFromRecord(value, 0));
+
+  const lastEmittedRef = useRef<Record<string, unknown>>(value ?? {});
+
+  useEffect(() => {
+    const incoming = value ?? {};
+    if (recordsEqual(lastEmittedRef.current, incoming)) return;
+    lastEmittedRef.current = incoming;
+    idCounter.current += 1;
+    setEntries(entriesFromRecord(incoming, idCounter.current));
+  }, [value]);
+
+  const emitChange = useCallback(
+    (next: Entry[]) => {
+      const nextRecord = recordFromEntries(next);
+      if (recordsEqual(lastEmittedRef.current, nextRecord)) return;
+      lastEmittedRef.current = nextRecord;
+      onChange(nextRecord);
+    },
+    [onChange],
+  );
+
+  const updateEntries = useCallback(
+    (updater: (prev: Entry[]) => Entry[]) => {
+      setEntries((prev) => {
+        const next = updater(prev);
+        emitChange(next);
+        return next;
+      });
+    },
+    [emitChange],
+  );
+
+  const addEntry = () => {
+    updateEntries((prev) => [...prev, { id: nextId(), key: "", value: "" }]);
+  };
+
+  const removeEntry = (id: string) => {
+    updateEntries((prev) => prev.filter((e) => e.id !== id));
+  };
+
+  const updateKey = (id: string, key: string) => {
+    updateEntries((prev) => prev.map((e) => (e.id === id ? { ...e, key } : e)));
+  };
+
+  const updateValue = (id: string, value: string) => {
+    updateEntries((prev) => prev.map((e) => (e.id === id ? { ...e, value } : e)));
+  };
+
+  return (
+    <div className="mt-2 space-y-2">
+      {entries.length > 0 ? (
+        <div className="space-y-1.5">
+          {entries.map((entry) => (
+            <div key={entry.id} className="flex items-start gap-1.5">
+              <input
+                className="w-1/3 shrink-0 rounded-[calc(var(--radius)-0.25rem)] border border-input bg-muted/30 px-2 py-1 text-xs"
+                value={entry.key}
+                onChange={(e) => updateKey(entry.id, e.target.value)}
+                placeholder={keyPlaceholder}
+                spellCheck={false}
+              />
+              <div className="min-w-0 flex-1">
+                <VariableInput
+                  value={entry.value}
+                  onChange={(v) => updateValue(entry.id, v)}
+                  nodeId={nodeId}
+                  placeholder={valuePlaceholder}
+                />
+              </div>
+              <button
+                type="button"
+                onClick={() => removeEntry(entry.id)}
+                className="inline-flex h-7 w-7 shrink-0 items-center justify-center rounded border border-destructive/40 bg-destructive/10 text-destructive hover:bg-destructive/20"
+                aria-label="Remove entry"
+              >
+                <Trash2 className="h-3.5 w-3.5" />
+              </button>
+            </div>
+          ))}
+        </div>
+      ) : (
+        <div className="rounded-[calc(var(--radius)-0.3rem)] border border-dashed border-border/60 bg-muted/20 px-2 py-1.5 text-[11px] text-muted-foreground">
+          {emptyLabel}
+        </div>
+      )}
+      <button
+        type="button"
+        onClick={addEntry}
+        className="inline-flex items-center gap-1 rounded-[calc(var(--radius)-0.3rem)] border border-border/60 bg-muted/40 px-2 py-1 text-xs font-medium text-foreground hover:bg-muted/70"
+      >
+        <Plus className="h-3.5 w-3.5" />
+        {addLabel}
+      </button>
+    </div>
+  );
+}

--- a/apps/web/src/features/canvas/components/KeyValueVariableEditor.tsx
+++ b/apps/web/src/features/canvas/components/KeyValueVariableEditor.tsx
@@ -109,41 +109,76 @@ export function KeyValueVariableEditor({
     updateEntries((prev) => prev.map((e) => (e.id === id ? { ...e, key } : e)));
   };
 
+  const commitKey = (id: string) => {
+    updateEntries((prev) =>
+      prev.map((e) => (e.id === id && e.key !== e.key.trim() ? { ...e, key: e.key.trim() } : e)),
+    );
+  };
+
   const updateValue = (id: string, value: string) => {
     updateEntries((prev) => prev.map((e) => (e.id === id ? { ...e, value } : e)));
   };
+
+  const rowIssues = new Map<string, string>();
+  const seenKeys = new Set<string>();
+  for (const entry of entries) {
+    const trimmed = entry.key.trim();
+    if (!trimmed) {
+      if (entry.value) rowIssues.set(entry.id, "Key is required — this row will not be sent.");
+      continue;
+    }
+    if (seenKeys.has(trimmed)) {
+      rowIssues.set(
+        entry.id,
+        `Duplicate key "${trimmed}" — only the last row with this key will be sent.`,
+      );
+    } else {
+      seenKeys.add(trimmed);
+    }
+  }
 
   return (
     <div className="mt-2 space-y-2">
       {entries.length > 0 ? (
         <div className="space-y-1.5">
-          {entries.map((entry) => (
-            <div key={entry.id} className="flex items-start gap-1.5">
-              <input
-                className="w-1/3 shrink-0 rounded-[calc(var(--radius)-0.25rem)] border border-input bg-muted/30 px-2 py-1 text-xs"
-                value={entry.key}
-                onChange={(e) => updateKey(entry.id, e.target.value)}
-                placeholder={keyPlaceholder}
-                spellCheck={false}
-              />
-              <div className="min-w-0 flex-1">
-                <VariableInput
-                  value={entry.value}
-                  onChange={(v) => updateValue(entry.id, v)}
-                  nodeId={nodeId}
-                  placeholder={valuePlaceholder}
+          {entries.map((entry) => {
+            const issue = rowIssues.get(entry.id);
+            return (
+              <div key={entry.id} className="flex items-start gap-1.5">
+                <input
+                  className={
+                    issue
+                      ? "w-1/3 shrink-0 rounded-[calc(var(--radius)-0.25rem)] border border-destructive/60 bg-destructive/5 px-2 py-1 text-xs"
+                      : "w-1/3 shrink-0 rounded-[calc(var(--radius)-0.25rem)] border border-input bg-muted/30 px-2 py-1 text-xs"
+                  }
+                  value={entry.key}
+                  onChange={(e) => updateKey(entry.id, e.target.value)}
+                  onBlur={() => commitKey(entry.id)}
+                  placeholder={keyPlaceholder}
+                  aria-label={keyPlaceholder}
+                  aria-invalid={issue ? true : undefined}
+                  title={issue}
+                  spellCheck={false}
                 />
+                <div className="min-w-0 flex-1">
+                  <VariableInput
+                    value={entry.value}
+                    onChange={(v) => updateValue(entry.id, v)}
+                    nodeId={nodeId}
+                    placeholder={valuePlaceholder}
+                  />
+                </div>
+                <button
+                  type="button"
+                  onClick={() => removeEntry(entry.id)}
+                  className="inline-flex h-7 w-7 shrink-0 items-center justify-center rounded border border-destructive/40 bg-destructive/10 text-destructive hover:bg-destructive/20"
+                  aria-label="Remove entry"
+                >
+                  <Trash2 className="h-3.5 w-3.5" />
+                </button>
               </div>
-              <button
-                type="button"
-                onClick={() => removeEntry(entry.id)}
-                className="inline-flex h-7 w-7 shrink-0 items-center justify-center rounded border border-destructive/40 bg-destructive/10 text-destructive hover:bg-destructive/20"
-                aria-label="Remove entry"
-              >
-                <Trash2 className="h-3.5 w-3.5" />
-              </button>
-            </div>
-          ))}
+            );
+          })}
         </div>
       ) : (
         <div className="rounded-[calc(var(--radius)-0.3rem)] border border-dashed border-border/60 bg-muted/20 px-2 py-1.5 text-[11px] text-muted-foreground">

--- a/apps/web/src/features/canvas/components/inspectors/HttpInspector.tsx
+++ b/apps/web/src/features/canvas/components/inspectors/HttpInspector.tsx
@@ -2,6 +2,8 @@ import type { Node } from "@xyflow/react";
 import type { HttpData, NodeDataMap } from "../../types";
 import { useUpdateNodeData } from "../../hooks/useUpdateNodeData";
 import { JsonField } from "../JsonField";
+import { KeyValueVariableEditor } from "../KeyValueVariableEditor";
+import { VariableInput } from "../variable-picker/VariableInput";
 import { CredentialSelector } from "@/components/shared/CredentialSelector";
 import type { CredentialRef } from "@/lib/credentials";
 import {
@@ -90,16 +92,16 @@ export function HttpInspector({ node, updateData, isExpanded }: HttpInspectorPro
       </div>
       <div className="space-y-2">
         <label className="block text-xs text-muted-foreground">URL</label>
-        <input
-          className="w-full rounded-[calc(var(--radius)-0.25rem)] border border-input bg-muted/30 px-2 py-1 text-sm"
+        <VariableInput
           value={node.data.url ?? ""}
-          onChange={(e) =>
+          onChange={(v) =>
             updateHttpData((d) => ({
               ...d,
-              url: e.target.value,
+              url: v,
             }))
           }
           placeholder="https://api.example.com/path"
+          nodeId={node.id}
         />
         {isExpanded && (
           <div className="text-xs text-muted-foreground/70">
@@ -111,10 +113,8 @@ export function HttpInspector({ node, updateData, isExpanded }: HttpInspectorPro
         className="rounded-[calc(var(--radius)-0.25rem)] border border-border/60 bg-muted/20 p-2"
         open={isExpanded}
       >
-        <summary className="cursor-pointer text-xs text-muted-foreground">
-          Headers (JSON object)
-        </summary>
-        <JsonField
+        <summary className="cursor-pointer text-xs text-muted-foreground">Headers</summary>
+        <KeyValueVariableEditor
           value={node.data.headers}
           onChange={(obj) =>
             updateHttpData((d) => ({
@@ -122,6 +122,11 @@ export function HttpInspector({ node, updateData, isExpanded }: HttpInspectorPro
               headers: obj,
             }))
           }
+          nodeId={node.id}
+          keyPlaceholder="Header name"
+          valuePlaceholder="Header value"
+          addLabel="Add header"
+          emptyLabel="No headers defined."
         />
         {isExpanded && (
           <div className="mt-1 text-xs text-muted-foreground/70">
@@ -133,10 +138,8 @@ export function HttpInspector({ node, updateData, isExpanded }: HttpInspectorPro
         className="rounded-[calc(var(--radius)-0.25rem)] border border-border/60 bg-muted/20 p-2"
         open={isExpanded}
       >
-        <summary className="cursor-pointer text-xs text-muted-foreground">
-          Query Params (JSON object)
-        </summary>
-        <JsonField
+        <summary className="cursor-pointer text-xs text-muted-foreground">Query Params</summary>
+        <KeyValueVariableEditor
           value={node.data.query}
           onChange={(obj) =>
             updateHttpData((d) => ({
@@ -144,6 +147,11 @@ export function HttpInspector({ node, updateData, isExpanded }: HttpInspectorPro
               query: obj,
             }))
           }
+          nodeId={node.id}
+          keyPlaceholder="Param name"
+          valuePlaceholder="Param value"
+          addLabel="Add param"
+          emptyLabel="No query params defined."
         />
         {isExpanded && (
           <div className="mt-1 text-xs text-muted-foreground/70">


### PR DESCRIPTION
Wires the variable picker into the HTTP node inspector so users can reference upstream outputs directly in the URL, headers, and query params instead of hand-typing references. Swaps the raw-JSON editors for headers/query with a new `KeyValueVariableEditor` that keeps the existing shape.

Closes #495