### PR TITLE
fix: improve variable picker array handling

### DIFF
--- a/apps/web/src/features/canvas/components/inspectors/SplitInspector.tsx
+++ b/apps/web/src/features/canvas/components/inspectors/SplitInspector.tsx
@@ -2,6 +2,7 @@ import type { Node } from "@xyflow/react";
 import type { SplitData } from "../../types";
 import { useUpdateNodeData } from "../../hooks/useUpdateNodeData";
 import { VariableInput } from "../variable-picker/VariableInput";
+import { toArraySelection } from "../../utils/listFieldPaths";
 
 type SplitInspectorProps = {
   node: Node<SplitData>;
@@ -22,6 +23,7 @@ export function SplitInspector({ node, updateData, isExpanded }: SplitInspectorP
         onChange={(v) => updateSplitData((d) => ({ ...d, array_field: v }))}
         placeholder="$json.items"
         nodeId={node.id}
+        transformSelectedPath={toArraySelection}
       />
       <div className="text-xs text-muted-foreground">Path to the array field to iterate over.</div>
       {isExpanded && (

--- a/apps/web/src/features/canvas/components/variable-picker/VariableTreeView.tsx
+++ b/apps/web/src/features/canvas/components/variable-picker/VariableTreeView.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { memo, useState, useCallback } from "react";
-import { ChevronRight, ChevronDown, Copy } from "lucide-react";
+import { ChevronRight, ChevronDown, Copy, Hash } from "lucide-react";
 import { cn } from "@/lib/cn";
 import { toast } from "@/components/ui/toast";
 import type { VariableTreeNode } from "../../lib/variableSchema";
@@ -42,6 +42,89 @@ function formatSampleValue(value: unknown): string {
   return String(value);
 }
 
+function cloneNodeForArrayIndex(
+  templateNode: VariableTreeNode,
+  arrayPath: string,
+  index: number,
+): VariableTreeNode {
+  const oldPrefix = templateNode.path;
+  const newPrefix = `${arrayPath}[${index}]`;
+  const rewrite = (node: VariableTreeNode): VariableTreeNode => ({
+    ...node,
+    key: node === templateNode ? `[${index}]` : node.key,
+    path: node.path.startsWith(oldPrefix)
+      ? `${newPrefix}${node.path.slice(oldPrefix.length)}`
+      : node.path,
+    children: node.children?.map(rewrite),
+  });
+
+  return rewrite(templateNode);
+}
+
+function findIndexTemplateNode(node: VariableTreeNode): VariableTreeNode | undefined {
+  return node.children?.find((child) => /^\[\d+\]$/.test(child.key));
+}
+
+function ArrayIndexLookup({
+  node,
+  onSelect,
+  depth,
+}: {
+  node: VariableTreeNode;
+  onSelect: (path: string) => void;
+  depth: number;
+}) {
+  const [indexValue, setIndexValue] = useState("");
+  const parsedIndex = Number.parseInt(indexValue, 10);
+  const isValid =
+    Number.isInteger(parsedIndex) &&
+    parsedIndex >= 0 &&
+    (node.arrayLength === undefined || parsedIndex < node.arrayLength);
+  const templateNode = findIndexTemplateNode(node);
+  const indexedNode =
+    isValid && templateNode ? cloneNodeForArrayIndex(templateNode, node.path, parsedIndex) : null;
+
+  const handleSubmit = useCallback(
+    (e: React.FormEvent) => {
+      e.preventDefault();
+      if (!isValid) return;
+      onSelect(`${node.path}[${parsedIndex}]`);
+    },
+    [isValid, node.path, onSelect, parsedIndex],
+  );
+
+  return (
+    <div>
+      <form
+        className="flex items-center gap-1.5 px-1.5 py-1 text-xs"
+        style={{ paddingLeft: `${depth * 12 + 4}px` }}
+        onSubmit={handleSubmit}
+      >
+        <Hash className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+        <span className="shrink-0 text-muted-foreground">Index</span>
+        <input
+          type="number"
+          min={0}
+          max={node.arrayLength !== undefined ? Math.max(0, node.arrayLength - 1) : undefined}
+          value={indexValue}
+          onChange={(e) => setIndexValue(e.target.value)}
+          placeholder={node.arrayLength !== undefined ? `0-${node.arrayLength - 1}` : "0"}
+          className="h-6 min-w-0 flex-1 rounded border border-border/60 bg-muted/30 px-1.5 text-xs outline-none focus:border-ring"
+          onClick={(e) => e.stopPropagation()}
+        />
+        <button
+          type="submit"
+          disabled={!isValid}
+          className="h-6 shrink-0 rounded border border-border/60 px-2 text-[10px] font-medium text-muted-foreground hover:bg-muted/50 disabled:cursor-not-allowed disabled:opacity-40"
+        >
+          Use
+        </button>
+      </form>
+      {indexedNode && <VariableTreeView nodes={[indexedNode]} onSelect={onSelect} depth={depth} />}
+    </div>
+  );
+}
+
 function TreeRow({
   node,
   onSelect,
@@ -53,6 +136,11 @@ function TreeRow({
 }) {
   const [isOpen, setIsOpen] = useState(false);
   const hasChildren = node.children && node.children.length > 0;
+  const hiddenArrayItems =
+    node.type === "array" &&
+    node.arrayLength !== undefined &&
+    node.children !== undefined &&
+    node.arrayLength > node.children.length;
 
   const handleSelect = useCallback(() => {
     onSelect(node.path);
@@ -128,6 +216,12 @@ function TreeRow({
         {/* Type badge */}
         <TypeBadge type={node.type} />
 
+        {node.type === "array" && node.arrayLength !== undefined && (
+          <span className="shrink-0 text-[10px] text-muted-foreground/70">
+            {node.arrayLength} items
+          </span>
+        )}
+
         {/* Sample value preview */}
         {node.sampleValue !== undefined && (
           <span className="truncate text-[10px] text-muted-foreground/70">
@@ -147,7 +241,12 @@ function TreeRow({
 
       {/* Children */}
       {hasChildren && isOpen && (
-        <VariableTreeView nodes={node.children!} onSelect={onSelect} depth={depth + 1} />
+        <>
+          <VariableTreeView nodes={node.children!} onSelect={onSelect} depth={depth + 1} />
+          {hiddenArrayItems && (
+            <ArrayIndexLookup node={node} onSelect={onSelect} depth={depth + 1} />
+          )}
+        </>
       )}
     </div>
   );

--- a/apps/web/src/features/canvas/hooks/useVariableInput.test.ts
+++ b/apps/web/src/features/canvas/hooks/useVariableInput.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+import { parseVariableReferences } from "./useVariableInput";
+
+describe("parseVariableReferences", () => {
+  it("parses root array item references", () => {
+    expect(parseVariableReferences("$json[12].title")).toEqual([
+      {
+        full: "$json[12].title",
+        nodeName: "json",
+        fieldPath: "[12].title",
+        start: 0,
+        end: 15,
+      },
+    ]);
+  });
+
+  it("continues to parse dotted node output references", () => {
+    expect(parseVariableReferences("$FetchPosts.body.posts[1].title")).toEqual([
+      {
+        full: "$FetchPosts.body.posts[1].title",
+        nodeName: "FetchPosts",
+        fieldPath: "body.posts[1].title",
+        start: 0,
+        end: 31,
+      },
+    ]);
+  });
+});

--- a/apps/web/src/features/canvas/hooks/useVariableInput.ts
+++ b/apps/web/src/features/canvas/hooks/useVariableInput.ts
@@ -2,8 +2,9 @@
 
 import { useState, useCallback, useRef, useMemo } from "react";
 
-/** Regex matching Go resolver's $ notation: $nodeName or $nodeName.field.path */
-const VARIABLE_REGEX = /\$([a-zA-Z_][a-zA-Z0-9_-]*)(?:\.([a-zA-Z0-9_\[\]\.\-$]+))?/g;
+/** Regex matching Go resolver's $ notation: $nodeName, $nodeName.field, or $json[0].field. */
+const VARIABLE_REGEX =
+  /\$([a-zA-Z_][a-zA-Z0-9_-]*)((?:\.[a-zA-Z0-9_\[\]\.\-$]+|\[\d+\][a-zA-Z0-9_\[\]\.\-$]*)?)/g;
 
 export type VariableMatch = {
   full: string;
@@ -372,10 +373,13 @@ export function parseVariableReferences(value: string): VariableMatch[] {
   while ((match = VARIABLE_REGEX.exec(value)) !== null) {
     // Skip escaped: \$ means literal $, don't treat as variable
     if (match.index > 0 && value[match.index - 1] === "\\") continue;
+    const rawFieldPath = match[2] || undefined;
+    const fieldPath = rawFieldPath?.startsWith(".") ? rawFieldPath.slice(1) : rawFieldPath;
+
     matches.push({
       full: match[0],
       nodeName: match[1],
-      fieldPath: match[2],
+      fieldPath,
       start: match.index,
       end: match.index + match[0].length,
     });

--- a/apps/web/src/features/canvas/hooks/useVariableTree.ts
+++ b/apps/web/src/features/canvas/hooks/useVariableTree.ts
@@ -10,7 +10,30 @@ import {
   type VariableSource,
   type VariableTreeNode,
 } from "../lib/variableSchema";
-import type { NodeKind } from "../types";
+import type { CanvasNode, NodeKind } from "../types";
+
+const WORKING_JSON_KINDS = new Set<NodeKind>(["edit", "filter", "sort", "limit"]);
+
+function variableTypeForValue(value: unknown): VariableTreeNode["type"] {
+  if (value === null || value === undefined) return "unknown";
+  if (Array.isArray(value)) return "array";
+  switch (typeof value) {
+    case "string":
+      return "string";
+    case "number":
+      return "number";
+    case "boolean":
+      return "boolean";
+    case "object":
+      return "object";
+    default:
+      return "unknown";
+  }
+}
+
+function arrayLengthForValue(value: unknown): number | undefined {
+  return Array.isArray(value) ? value.length : undefined;
+}
 
 /**
  * Merges execution data tree nodes into schema tree nodes.
@@ -55,6 +78,77 @@ function mergeTreeNodes(
   return merged;
 }
 
+function prefixTreePaths(nodes: VariableTreeNode[], rootPath: string): VariableTreeNode[] {
+  return nodes.map((node) => ({
+    ...node,
+    path: node.path.startsWith("$") ? node.path : `${rootPath}.${node.path}`,
+    children: node.children ? prefixTreePaths(node.children, rootPath) : undefined,
+  }));
+}
+
+function itemTreeFromItems(items: unknown[], parentPath: string): VariableTreeNode[] {
+  let merged: VariableTreeNode[] = [];
+  for (const item of items) {
+    const itemChildren = jsonToVariableTree(item, parentPath);
+    merged = mergeTreeNodes(merged, itemChildren);
+  }
+  return merged;
+}
+
+function buildSplitItemNode(items: unknown[] | undefined): VariableTreeNode {
+  const firstItem = items?.[0];
+  return {
+    key: "$item",
+    path: "$item",
+    type: variableTypeForValue(firstItem),
+    arrayLength: arrayLengthForValue(firstItem),
+    source: items && items.length > 0 ? "execution" : "schema",
+    children: items && items.length > 0 ? itemTreeFromItems(items, "$item") : undefined,
+  };
+}
+
+function splitItemsFromExecution(output: unknown): unknown[] | undefined {
+  if (!output || typeof output !== "object") return undefined;
+  const items = (output as Record<string, unknown>)["_split_items"];
+  return Array.isArray(items) ? items : undefined;
+}
+
+function createWorkingJsonSource(
+  upstreamNodes: CanvasNode[],
+  executionCtx: ReturnType<typeof useExecutionOptional>,
+): VariableSource | null {
+  if (!executionCtx) return null;
+
+  for (const upstreamNode of upstreamNodes) {
+    const kind = upstreamNode.type as NodeKind;
+    if (!WORKING_JSON_KINDS.has(kind)) continue;
+
+    const execData = executionCtx.getNodeExecution(upstreamNode.id);
+    const output = execData?.output;
+    if (!output || typeof output !== "object" || !("$json" in output)) continue;
+
+    const jsonValue = (output as Record<string, unknown>)["$json"];
+    return {
+      nodeId: `${upstreamNode.id}:$json`,
+      nodeLabel: "$json",
+      nodeKind: kind,
+      rootPath: "$json",
+      children: [
+        {
+          key: "$json",
+          path: "$json",
+          type: variableTypeForValue(jsonValue),
+          arrayLength: arrayLengthForValue(jsonValue),
+          source: "execution",
+          children: jsonToVariableTree(jsonValue, "$json"),
+        },
+      ],
+    };
+  }
+
+  return null;
+}
+
 /**
  * Hook to build a variable tree for a given node.
  * Returns VariableSource[] representing all upstream nodes' outputs.
@@ -86,7 +180,7 @@ export function useVariableTree(nodeId: string): VariableSource[] {
 
     const PASS_THROUGH_KINDS = new Set<NodeKind>(["if", "switch", "wait"]);
 
-    return upstreamNodes.map((upstreamNode) => {
+    const sources = upstreamNodes.map((upstreamNode) => {
       const kind = upstreamNode.type as NodeKind;
       const label = (upstreamNode.data as { label?: string }).label ?? kind;
       const rootPath = `$${label}`;
@@ -96,10 +190,7 @@ export function useVariableTree(nodeId: string): VariableSource[] {
         upstreamNode.data as Record<string, unknown>,
       );
 
-      const prefixedSchema = staticSchema.map((node) => ({
-        ...node,
-        path: node.path.startsWith("$") ? node.path : `${rootPath}.${node.path}`,
-      }));
+      const prefixedSchema = prefixTreePaths(staticSchema, rootPath);
 
       // Check for execution data
       let executionTree: VariableTreeNode[] = [];
@@ -115,6 +206,12 @@ export function useVariableTree(nodeId: string): VariableSource[] {
       let children: VariableTreeNode[];
       if (PASS_THROUGH_KINDS.has(kind)) {
         children = executionTree.length > 0 ? executionTree : prefixedSchema;
+      } else if (kind === "split") {
+        const splitItems = splitItemsFromExecution(
+          executionCtx?.getNodeExecution(upstreamNode.id)?.output,
+        );
+        const itemNode = buildSplitItemNode(splitItems);
+        children = mergeTreeNodes([itemNode], executionTree);
       } else {
         children = mergeTreeNodes(prefixedSchema, executionTree);
       }
@@ -127,6 +224,9 @@ export function useVariableTree(nodeId: string): VariableSource[] {
         children,
       };
     });
+
+    const workingJsonSource = createWorkingJsonSource(upstreamNodes, executionCtx);
+    return workingJsonSource ? [workingJsonSource, ...sources] : sources;
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [nodeId, nodeIdentities, edgePairs, executionCtx?.state.nodes]);
 }

--- a/apps/web/src/features/canvas/lib/variableSchema.test.ts
+++ b/apps/web/src/features/canvas/lib/variableSchema.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vitest";
+import { jsonToVariableTree } from "./variableSchema";
+
+describe("jsonToVariableTree", () => {
+  it("exposes concrete array items for small arrays", () => {
+    const tree = jsonToVariableTree(
+      {
+        posts: [
+          { id: 1, title: "First" },
+          { id: 2, title: "Second" },
+          { id: 3, title: "Third" },
+        ],
+      },
+      "$FetchPosts",
+    );
+
+    const posts = tree.find((node) => node.key === "posts");
+    expect(posts?.type).toBe("array");
+    expect(posts?.arrayLength).toBe(3);
+    expect(posts?.children?.map((child) => child.path)).toEqual([
+      "$FetchPosts.posts[0]",
+      "$FetchPosts.posts[1]",
+      "$FetchPosts.posts[2]",
+    ]);
+    expect(posts?.children?.[1].children?.map((child) => child.path)).toContain(
+      "$FetchPosts.posts[1].title",
+    );
+  });
+
+  it("caps large arrays and preserves the real length for indexed lookup", () => {
+    const posts = Array.from({ length: 60 }, (_, index) => ({
+      id: index + 1,
+      title: `Post ${index + 1}`,
+    }));
+
+    const tree = jsonToVariableTree({ posts }, "$FetchPosts");
+    const postsNode = tree.find((node) => node.key === "posts");
+
+    expect(postsNode?.arrayLength).toBe(60);
+    expect(postsNode?.children).toHaveLength(10);
+    expect(postsNode?.children?.at(-1)?.path).toBe("$FetchPosts.posts[9]");
+  });
+
+  it("does not invent an invalid [0] entry for empty arrays", () => {
+    const tree = jsonToVariableTree({ posts: [] }, "$FetchPosts");
+    const posts = tree.find((node) => node.key === "posts");
+
+    expect(posts?.type).toBe("array");
+    expect(posts?.children).toEqual([]);
+  });
+});

--- a/apps/web/src/features/canvas/lib/variableSchema.ts
+++ b/apps/web/src/features/canvas/lib/variableSchema.ts
@@ -5,6 +5,7 @@ export type VariableTreeNode = {
   path: string;
   type: "string" | "number" | "boolean" | "object" | "array" | "unknown";
   sampleValue?: unknown;
+  arrayLength?: number;
   children?: VariableTreeNode[];
   source: "schema" | "execution";
 };
@@ -18,6 +19,7 @@ export type VariableSource = {
 };
 
 const MAX_KEYS = 50;
+const MAX_ARRAY_PREVIEW_ITEMS = 10;
 
 function inferType(value: unknown): VariableTreeNode["type"] {
   if (value === null || value === undefined) return "unknown";
@@ -38,7 +40,7 @@ function inferType(value: unknown): VariableTreeNode["type"] {
 
 /**
  * Walks arbitrary JSON into a tree of VariableTreeNodes.
- * Arrays: inspects [0] for element structure.
+ * Arrays: exposes a small concrete preview and stores length for indexed lookup in the picker.
  * Objects: caps at MAX_KEYS keys.
  * Primitives: leaf nodes with type/sample value.
  */
@@ -52,31 +54,26 @@ export function jsonToVariableTree(
   if (data === null || data === undefined) return [];
 
   if (Array.isArray(data)) {
-    const firstItem = data[0];
-    if (firstItem === undefined) {
-      return [
-        {
-          key: "[0]",
-          path: `${parentPath}[0]`,
-          type: "unknown",
-          source: "execution",
-        },
-      ];
-    }
-    // Inspect the first element to infer array element structure
-    const elementType = inferType(firstItem);
-    if (elementType === "object" && typeof firstItem === "object" && firstItem !== null) {
-      return jsonToVariableTree(firstItem, `${parentPath}[0]`, maxDepth, currentDepth + 1);
-    }
-    return [
-      {
-        key: "[0]",
-        path: `${parentPath}[0]`,
-        type: elementType,
-        sampleValue: firstItem,
+    return data.slice(0, MAX_ARRAY_PREVIEW_ITEMS).map((item, index) => {
+      const itemPath = `${parentPath}[${index}]`;
+      const itemType = inferType(item);
+      const node: VariableTreeNode = {
+        key: `[${index}]`,
+        path: itemPath,
+        type: itemType,
+        arrayLength: Array.isArray(item) ? item.length : undefined,
         source: "execution",
-      },
-    ];
+      };
+
+      if ((itemType === "object" || itemType === "array") && item !== null) {
+        const children = jsonToVariableTree(item, itemPath, maxDepth, currentDepth + 1);
+        if (children.length > 0) node.children = children;
+      } else {
+        node.sampleValue = item;
+      }
+
+      return node;
+    });
   }
 
   if (typeof data === "object") {
@@ -92,6 +89,7 @@ export function jsonToVariableTree(
           key,
           path: fullPath,
           type: valueType,
+          arrayLength: Array.isArray(value) ? value.length : undefined,
           source: "execution" as const,
           children: jsonToVariableTree(value, fullPath, maxDepth, currentDepth + 1),
         };

--- a/services/rune-worker/pkg/nodes/custom/sort/sort_node_test.go
+++ b/services/rune-worker/pkg/nodes/custom/sort/sort_node_test.go
@@ -87,6 +87,28 @@ func TestSortNodeScenarios(t *testing.T) {
 			},
 			wantIDs: []string{"3", "2", "1"},
 		},
+		{
+			name: "discovers single incoming http array when input array is blank",
+			parameters: map[string]any{
+				"rules": []any{map[string]any{"field": "$item.id", "direction": "desc", "type": "auto"}},
+			},
+			input: map[string]any{
+				"$HTTP": map[string]any{
+					"status": 200,
+					"body": map[string]any{
+						"posts": []any{
+							map[string]any{"id": "1"},
+							map[string]any{"id": "3"},
+							map[string]any{"id": "2"},
+						},
+						"total": 60,
+						"skip":  0,
+						"limit": 60,
+					},
+				},
+			},
+			wantIDs: []string{"3", "2", "1"},
+		},
 	}
 
 	for _, tt := range tests {

--- a/services/rune-worker/pkg/nodes/shared/listops/listops.go
+++ b/services/rune-worker/pkg/nodes/shared/listops/listops.go
@@ -7,6 +7,7 @@ package listops
 import (
 	"fmt"
 	"reflect"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -20,7 +21,11 @@ import (
 // - nil, which falls back to $json
 func ResolveArrayInput(input map[string]any, raw any) ([]any, error) {
 	if raw == nil {
-		raw = input["$json"]
+		if workingJSON, ok := input["$json"]; ok {
+			raw = workingJSON
+		} else if discovered, ok := discoverSingleArrayInput(input); ok {
+			raw = discovered
+		}
 	}
 
 	resolved, err := resolveValue(input, raw)
@@ -34,6 +39,69 @@ func ResolveArrayInput(input map[string]any, raw any) ([]any, error) {
 	}
 
 	return items, nil
+}
+
+func discoverSingleArrayInput(input map[string]any) (any, bool) {
+	candidates := make([]any, 0, 1)
+
+	keys := make([]string, 0, len(input))
+	for key := range input {
+		if strings.HasPrefix(key, "_") {
+			continue
+		}
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+
+	for _, key := range keys {
+		collectArrayCandidates(input[key], &candidates)
+		if len(candidates) > 1 {
+			return nil, false
+		}
+	}
+
+	if len(candidates) != 1 {
+		return nil, false
+	}
+	return candidates[0], true
+}
+
+func collectArrayCandidates(value any, candidates *[]any) {
+	if value == nil || len(*candidates) > 1 {
+		return
+	}
+
+	if _, ok := ToAnySlice(value); ok {
+		*candidates = append(*candidates, value)
+		return
+	}
+
+	rv := reflect.ValueOf(value)
+	if rv.Kind() == reflect.Pointer || rv.Kind() == reflect.Interface {
+		if rv.IsNil() {
+			return
+		}
+		rv = rv.Elem()
+	}
+
+	if rv.Kind() != reflect.Map {
+		return
+	}
+	if rv.IsNil() {
+		return
+	}
+
+	mapKeys := rv.MapKeys()
+	sort.Slice(mapKeys, func(i, j int) bool {
+		return fmt.Sprint(mapKeys[i].Interface()) < fmt.Sprint(mapKeys[j].Interface())
+	})
+
+	for _, key := range mapKeys {
+		collectArrayCandidates(rv.MapIndex(key).Interface(), candidates)
+		if len(*candidates) > 1 {
+			return
+		}
+	}
 }
 
 func resolveValue(input map[string]any, raw any) (any, error) {

--- a/services/rune-worker/pkg/resolver/reference_path.go
+++ b/services/rune-worker/pkg/resolver/reference_path.go
@@ -24,8 +24,16 @@ func ResolveReferenceValue(
 		return nil, "", fmt.Errorf("invalid reference: missing root key")
 	}
 
-	parts := strings.SplitN(path, ".", 2)
-	rootName := parts[0]
+	separatorIndex := strings.IndexAny(path, ".[")
+	rootName := path
+	remainingPath := ""
+	if separatorIndex >= 0 {
+		rootName = path[:separatorIndex]
+		remainingPath = path[separatorIndex:]
+		if strings.HasPrefix(remainingPath, ".") {
+			remainingPath = strings.TrimPrefix(remainingPath, ".")
+		}
+	}
 	if rootName == "" {
 		return nil, "", fmt.Errorf("invalid reference: missing root key")
 	}
@@ -41,11 +49,11 @@ func ResolveReferenceValue(
 		return nil, rootKey, fmt.Errorf("node '%s' not found in context", rootName)
 	}
 
-	if len(parts) == 1 {
+	if remainingPath == "" {
 		return nodeData, rootKey, nil
 	}
 
-	value, err := NavigateValuePath(nodeData, parts[1])
+	value, err := NavigateValuePath(nodeData, remainingPath)
 	if err != nil {
 		return nil, rootKey, err
 	}

--- a/services/rune-worker/pkg/resolver/reference_path.go
+++ b/services/rune-worker/pkg/resolver/reference_path.go
@@ -30,9 +30,7 @@ func ResolveReferenceValue(
 	if separatorIndex >= 0 {
 		rootName = path[:separatorIndex]
 		remainingPath = path[separatorIndex:]
-		if strings.HasPrefix(remainingPath, ".") {
-			remainingPath = strings.TrimPrefix(remainingPath, ".")
-		}
+		remainingPath = strings.TrimPrefix(remainingPath, ".")
 	}
 	if rootName == "" {
 		return nil, "", fmt.Errorf("invalid reference: missing root key")

--- a/services/rune-worker/pkg/resolver/reference_path_test.go
+++ b/services/rune-worker/pkg/resolver/reference_path_test.go
@@ -76,3 +76,25 @@ func TestResolveReferenceValue_DirectLookupFallback(t *testing.T) {
 		t.Fatalf("expected fallback value, got %v", value)
 	}
 }
+
+func TestResolveReferenceValue_RootArrayIndex(t *testing.T) {
+	t.Parallel()
+
+	ctx := map[string]interface{}{
+		"$json": []interface{}{
+			map[string]interface{}{"id": float64(1), "title": "first"},
+			map[string]interface{}{"id": float64(2), "title": "second"},
+		},
+	}
+
+	value, key, err := ResolveReferenceValue(ctx, "$json[1].title", false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if key != "$json" {
+		t.Fatalf("expected root key $json, got %s", key)
+	}
+	if value != "second" {
+		t.Fatalf("expected second, got %v", value)
+	}
+}

--- a/services/rune-worker/pkg/resolver/resolver.go
+++ b/services/rune-worker/pkg/resolver/resolver.go
@@ -36,11 +36,11 @@ func (r *Resolver) GetUsedKeys() []string {
 	return keys
 }
 
-// referencePattern matches $node_name.path.to.field or $node_name.array[0].
+// referencePattern matches $node_name.path.to.field, $node_name.array[0], or $json[0].
 // Field paths may themselves contain $ segments, such as $Filter.$json.
-var referencePattern = regexp.MustCompile(`\$([a-zA-Z0-9_-]+)(\.[a-zA-Z0-9_\[\]\.\$-]+)?`)
+var referencePattern = regexp.MustCompile(`\$([a-zA-Z0-9_-]+)((?:\.|\[)[a-zA-Z0-9_\[\]\.\$-]+)?`)
 
-var fullReferencePattern = regexp.MustCompile(`^\$[a-zA-Z0-9_-]+(?:\.[a-zA-Z0-9_\[\]\.\$-]+)?$`)
+var fullReferencePattern = regexp.MustCompile(`^\$[a-zA-Z0-9_-]+(?:(?:\.|\[)[a-zA-Z0-9_\[\]\.\$-]+)?$`)
 
 // ResolveParameters recursively resolves all parameter values in the given map.
 // It replaces string values that match the pattern $node_name.path with the actual value

--- a/services/rune-worker/pkg/resolver/resolver_test.go
+++ b/services/rune-worker/pkg/resolver/resolver_test.go
@@ -23,6 +23,10 @@ func TestResolver_ResolveParameters(t *testing.T) {
 			"user_id": "456",
 			"action":  "login",
 		},
+		"$json": []interface{}{
+			map[string]interface{}{"id": 1, "name": "First"},
+			map[string]interface{}{"id": 2, "name": "Second"},
+		},
 	}
 
 	tests := []struct {
@@ -58,6 +62,16 @@ func TestResolver_ResolveParameters(t *testing.T) {
 			},
 			want: map[string]interface{}{
 				"first_value": "first",
+			},
+			wantErr: false,
+		},
+		{
+			name: "root array index reference",
+			parameters: map[string]interface{}{
+				"second_name": "$json[1].name",
+			},
+			want: map[string]interface{}{
+				"second_name": "Second",
 			},
 			wantErr: false,
 		},


### PR DESCRIPTION
Improves variable picker behavior for array outputs and list-transform nodes. The picker now previews array indices (without flooding the inspector), supports indexed lookup for arrays, and exposes contextual `$json` and `$item` paths more intuitively.

Fixes #559 