### PR TITLE
fix(canvas): preserve user-typed spaces in variable inputs

### DIFF
--- a/apps/web/src/features/canvas/hooks/useVariableInput.ts
+++ b/apps/web/src/features/canvas/hooks/useVariableInput.ts
@@ -13,14 +13,10 @@ export type VariableMatch = {
   end: number;
 };
 
-// Strip zero-width markers and non-breaking spaces. Chrome injects NBSP around
-// contenteditable="false" pill elements as a rendering artifact; users never
-// type these intentionally, so we drop them entirely instead of converting to
-// regular spaces (which would leak leading/trailing whitespace into node data).
-const RAW_TEXT_STRIP_REGEX = /[\u200B\uFEFF\u00A0]/g;
+const ZERO_WIDTH_STRIP_REGEX = /[\u200B\uFEFF]/g;
 
 function normalizeRawText(text: string): string {
-  return text.replace(RAW_TEXT_STRIP_REGEX, "");
+  return text.replace(ZERO_WIDTH_STRIP_REGEX, "").replace(/\u00A0/g, " ");
 }
 
 function isBlockElement(node: Node): node is HTMLElement {
@@ -49,7 +45,7 @@ function blockPrefixLength(child: Node, childIndex: number): number {
 }
 
 function isStrippedChar(ch: string): boolean {
-  return ch === "\u200B" || ch === "\uFEFF" || ch === "\u00A0";
+  return ch === "\u200B" || ch === "\uFEFF";
 }
 
 function rawLengthOfTextPrefix(text: string, endOffset: number): number {


### PR DESCRIPTION
`normalizeRawText` previously stripped NBSP (\u00A0) unconditionally, destroying consecutive spaces since Chrome substitutes NBSP for user-typed spaces that would otherwise collapse in contentEditable. This change converts NBSP to a regular space while still stripping zero-width markers (\u200B, \uFEFF).

Fixes #524 