### PR TITLE
fix: resolve wait node indicator and add live countdown

### DIFF
--- a/apps/web/src/features/canvas/nodes/WaitNode.tsx
+++ b/apps/web/src/features/canvas/nodes/WaitNode.tsx
@@ -1,14 +1,19 @@
 "use client";
 
-import { memo } from "react";
+import { memo, useEffect, useState } from "react";
 import { type Node, type NodeProps } from "@xyflow/react";
 import { Clock } from "lucide-react";
 import { BaseNode } from "./BaseNode";
+import { useNodeExecution } from "../context/ExecutionContext";
 import type { WaitData } from "../types";
 
 export const WaitNode = memo(function WaitNode({ id, data }: NodeProps<Node<WaitData>>) {
   const amount = data.amount ?? 1;
   const unit = data.unit ?? "seconds";
+
+  const execution = useNodeExecution(id);
+  const resumeAt = extractResumeAt(execution?.output);
+  const isWaiting = execution?.status === "waiting" && resumeAt !== null;
 
   return (
     <BaseNode
@@ -19,9 +24,53 @@ export const WaitNode = memo(function WaitNode({ id, data }: NodeProps<Node<Wait
       borderColor="--node-flow-border"
       pinned={data.pinned}
     >
-      <div className="text-xs text-muted-foreground">
-        Wait {amount} {unit}
-      </div>
+      {isWaiting ? (
+        <WaitCountdown resumeAt={resumeAt} />
+      ) : (
+        <div className="text-xs text-muted-foreground">
+          Wait {amount} {unit}
+        </div>
+      )}
     </BaseNode>
   );
 });
+
+function WaitCountdown({ resumeAt }: { resumeAt: number }) {
+  const [now, setNow] = useState(() => Date.now());
+
+  useEffect(() => {
+    const tick = () => setNow(Date.now());
+    tick();
+    const id = window.setInterval(tick, 1000);
+    return () => window.clearInterval(id);
+  }, []);
+
+  const remainingMs = Math.max(0, resumeAt - now);
+  const label = remainingMs === 0 ? "Resuming…" : `Resumes in ${formatRemaining(remainingMs)}`;
+
+  return (
+    <div className="inline-flex items-center gap-1.5 rounded-full border border-yellow-500/40 bg-yellow-500/10 px-2 py-0.5 text-xs font-medium text-yellow-500 tabular-nums">
+      <Clock className="h-3 w-3" />
+      <span>{label}</span>
+    </div>
+  );
+}
+
+function extractResumeAt(output: unknown): number | null {
+  if (!output || typeof output !== "object") return null;
+  const value = (output as Record<string, unknown>).resume_at;
+  return typeof value === "number" && Number.isFinite(value) ? value : null;
+}
+
+function formatRemaining(ms: number): string {
+  const totalSeconds = Math.ceil(ms / 1000);
+  const days = Math.floor(totalSeconds / 86400);
+  const hours = Math.floor((totalSeconds % 86400) / 3600);
+  const minutes = Math.floor((totalSeconds % 3600) / 60);
+  const seconds = totalSeconds % 60;
+
+  if (days > 0) return `${days}d ${hours}h`;
+  if (hours > 0) return `${hours}h ${minutes}m`;
+  if (minutes > 0) return `${minutes}m ${seconds}s`;
+  return `${seconds}s`;
+}

--- a/services/rune-worker/pkg/messaging/resume_consumer.go
+++ b/services/rune-worker/pkg/messaging/resume_consumer.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"time"
 
 	"rune-worker/pkg/core"
 	"rune-worker/pkg/dsl"
@@ -105,6 +106,15 @@ func (c *ResumeConsumer) handleResume(ctx context.Context, payload []byte) error
 		return queue.NonRetryable(fmt.Errorf("wait node %s not found in workflow", msg.CurrentNode))
 	}
 
+	// Publish success status for wait node
+	if err := c.publishWaitSuccessStatus(ctx, msg, &node); err != nil {
+		slog.Error("failed to publish wait success status",
+			"error", err,
+			"workflow_id", msg.WorkflowID,
+			"execution_id", msg.ExecutionID,
+			"node_id", node.ID)
+	}
+
 	// Determine next nodes after the wait node
 	nextNodes := c.determineNextNodes(&msg.WorkflowDefinition, &node)
 
@@ -152,6 +162,38 @@ func (c *ResumeConsumer) handleResume(ctx context.Context, payload []byte) error
 	}
 
 	return nil
+}
+
+// publishWaitSuccessStatus emits a success NodeStatusMessage
+// for the resumed wait node.
+func (c *ResumeConsumer) publishWaitSuccessStatus(ctx context.Context, msg *messages.NodeExecutionMessage, node *core.Node) error {
+	statusMsg := &messages.NodeStatusMessage{
+		WorkflowID:  msg.WorkflowID,
+		ExecutionID: msg.ExecutionID,
+		NodeID:      node.ID,
+		NodeName:    node.Name,
+		Status:      messages.StatusSuccess,
+		ExecutedAt:  time.Now(),
+		DurationMs:  0,
+	}
+
+	if len(msg.LineageStack) > 0 {
+		statusMsg.LineageStack = append(statusMsg.LineageStack, msg.LineageStack...)
+		top := msg.LineageStack[len(msg.LineageStack)-1]
+		statusMsg.BranchID = top.BranchID
+		statusMsg.SplitNodeID = top.SplitNodeID
+		itemIndex := top.ItemIndex
+		totalItems := top.TotalItems
+		statusMsg.ItemIndex = &itemIndex
+		statusMsg.TotalItems = &totalItems
+	}
+
+	payload, err := statusMsg.Encode()
+	if err != nil {
+		return fmt.Errorf("encode wait success status: %w", err)
+	}
+
+	return c.publisher.Publish(ctx, queue.QueueWorkflowNodeStatus, payload)
 }
 
 // determineNextNodes finds nodes connected after the wait node.

--- a/services/rune-worker/pkg/messaging/resume_consumer.go
+++ b/services/rune-worker/pkg/messaging/resume_consumer.go
@@ -14,6 +14,7 @@ import (
 	"rune-worker/pkg/platform/config"
 	"rune-worker/pkg/platform/queue"
 	"rune-worker/pkg/registry"
+	"rune-worker/pkg/resolver"
 
 	"github.com/redis/go-redis/v9"
 )
@@ -164,15 +165,22 @@ func (c *ResumeConsumer) handleResume(ctx context.Context, payload []byte) error
 	return nil
 }
 
-// publishWaitSuccessStatus emits a success NodeStatusMessage
-// for the resumed wait node.
+// publishWaitSuccessStatus emits a success NodeStatusMessage for the resumed
+// wait node. The output (resume_at, timer_id) and resolved parameters are
+// carried forward from the suspend-time snapshot so that persisted execution
+// history retains the original runtime data after the status transitions.
 func (c *ResumeConsumer) publishWaitSuccessStatus(ctx context.Context, msg *messages.NodeExecutionMessage, node *core.Node) error {
+	output := extractWaitOutput(msg.AccumulatedContext, node.Name)
+	params := resolveWaitParameters(node, msg.AccumulatedContext)
+
 	statusMsg := &messages.NodeStatusMessage{
 		WorkflowID:  msg.WorkflowID,
 		ExecutionID: msg.ExecutionID,
 		NodeID:      node.ID,
 		NodeName:    node.Name,
 		Status:      messages.StatusSuccess,
+		Parameters:  params,
+		Output:      output,
 		ExecutedAt:  time.Now(),
 		DurationMs:  0,
 	}
@@ -194,6 +202,37 @@ func (c *ResumeConsumer) publishWaitSuccessStatus(ctx context.Context, msg *mess
 	}
 
 	return c.publisher.Publish(ctx, queue.QueueWorkflowNodeStatus, payload)
+}
+
+// extractWaitOutput returns the wait node's original output
+// ({resume_at, timer_id}) which the wait node stashed in the accumulated
+// context under $<node_name> before suspending.
+func extractWaitOutput(accumulated map[string]any, nodeName string) map[string]any {
+	if accumulated == nil || nodeName == "" {
+		return nil
+	}
+	raw, ok := accumulated["$"+nodeName]
+	if !ok {
+		return nil
+	}
+	output, ok := raw.(map[string]any)
+	if !ok {
+		return nil
+	}
+	return output
+}
+
+// resolveWaitParameters resolves the wait node's parameter references against
+// the accumulated context, matching what was emitted on the waiting status.
+func resolveWaitParameters(node *core.Node, accumulated map[string]any) map[string]any {
+	if len(node.Parameters) == 0 || accumulated == nil {
+		return node.Parameters
+	}
+	resolved, err := resolver.NewResolver(accumulated).ResolveParameters(node.Parameters)
+	if err != nil {
+		return node.Parameters
+	}
+	return resolved
 }
 
 // determineNextNodes finds nodes connected after the wait node.

--- a/services/rune-worker/pkg/messaging/resume_consumer_test.go
+++ b/services/rune-worker/pkg/messaging/resume_consumer_test.go
@@ -86,6 +86,24 @@ func TestResumeConsumerHandleResume_PublishesNextNode(t *testing.T) {
 	if len(nextMsg.LineageStack) != 1 || nextMsg.LineageStack[0].BranchID != "branch-1" {
 		t.Fatalf("expected lineage stack to be preserved")
 	}
+
+	statusMsgs := pub.published["workflow.node.status"]
+	if len(statusMsgs) != 1 {
+		t.Fatalf("expected 1 wait success status message, got %d", len(statusMsgs))
+	}
+	statusMsg, err := messages.DecodeNodeStatusMessage(statusMsgs[0])
+	if err != nil {
+		t.Fatalf("decode status failed: %v", err)
+	}
+	if statusMsg.NodeID != "wait-1" {
+		t.Fatalf("expected wait node id, got %s", statusMsg.NodeID)
+	}
+	if statusMsg.Status != messages.StatusSuccess {
+		t.Fatalf("expected success status, got %s", statusMsg.Status)
+	}
+	if statusMsg.BranchID != "branch-1" {
+		t.Fatalf("expected lineage branch id to be propagated, got %s", statusMsg.BranchID)
+	}
 }
 
 func TestResumeConsumerHandleResume_PublishesCompletionWhenNoNextNode(t *testing.T) {
@@ -116,6 +134,18 @@ func TestResumeConsumerHandleResume_PublishesCompletionWhenNoNextNode(t *testing
 	}
 	if completion.Status != messages.CompletionStatusCompleted {
 		t.Fatalf("expected completed status, got %s", completion.Status)
+	}
+
+	statusMsgs := pub.published["workflow.node.status"]
+	if len(statusMsgs) != 1 {
+		t.Fatalf("expected 1 wait success status message, got %d", len(statusMsgs))
+	}
+	statusMsg, err := messages.DecodeNodeStatusMessage(statusMsgs[0])
+	if err != nil {
+		t.Fatalf("decode status failed: %v", err)
+	}
+	if statusMsg.Status != messages.StatusSuccess || statusMsg.NodeID != "wait-1" {
+		t.Fatalf("expected wait node success status, got status=%s node=%s", statusMsg.Status, statusMsg.NodeID)
 	}
 }
 

--- a/services/rune-worker/pkg/messaging/resume_consumer_test.go
+++ b/services/rune-worker/pkg/messaging/resume_consumer_test.go
@@ -21,14 +21,16 @@ func makeResumeMessage() *messages.NodeExecutionMessage {
 			WorkflowID:  "wf-resume",
 			ExecutionID: "exec-resume",
 			Nodes: []core.Node{
-				{ID: "wait-1", Name: "Wait", Type: "wait", Parameters: map[string]any{}},
+				{ID: "wait-1", Name: "Wait", Type: "wait", Parameters: map[string]any{"amount": 2, "unit": "minutes"}},
 				{ID: "next-1", Name: "Next", Type: "conditional", Parameters: map[string]any{"expression": "true"}},
 			},
 			Edges: []core.Edge{
 				{ID: "edge-1", Src: "wait-1", Dst: "next-1"},
 			},
 		},
-		AccumulatedContext: map[string]any{"$wait": map[string]any{"resume_at": 123}},
+		AccumulatedContext: map[string]any{
+			"$Wait": map[string]any{"resume_at": int64(123), "timer_id": "timer-1"},
+		},
 		LineageStack: []messages.StackFrame{
 			{SplitNodeID: "split-1", BranchID: "branch-1", ItemIndex: 0, TotalItems: 2},
 		},
@@ -103,6 +105,15 @@ func TestResumeConsumerHandleResume_PublishesNextNode(t *testing.T) {
 	}
 	if statusMsg.BranchID != "branch-1" {
 		t.Fatalf("expected lineage branch id to be propagated, got %s", statusMsg.BranchID)
+	}
+	if statusMsg.Output["timer_id"] != "timer-1" {
+		t.Fatalf("expected wait output to be preserved on success status, got %v", statusMsg.Output)
+	}
+	if amount, _ := statusMsg.Parameters["amount"].(float64); amount != 2 {
+		t.Fatalf("expected resolved amount=2, got %v", statusMsg.Parameters["amount"])
+	}
+	if unit, _ := statusMsg.Parameters["unit"].(string); unit != "minutes" {
+		t.Fatalf("expected resolved unit=minutes, got %v", statusMsg.Parameters["unit"])
 	}
 }
 

--- a/services/rune-worker/pkg/nodes/custom/wait/wait_node.go
+++ b/services/rune-worker/pkg/nodes/custom/wait/wait_node.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"time"
 
+	"rune-worker/pkg/core"
 	"rune-worker/pkg/messages"
 	"rune-worker/pkg/nodes"
 	"rune-worker/plugin"
@@ -36,6 +37,18 @@ func (n *WaitNode) Execute(ctx context.Context, execCtx plugin.ExecutionContext)
 	}
 
 	resumeAt := time.Now().Add(convertToDuration(amount, unit)).UTC()
+	timerID := uuid.NewString()
+
+	output := map[string]any{
+		"resume_at": resumeAt.UnixMilli(),
+		"timer_id":  timerID,
+	}
+
+	// Accumulate the wait output into the frozen context under $<node_name>, so
+	// the resume consumer can hydrate the final success status with the same
+	// runtime data that was emitted on the waiting status. Without this, the
+	// persisted execution snapshot would lose resume_at/timer_id after resume.
+	accumulated := accumulateWaitOutput(execCtx.Input, execCtx.Workflow, execCtx.NodeID, output)
 
 	// Freeze current execution message
 	frozen := messages.NodeExecutionMessage{
@@ -45,7 +58,7 @@ func (n *WaitNode) Execute(ctx context.Context, execCtx plugin.ExecutionContext)
 		ExecutionID:        execCtx.ExecutionID,
 		CurrentNode:        execCtx.NodeID,
 		WorkflowDefinition: execCtx.Workflow,
-		AccumulatedContext: execCtx.Input,
+		AccumulatedContext: accumulated,
 		LineageStack:       execCtx.LineageStack,
 		FromNode:           execCtx.FromNode,
 		IsWorkerInitiated:  true,
@@ -56,8 +69,6 @@ func (n *WaitNode) Execute(ctx context.Context, execCtx plugin.ExecutionContext)
 		return nil, fmt.Errorf("encode frozen state: %w", err)
 	}
 
-	timerID := uuid.NewString()
-
 	// Atomic pipeline: store payload and schedule timer
 	pipe := redisClient.TxPipeline()
 	pipe.HSet(ctx, "scheduler:payloads", timerID, payload)
@@ -66,11 +77,21 @@ func (n *WaitNode) Execute(ctx context.Context, execCtx plugin.ExecutionContext)
 		return nil, fmt.Errorf("schedule wait timer: %w", err)
 	}
 
-	// Emit waiting status
-	return map[string]any{
-		"resume_at": resumeAt.UnixMilli(),
-		"timer_id":  timerID,
-	}, nil
+	return output, nil
+}
+
+func accumulateWaitOutput(input map[string]any, workflow core.Workflow, nodeID string, output map[string]any) map[string]any {
+	accumulated := make(map[string]any, len(input)+1)
+	for k, v := range input {
+		accumulated[k] = v
+	}
+
+	node, found := workflow.GetNodeByID(nodeID)
+	if !found || node.Name == "" {
+		return accumulated
+	}
+	accumulated["$"+node.Name] = output
+	return accumulated
 }
 
 func parseInterval(params map[string]any) (int, string, error) {

--- a/services/rune-worker/pkg/nodes/custom/wait/wait_node_test.go
+++ b/services/rune-worker/pkg/nodes/custom/wait/wait_node_test.go
@@ -361,3 +361,48 @@ func TestWaitNode_FrozenStateIncludesContext(t *testing.T) {
 		t.Errorf("Timer score mismatch: got %v, want %v", int64(score), resumeAt)
 	}
 }
+
+func TestAccumulateWaitOutput(t *testing.T) {
+	t.Parallel()
+
+	workflow := core.Workflow{
+		Nodes: []core.Node{
+			{ID: "wait-1", Name: "Wait Node", Type: "wait"},
+		},
+	}
+	input := map[string]any{"$http_node": map[string]any{"status": 200}}
+	output := map[string]any{"resume_at": int64(999), "timer_id": "t-abc"}
+
+	accumulated := accumulateWaitOutput(input, workflow, "wait-1", output)
+
+	if accumulated["$http_node"] == nil {
+		t.Fatalf("expected existing context entries to be preserved")
+	}
+	got, ok := accumulated["$Wait Node"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected $Wait Node key, got %v", accumulated["$Wait Node"])
+	}
+	if got["resume_at"] != int64(999) || got["timer_id"] != "t-abc" {
+		t.Fatalf("expected output to be accumulated under $<node_name>, got %v", got)
+	}
+
+	// Input map must not be mutated.
+	if _, exists := input["$Wait Node"]; exists {
+		t.Fatalf("expected input map to remain unmutated")
+	}
+}
+
+func TestAccumulateWaitOutput_UnknownNode(t *testing.T) {
+	t.Parallel()
+
+	accumulated := accumulateWaitOutput(
+		map[string]any{"foo": "bar"},
+		core.Workflow{},
+		"missing",
+		map[string]any{"resume_at": int64(1)},
+	)
+
+	if len(accumulated) != 1 || accumulated["foo"] != "bar" {
+		t.Fatalf("expected only existing context when node lookup fails, got %v", accumulated)
+	}
+}


### PR DESCRIPTION
Fixes #535 by publishing a success NodeStatusMessage for the wait node when its timer resumes, so the yellow waiting indicator transitions to the green completed one instead of sticking forever. While we're at it, the wait node now shows a live "Resumes in ..." countdown pill, giving users real feedback during long waits.