### PR TITLE
fix(api): reject trigger-only workflow runs

### DIFF
--- a/services/api/src/workflow/queue.py
+++ b/services/api/src/workflow/queue.py
@@ -4,6 +4,35 @@ from src.queue.base import BaseQueuePublisher
 from src.workflow.schemas import NodeExecutionMessage
 
 
+NO_ACTION_NODES_MESSAGE = "This workflow has no action nodes."
+
+
+def get_first_executable_node_ids(workflow_data: dict) -> list[str]:
+    """Validate a workflow can start and return nodes after the trigger."""
+    nodes = workflow_data.get("nodes", [])
+    edges = workflow_data.get("edges", [])
+
+    if not nodes:
+        raise ValueError("Workflow has no nodes to execute")
+
+    trigger_nodes = [node for node in nodes if node.get("trigger", False)]
+
+    if len(trigger_nodes) != 1:
+        raise ValueError("Workflow must have exactly one trigger node")
+
+    trigger_node_id = trigger_nodes[0].get("id")
+    first_nodes = [
+        edge.get("dst")
+        for edge in edges
+        if edge.get("src") == trigger_node_id and edge.get("dst")
+    ]
+
+    if not first_nodes:
+        raise ValueError(NO_ACTION_NODES_MESSAGE)
+
+    return first_nodes
+
+
 class WorkflowQueueService(BaseQueuePublisher):
     """Service for publishing workflow execution messages to RabbitMQ."""
 
@@ -42,33 +71,7 @@ class WorkflowQueueService(BaseQueuePublisher):
         Raises:
             ValueError: If workflow has invalid structure
         """
-        # Find trigger nodes and the first executable nodes
-        nodes = workflow_data.get("nodes", [])
-        edges = workflow_data.get("edges", [])
-
-        if not nodes:
-            raise ValueError("Workflow has no nodes to execute")
-
-        # Validate trigger nodes - must have exactly one
-        trigger_nodes = [node for node in nodes if node.get("trigger", False)]
-
-        if len(trigger_nodes) != 1:
-            raise ValueError("Workflow must have exactly one trigger node")
-
-        # Get the single trigger node
-        trigger_node = trigger_nodes[0]
-        trigger_node_id = trigger_node.get("id")
-
-        # Find the executable nodes the trigger points to
-        first_nodes = []
-
-        for edge in edges:
-            if edge.get("src") == trigger_node_id:
-                dst_node_id = edge.get("dst")
-                first_nodes.append(dst_node_id)
-
-        if not first_nodes:
-            return None
+        first_nodes = get_first_executable_node_ids(workflow_data)
 
         # For now, use the first one (in the future, might send multiple messages)
         first_node = first_nodes[0]

--- a/services/api/src/workflow/queue.py
+++ b/services/api/src/workflow/queue.py
@@ -21,6 +21,9 @@ def get_first_executable_node_ids(workflow_data: dict) -> list[str]:
         raise ValueError("Workflow must have exactly one trigger node")
 
     trigger_node_id = trigger_nodes[0].get("id")
+    if not trigger_node_id:
+        raise ValueError("Trigger node must have an id")
+
     first_nodes = [
         edge.get("dst")
         for edge in edges
@@ -31,6 +34,11 @@ def get_first_executable_node_ids(workflow_data: dict) -> list[str]:
         raise ValueError(NO_ACTION_NODES_MESSAGE)
 
     return first_nodes
+
+
+def validate_workflow_can_run(workflow_data: dict) -> None:
+    """Raise ValueError if a workflow cannot be queued for execution."""
+    get_first_executable_node_ids(workflow_data)
 
 
 class WorkflowQueueService(BaseQueuePublisher):

--- a/services/api/src/workflow/service.py
+++ b/services/api/src/workflow/service.py
@@ -32,7 +32,7 @@ from src.workflow.constants import (
     SCHEDULED_TRIGGER_PARAM_UNIT,
     SCHEDULED_TRIGGER_UNIT_MULTIPLIERS,
 )
-from src.workflow.queue import get_first_executable_node_ids
+from src.workflow.queue import validate_workflow_can_run
 
 
 class WorkflowVersionConflictError(Exception):
@@ -540,7 +540,7 @@ class WorkflowService:
             version.workflow_data
         )
 
-        get_first_executable_node_ids(resolved_workflow_data)
+        validate_workflow_can_run(resolved_workflow_data)
 
         # Generate a unique execution ID
         execution_id = str(uuid.uuid4())

--- a/services/api/src/workflow/service.py
+++ b/services/api/src/workflow/service.py
@@ -32,6 +32,7 @@ from src.workflow.constants import (
     SCHEDULED_TRIGGER_PARAM_UNIT,
     SCHEDULED_TRIGGER_UNIT_MULTIPLIERS,
 )
+from src.workflow.queue import get_first_executable_node_ids
 
 
 class WorkflowVersionConflictError(Exception):
@@ -538,6 +539,8 @@ class WorkflowService:
         resolved_workflow_data = await self.resolve_workflow_credentials(
             version.workflow_data
         )
+
+        get_first_executable_node_ids(resolved_workflow_data)
 
         # Generate a unique execution ID
         execution_id = str(uuid.uuid4())

--- a/services/api/test/workflow/test_workflow_api.py
+++ b/services/api/test/workflow/test_workflow_api.py
@@ -5,7 +5,8 @@ import json
 import pytest
 from sqlmodel import select
 
-from src.db.models import Workflow, WorkflowVersion
+from src.db.models import Execution, Workflow, WorkflowVersion
+from src.workflow.queue import NO_ACTION_NODES_MESSAGE
 
 
 class TestWorkflowShellAPI:
@@ -279,6 +280,39 @@ class TestWorkflowRunAPI:
 
         response = await authenticated_client.post(f"/workflows/{workflow_id}/run")
         assert response.status_code == 400
+
+    @pytest.mark.asyncio
+    async def test_run_trigger_only_workflow_returns_400_without_execution(
+        self, authenticated_client, workflow_service, test_db, test_user
+    ):
+        workflow = await workflow_service.create(
+            user_id=test_user.id,
+            name="Trigger Only",
+            description="",
+        )
+        version = await workflow_service.create_version(
+            workflow=workflow,
+            user_id=test_user.id,
+            workflow_data={
+                "nodes": [{"id": "trigger", "type": "trigger", "trigger": True}],
+                "edges": [],
+            },
+            base_version_id=None,
+            message="Initial trigger-only version",
+        )
+        await workflow_service.publish_version(workflow, version.id)
+
+        response = await authenticated_client.post(f"/workflows/{workflow.id}/run")
+
+        assert response.status_code == 400
+        assert response.json()["message"] == NO_ACTION_NODES_MESSAGE
+
+        executions = (
+            await test_db.exec(
+                select(Execution).where(Execution.workflow_id == workflow.id)
+            )
+        ).all()
+        assert executions == []
 
 
 class TestWorkflowStatusAPI:

--- a/services/api/test/workflow/test_workflow_queue.py
+++ b/services/api/test/workflow/test_workflow_queue.py
@@ -1,5 +1,7 @@
 """Unit tests for workflow queue start-node validation."""
 
+import re
+
 import pytest
 
 from src.workflow.queue import (
@@ -9,7 +11,7 @@ from src.workflow.queue import (
 
 
 def test_trigger_only_workflow_is_rejected():
-    with pytest.raises(ValueError, match=NO_ACTION_NODES_MESSAGE):
+    with pytest.raises(ValueError, match=re.escape(NO_ACTION_NODES_MESSAGE)):
         get_first_executable_node_ids(
             {
                 "nodes": [{"id": "trigger", "type": "trigger", "trigger": True}],

--- a/services/api/test/workflow/test_workflow_queue.py
+++ b/services/api/test/workflow/test_workflow_queue.py
@@ -1,4 +1,5 @@
 """Unit tests for workflow queue start-node validation."""
+
 import pytest
 
 from src.workflow.queue import (

--- a/services/api/test/workflow/test_workflow_queue.py
+++ b/services/api/test/workflow/test_workflow_queue.py
@@ -1,0 +1,35 @@
+"""Unit tests for workflow queue start-node validation."""
+import pytest
+
+from src.workflow.queue import (
+    NO_ACTION_NODES_MESSAGE,
+    get_first_executable_node_ids,
+)
+
+
+def test_trigger_only_workflow_is_rejected():
+    with pytest.raises(ValueError, match=NO_ACTION_NODES_MESSAGE):
+        get_first_executable_node_ids(
+            {
+                "nodes": [{"id": "trigger", "type": "trigger", "trigger": True}],
+                "edges": [],
+            }
+        )
+
+
+def test_first_executable_nodes_follow_trigger_edges():
+    first_nodes = get_first_executable_node_ids(
+        {
+            "nodes": [
+                {"id": "trigger", "type": "trigger", "trigger": True},
+                {"id": "action-1", "type": "action", "trigger": False},
+                {"id": "action-2", "type": "action", "trigger": False},
+            ],
+            "edges": [
+                {"id": "edge-1", "src": "trigger", "dst": "action-1"},
+                {"id": "edge-2", "src": "trigger", "dst": "action-2"},
+            ],
+        }
+    )
+
+    assert first_nodes == ["action-1", "action-2"]


### PR DESCRIPTION
Prevents trigger-only workflows from creating pending executions that never reach the worker. Adds shared start-node validation before execution rows are created, keeps queue publishing from silently no-oping.

Fixes #501 