### PR TITLE
fix(canvas): polish variable picker and node config UX

### DIFF
--- a/apps/web/src/features/canvas/components/Inspector.tsx
+++ b/apps/web/src/features/canvas/components/Inspector.tsx
@@ -437,6 +437,7 @@ export function Inspector({
                     <RuntimeDataPanel
                       nodeId={selectedNode.id}
                       nodeLabel={selectedNode.data.label}
+                      nodeType={selectedNode.type}
                     />
                   </div>
                 </TabsContent>

--- a/apps/web/src/features/canvas/components/inspectors/EditInspector.tsx
+++ b/apps/web/src/features/canvas/components/inspectors/EditInspector.tsx
@@ -57,7 +57,7 @@ export function EditInspector({ node, updateData, isExpanded }: EditInspectorPro
   };
 
   const addAssignment = () => {
-    updateAssignments((as) => [...as, { name: "newField", value: "", type: "string" }]);
+    updateAssignments((as) => [...as, { name: "", value: "", type: "string" }]);
   };
 
   const removeAssignment = (idx: number) => {

--- a/apps/web/src/features/canvas/components/inspectors/RuntimeDataPanel.tsx
+++ b/apps/web/src/features/canvas/components/inspectors/RuntimeDataPanel.tsx
@@ -261,12 +261,15 @@ export function RuntimeDataPanel({ nodeId, nodeLabel, nodeType }: RuntimeDataPan
     });
   }, [sortedExecutions]);
 
-  const selectedExecution =
-    (showExecutionSelector
-      ? sortedExecutions.find(
-          (execution) => nodeExecutionInstanceKey(execution) === selectedExecutionKey,
-        )
-      : undefined) ?? nodeExecution;
+  const selectedSplitExecution = showExecutionSelector
+    ? (sortedExecutions.find(
+        (execution) => nodeExecutionInstanceKey(execution) === selectedExecutionKey,
+      ) ?? sortedExecutions[0])
+    : undefined;
+  const selectedExecution = selectedSplitExecution ?? nodeExecution;
+  const displayedError = selectedSplitExecution
+    ? selectedSplitExecution.error
+    : nodeExecution?.error;
 
   if (!nodeExecution || nodeExecution.status === "idle") {
     return (
@@ -313,7 +316,7 @@ export function RuntimeDataPanel({ nodeId, nodeLabel, nodeType }: RuntimeDataPan
       <JsonSection label="Parameters" data={selectedExecution?.parameters} nodeLabel={nodeLabel} />
       <JsonSection label="Output" data={selectedExecution?.output} nodeLabel={nodeLabel} />
 
-      <ErrorDisplay error={selectedExecution?.error ?? nodeExecution.error} />
+      <ErrorDisplay error={displayedError} />
 
       {(selectedExecution?.executedAt ?? nodeExecution.executedAt) && (
         <div className="border-t border-border pt-3 text-xs text-muted-foreground">

--- a/apps/web/src/features/canvas/components/inspectors/RuntimeDataPanel.tsx
+++ b/apps/web/src/features/canvas/components/inspectors/RuntimeDataPanel.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useMemo } from "react";
+import { useEffect, useMemo, useState } from "react";
 import {
   Clock,
   AlertCircle,
@@ -11,16 +11,28 @@ import {
   Copy,
 } from "lucide-react";
 import { toast } from "@/components/ui/toast";
-import { useNodeExecution } from "../../context/ExecutionContext";
-import type { NodeExecutionStatus, NodeExecutionData } from "../../types/execution";
+import { useNodeExecution, useNodeExecutions } from "../../context/ExecutionContext";
+import {
+  nodeExecutionInstanceKey,
+  type NodeExecutionStatus,
+  type NodeExecutionData,
+} from "../../types/execution";
+import type { NodeKind } from "../../types";
 import { cn } from "@/lib/cn";
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/components/ui/collapsible";
-import { useState } from "react";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
 import { JsonTreeViewer } from "../json-tree/JsonTreeViewer";
 
 interface RuntimeDataPanelProps {
   nodeId: string;
   nodeLabel?: string;
+  nodeType?: NodeKind;
 }
 
 function StatusBadge({ status, durationMs }: { status: NodeExecutionStatus; durationMs?: number }) {
@@ -203,8 +215,58 @@ function ErrorDisplay({ error }: { error: NodeExecutionData["error"] }) {
   );
 }
 
-export function RuntimeDataPanel({ nodeId, nodeLabel }: RuntimeDataPanelProps) {
+function executionOptionLabel(execution: NodeExecutionData, fallbackIndex: number): string {
+  if (execution.itemIndex !== undefined) {
+    const itemNumber = execution.itemIndex + 1;
+    return execution.totalItems !== undefined
+      ? `Item ${itemNumber} of ${execution.totalItems}`
+      : `Item ${itemNumber}`;
+  }
+  if (execution.branchId) return `Branch ${fallbackIndex + 1}`;
+  return `Run ${fallbackIndex + 1}`;
+}
+
+function sortNodeExecutions(executions: NodeExecutionData[]): NodeExecutionData[] {
+  return [...executions].sort((a, b) => {
+    if (a.itemIndex !== undefined && b.itemIndex !== undefined) {
+      return a.itemIndex - b.itemIndex;
+    }
+    if (a.itemIndex !== undefined) return -1;
+    if (b.itemIndex !== undefined) return 1;
+    return nodeExecutionInstanceKey(a).localeCompare(nodeExecutionInstanceKey(b));
+  });
+}
+
+export function RuntimeDataPanel({ nodeId, nodeLabel, nodeType }: RuntimeDataPanelProps) {
   const nodeExecution = useNodeExecution(nodeId);
+  const nodeExecutions = useNodeExecutions(nodeId);
+  const sortedExecutions = useMemo(() => sortNodeExecutions(nodeExecutions), [nodeExecutions]);
+  const [selectedExecutionKey, setSelectedExecutionKey] = useState<string | null>(null);
+  const showExecutionSelector = nodeType !== "aggregator" && sortedExecutions.length > 1;
+
+  useEffect(() => {
+    if (sortedExecutions.length === 0) {
+      setSelectedExecutionKey(null);
+      return;
+    }
+
+    setSelectedExecutionKey((current) => {
+      if (
+        current &&
+        sortedExecutions.some((execution) => nodeExecutionInstanceKey(execution) === current)
+      ) {
+        return current;
+      }
+      return nodeExecutionInstanceKey(sortedExecutions[0]);
+    });
+  }, [sortedExecutions]);
+
+  const selectedExecution =
+    (showExecutionSelector
+      ? sortedExecutions.find(
+          (execution) => nodeExecutionInstanceKey(execution) === selectedExecutionKey,
+        )
+      : undefined) ?? nodeExecution;
 
   if (!nodeExecution || nodeExecution.status === "idle") {
     return (
@@ -219,18 +281,44 @@ export function RuntimeDataPanel({ nodeId, nodeLabel }: RuntimeDataPanelProps) {
 
   return (
     <div className="space-y-4">
-      <StatusBadge status={nodeExecution.status} durationMs={nodeExecution.durationMs} />
+      <StatusBadge
+        status={selectedExecution?.status ?? nodeExecution.status}
+        durationMs={selectedExecution?.durationMs ?? nodeExecution.durationMs}
+      />
 
-      <JsonSection label="Input" data={nodeExecution.input} nodeLabel={nodeLabel} />
-      <JsonSection label="Parameters" data={nodeExecution.parameters} nodeLabel={nodeLabel} />
-      <JsonSection label="Output" data={nodeExecution.output} nodeLabel={nodeLabel} />
+      {showExecutionSelector && (
+        <div className="rounded-md border border-border/50 bg-muted/20 p-2">
+          <label className="block text-[10px] font-medium uppercase tracking-wide text-muted-foreground">
+            Split iteration
+          </label>
+          <Select value={selectedExecutionKey ?? ""} onValueChange={setSelectedExecutionKey}>
+            <SelectTrigger className="mt-1 h-8 rounded border-border/70 bg-background/80 px-2 py-1 text-xs">
+              <SelectValue placeholder="Select iteration" />
+            </SelectTrigger>
+            <SelectContent>
+              {sortedExecutions.map((execution, index) => {
+                const key = nodeExecutionInstanceKey(execution);
+                return (
+                  <SelectItem key={key} value={key} className="text-xs">
+                    {executionOptionLabel(execution, index)}
+                  </SelectItem>
+                );
+              })}
+            </SelectContent>
+          </Select>
+        </div>
+      )}
 
-      <ErrorDisplay error={nodeExecution.error} />
+      <JsonSection label="Input" data={selectedExecution?.input} nodeLabel={nodeLabel} />
+      <JsonSection label="Parameters" data={selectedExecution?.parameters} nodeLabel={nodeLabel} />
+      <JsonSection label="Output" data={selectedExecution?.output} nodeLabel={nodeLabel} />
 
-      {nodeExecution.executedAt && (
+      <ErrorDisplay error={selectedExecution?.error ?? nodeExecution.error} />
+
+      {(selectedExecution?.executedAt ?? nodeExecution.executedAt) && (
         <div className="border-t border-border pt-3 text-xs text-muted-foreground">
           <span className="font-medium">Executed:</span>{" "}
-          {new Date(nodeExecution.executedAt).toLocaleString()}
+          {new Date(selectedExecution?.executedAt ?? nodeExecution.executedAt!).toLocaleString()}
         </div>
       )}
     </div>

--- a/apps/web/src/features/canvas/components/inspectors/RuntimeDataPanel.tsx
+++ b/apps/web/src/features/canvas/components/inspectors/RuntimeDataPanel.tsx
@@ -87,7 +87,8 @@ function JsonSection({
   data: unknown;
   nodeLabel?: string;
 }) {
-  const [isOpen, setIsOpen] = useState(false);
+  const [isOpen, setIsOpen] = useState(label === "Output");
+  const [viewMode, setViewMode] = useState<"tree" | "json">("tree");
 
   const jsonString = useMemo(() => {
     if (data === undefined || data === null) return "";
@@ -127,18 +128,52 @@ function JsonSection({
           )}
         </CollapsibleTrigger>
         {isOpen && (
-          <button
-            onClick={handleCopy}
-            className="p-1 text-muted-foreground hover:text-foreground transition-colors"
-            title="Copy to clipboard"
-          >
-            <Copy className="h-3 w-3" />
-          </button>
+          <div className="flex items-center gap-1">
+            <div className="flex overflow-hidden rounded border border-border/60">
+              <button
+                type="button"
+                onClick={() => setViewMode("tree")}
+                className={cn(
+                  "px-1.5 py-0.5 text-[10px] transition-colors",
+                  viewMode === "tree"
+                    ? "bg-muted text-foreground"
+                    : "text-muted-foreground hover:text-foreground",
+                )}
+              >
+                Tree
+              </button>
+              <button
+                type="button"
+                onClick={() => setViewMode("json")}
+                className={cn(
+                  "border-l border-border/60 px-1.5 py-0.5 text-[10px] transition-colors",
+                  viewMode === "json"
+                    ? "bg-muted text-foreground"
+                    : "text-muted-foreground hover:text-foreground",
+                )}
+              >
+                JSON
+              </button>
+            </div>
+            <button
+              onClick={handleCopy}
+              className="p-1 text-muted-foreground hover:text-foreground transition-colors"
+              title="Copy to clipboard"
+            >
+              <Copy className="h-3 w-3" />
+            </button>
+          </div>
         )}
       </div>
       <CollapsibleContent>
-        <div className="max-h-64 overflow-auto rounded-md bg-muted/30 p-2">
-          <JsonTreeViewer data={data} rootPath={rootPath} defaultExpandDepth={2} />
+        <div className="max-h-96 overflow-auto rounded-md border border-border/40 bg-muted/30 p-2">
+          {viewMode === "tree" ? (
+            <JsonTreeViewer data={data} rootPath={rootPath} defaultExpandDepth={2} maxDepth={50} />
+          ) : (
+            <pre className="whitespace-pre-wrap break-words font-mono text-[11px] leading-relaxed text-foreground">
+              {jsonString}
+            </pre>
+          )}
         </div>
       </CollapsibleContent>
     </Collapsible>

--- a/apps/web/src/features/canvas/components/inspectors/SmtpInspector.tsx
+++ b/apps/web/src/features/canvas/components/inspectors/SmtpInspector.tsx
@@ -5,6 +5,7 @@ import { CredentialSelector } from "@/components/shared/CredentialSelector";
 import type { CredentialRef } from "@/lib/credentials";
 import { VariableInput } from "../variable-picker/VariableInput";
 import { VariableTextarea } from "../variable-picker/VariableTextarea";
+import { LEGACY_SMTP_PLACEHOLDER_VALUES } from "@/lib/workflow-dsl";
 
 type SmtpInspectorProps = {
   node: Node<SmtpData>;
@@ -12,18 +13,9 @@ type SmtpInspectorProps = {
   isExpanded: boolean;
 };
 
-const LEGACY_SMTP_EXAMPLES = new Set([
-  "sender@example.com",
-  "recipient@example.com",
-  "cc@example.com",
-  "bcc@example.com",
-  "Email subject line",
-  "Email message body",
-]);
-
 function editableSmtpValue(value: string | undefined): string {
   const trimmed = value?.trim();
-  if (!trimmed || LEGACY_SMTP_EXAMPLES.has(trimmed)) return "";
+  if (!trimmed || LEGACY_SMTP_PLACEHOLDER_VALUES.has(trimmed)) return "";
   return value ?? "";
 }
 

--- a/apps/web/src/features/canvas/components/inspectors/SmtpInspector.tsx
+++ b/apps/web/src/features/canvas/components/inspectors/SmtpInspector.tsx
@@ -12,6 +12,21 @@ type SmtpInspectorProps = {
   isExpanded: boolean;
 };
 
+const LEGACY_SMTP_EXAMPLES = new Set([
+  "sender@example.com",
+  "recipient@example.com",
+  "cc@example.com",
+  "bcc@example.com",
+  "Email subject line",
+  "Email message body",
+]);
+
+function editableSmtpValue(value: string | undefined): string {
+  const trimmed = value?.trim();
+  if (!trimmed || LEGACY_SMTP_EXAMPLES.has(trimmed)) return "";
+  return value ?? "";
+}
+
 export function SmtpInspector({ node, updateData, isExpanded }: SmtpInspectorProps) {
   const updateSmtpData = (updater: (data: SmtpData) => SmtpData) => {
     updateData(node.id, "smtp", updater);
@@ -36,32 +51,32 @@ export function SmtpInspector({ node, updateData, isExpanded }: SmtpInspectorPro
       />
 
       <label className="block text-xs text-muted-foreground">From</label>
-      <input
-        className="w-full rounded-[calc(var(--radius)-0.25rem)] border border-input bg-muted/30 px-2 py-1 text-sm"
-        value={node.data.from ?? ""}
-        onChange={(e) =>
+      <VariableInput
+        value={editableSmtpValue(node.data.from)}
+        onChange={(v) =>
           updateSmtpData((d) => ({
             ...d,
-            from: e.target.value,
+            from: v,
           }))
         }
         placeholder="sender@example.com"
+        nodeId={node.id}
       />
       {isExpanded && (
         <div className="text-xs text-muted-foreground/70">Email address of the sender</div>
       )}
 
       <label className="block text-xs text-muted-foreground">To</label>
-      <input
-        className="w-full rounded-[calc(var(--radius)-0.25rem)] border border-input bg-muted/30 px-2 py-1 text-sm"
-        value={node.data.to ?? ""}
-        onChange={(e) =>
+      <VariableInput
+        value={editableSmtpValue(node.data.to)}
+        onChange={(v) =>
           updateSmtpData((d) => ({
             ...d,
-            to: e.target.value,
+            to: v,
           }))
         }
         placeholder="recipient@example.com"
+        nodeId={node.id}
       />
       {isExpanded && (
         <div className="text-xs text-muted-foreground/70">
@@ -70,16 +85,16 @@ export function SmtpInspector({ node, updateData, isExpanded }: SmtpInspectorPro
       )}
 
       <label className="block text-xs text-muted-foreground">CC</label>
-      <input
-        className="w-full rounded-[calc(var(--radius)-0.25rem)] border border-input bg-muted/30 px-2 py-1 text-sm"
-        value={node.data.cc ?? ""}
-        onChange={(e) =>
+      <VariableInput
+        value={editableSmtpValue(node.data.cc)}
+        onChange={(v) =>
           updateSmtpData((d) => ({
             ...d,
-            cc: e.target.value,
+            cc: v,
           }))
         }
         placeholder="cc@example.com"
+        nodeId={node.id}
       />
       {isExpanded && (
         <div className="text-xs text-muted-foreground/70">
@@ -88,16 +103,16 @@ export function SmtpInspector({ node, updateData, isExpanded }: SmtpInspectorPro
       )}
 
       <label className="block text-xs text-muted-foreground">BCC</label>
-      <input
-        className="w-full rounded-[calc(var(--radius)-0.25rem)] border border-input bg-muted/30 px-2 py-1 text-sm"
-        value={node.data.bcc ?? ""}
-        onChange={(e) =>
+      <VariableInput
+        value={editableSmtpValue(node.data.bcc)}
+        onChange={(v) =>
           updateSmtpData((d) => ({
             ...d,
-            bcc: e.target.value,
+            bcc: v,
           }))
         }
         placeholder="bcc@example.com"
+        nodeId={node.id}
       />
       {isExpanded && (
         <div className="text-xs text-muted-foreground/70">
@@ -107,7 +122,7 @@ export function SmtpInspector({ node, updateData, isExpanded }: SmtpInspectorPro
 
       <label className="block text-xs text-muted-foreground">Subject</label>
       <VariableInput
-        value={node.data.subject ?? ""}
+        value={editableSmtpValue(node.data.subject)}
         onChange={(v) =>
           updateSmtpData((d) => ({
             ...d,
@@ -123,7 +138,7 @@ export function SmtpInspector({ node, updateData, isExpanded }: SmtpInspectorPro
 
       <label className="block text-xs text-muted-foreground">Body</label>
       <VariableTextarea
-        value={node.data.body ?? ""}
+        value={editableSmtpValue(node.data.body)}
         onChange={(v) =>
           updateSmtpData((d) => ({
             ...d,

--- a/apps/web/src/features/canvas/components/variable-picker/VariableInput.tsx
+++ b/apps/web/src/features/canvas/components/variable-picker/VariableInput.tsx
@@ -64,7 +64,7 @@ function pillHtml(
   const borderStyle = color ? `border-color:${color};` : "";
   const bgStyle = color ? `background:color-mix(in srgb, ${color} 15%, transparent);` : "";
   const colorStyle = color ? `color:${color};` : "";
-  return `<span contenteditable="false" data-value="${escapeAttr(seg.value)}" class="variable-pill" style="${borderStyle}${bgStyle}${colorStyle}">${escapeHtml(label)}<span class="variable-pill-remove" data-remove-index="${removeIndex}">\u00d7</span></span>\u200B`;
+  return `<span contenteditable="false" data-value="${escapeAttr(seg.value)}" class="variable-pill" style="${borderStyle}${bgStyle}${colorStyle}" title="${escapeAttr(seg.value)}"><span class="variable-pill-label">${escapeHtml(label)}</span><span class="variable-pill-remove" data-remove-index="${removeIndex}">\u00d7</span></span>\u200B`;
 }
 
 /**
@@ -283,6 +283,7 @@ export function VariableInput({
     handleInput,
     insertVariable,
     insertFromPicker,
+    rememberCursorPosition,
     setShowAutocomplete,
   } = useVariableInput({ value, onChange });
 
@@ -329,10 +330,14 @@ export function VariableInput({
     [insertFromPicker, transformSelectedPath],
   );
 
-  const togglePicker = useCallback((e: React.MouseEvent) => {
-    e.stopPropagation();
-    setPickerOpen((prev) => !prev);
-  }, []);
+  const togglePicker = useCallback(
+    (e: React.MouseEvent) => {
+      e.stopPropagation();
+      rememberCursorPosition();
+      setPickerOpen((prev) => !prev);
+    },
+    [rememberCursorPosition],
+  );
 
   const handleClick = useCallback(
     (e: React.MouseEvent<HTMLDivElement>) => {
@@ -392,6 +397,9 @@ export function VariableInput({
           className={editableClasses}
           onInput={onInput}
           onClick={handleClick}
+          onKeyUp={rememberCursorPosition}
+          onMouseUp={rememberCursorPosition}
+          onFocus={rememberCursorPosition}
           onPaste={handlePaste}
           onKeyDown={handleKeyDown}
           data-placeholder={placeholder}
@@ -402,6 +410,10 @@ export function VariableInput({
         {/* + button */}
         <button
           type="button"
+          onMouseDown={(e) => {
+            e.preventDefault();
+            rememberCursorPosition();
+          }}
           onClick={togglePicker}
           className={cn(
             "absolute right-1 top-1/2 flex h-5 w-5 -translate-y-1/2 items-center justify-center rounded-sm transition-colors",
@@ -446,31 +458,43 @@ export function VariableInput({
   display: inline-flex;
   align-items: center;
   gap: 2px;
+  max-width: calc(100% - 8px);
   border: 1px solid;
   border-radius: 9999px;
-  padding: 0px 4px 0px 8px;
-  font-size: 11px;
+  padding: 0px 3px 0px 6px;
+  font-size: 10px;
   font-weight: 500;
-  line-height: 1.4;
+  line-height: 1.35;
   vertical-align: baseline;
   user-select: all;
   cursor: default;
-  margin: 0 2px;
+  margin: 0 1px;
   white-space: nowrap;
+}
+.inline-variable-editable .variable-pill-label {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 .inline-variable-editable .variable-pill-remove {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  width: 14px;
-  height: 14px;
+  width: 12px;
+  height: 12px;
   border-radius: 9999px;
-  font-size: 12px;
+  font-size: 11px;
   line-height: 1;
   opacity: 0.5;
   cursor: pointer;
-  margin-left: 2px;
+  margin-left: 1px;
   transition: opacity 0.15s, background 0.15s;
+}
+.inline-variable-editable {
+  scrollbar-width: none;
+}
+.inline-variable-editable::-webkit-scrollbar {
+  display: none;
 }
 .inline-variable-editable .variable-pill-remove:hover {
   opacity: 1;
@@ -478,7 +502,8 @@ export function VariableInput({
 }
 .inline-variable-editable.empty-placeholder:empty::before {
   content: attr(data-placeholder);
-  color: hsl(var(--muted-foreground) / 0.4);
+  color: var(--muted-foreground);
+  opacity: 0.55;
   pointer-events: none;
 }
 `,

--- a/apps/web/src/features/canvas/context/ExecutionContext.tsx
+++ b/apps/web/src/features/canvas/context/ExecutionContext.tsx
@@ -18,6 +18,7 @@ import {
   rtesUpdateToNodeData,
   isCompletionMessage,
   parseWorkflowStatus,
+  isSameNodeExecutionInstance,
 } from "../types/execution";
 
 // Action types for the reducer
@@ -34,6 +35,48 @@ type ExecutionAction =
   | { type: "RESET" }
   | { type: "LOAD_STATE"; state: ExecutionState };
 
+function mergeNodeExecution(
+  existing: NodeExecutionData | undefined,
+  nodeData: NodeExecutionData,
+): NodeExecutionData {
+  return {
+    ...existing,
+    ...nodeData,
+    input: nodeData.input ?? existing?.input,
+    output: nodeData.output ?? existing?.output,
+    parameters: nodeData.parameters ?? existing?.parameters,
+    error: nodeData.status === "failed" ? (nodeData.error ?? existing?.error) : nodeData.error,
+    lineageHash: nodeData.lineageHash ?? existing?.lineageHash,
+    lineageStack: nodeData.lineageStack ?? existing?.lineageStack,
+    splitNodeId: nodeData.splitNodeId ?? existing?.splitNodeId,
+    branchId: nodeData.branchId ?? existing?.branchId,
+    itemIndex: nodeData.itemIndex ?? existing?.itemIndex,
+    totalItems: nodeData.totalItems ?? existing?.totalItems,
+    executedAt: nodeData.executedAt ?? new Date().toISOString(),
+  };
+}
+
+function upsertNodeExecutionInstance(
+  executions: Map<string, NodeExecutionData[]>,
+  nodeData: NodeExecutionData,
+): Map<string, NodeExecutionData[]> {
+  const nextExecutions = new Map(executions);
+  const existingInstances = nextExecutions.get(nodeData.nodeId) ?? [];
+  const existingIndex = existingInstances.findIndex((instance) =>
+    isSameNodeExecutionInstance(instance, nodeData),
+  );
+
+  const nextInstances = [...existingInstances];
+  if (existingIndex >= 0) {
+    nextInstances[existingIndex] = mergeNodeExecution(nextInstances[existingIndex], nodeData);
+  } else {
+    nextInstances.push(mergeNodeExecution(undefined, nodeData));
+  }
+
+  nextExecutions.set(nodeData.nodeId, nextInstances);
+  return nextExecutions;
+}
+
 /**
  * Reducer for execution state management.
  */
@@ -47,6 +90,7 @@ function executionReducer(state: ExecutionState, action: ExecutionAction): Execu
         status: "running",
         startedAt: new Date().toISOString(),
         nodes: new Map(),
+        nodeExecutions: new Map(),
         isHistorical: false,
       };
     }
@@ -69,27 +113,21 @@ function executionReducer(state: ExecutionState, action: ExecutionAction): Execu
 
       const newNodes = new Map(state.nodes);
       const existingNode = newNodes.get(nodeData.nodeId);
+      const mergedNode = mergeNodeExecution(existingNode, nodeData);
 
       // Merge with existing data (preserve previous input/output if not provided)
-      newNodes.set(nodeData.nodeId, {
-        ...existingNode,
-        ...nodeData,
-        input: nodeData.input ?? existingNode?.input,
-        output: nodeData.output ?? existingNode?.output,
-        parameters: nodeData.parameters ?? existingNode?.parameters,
-        error:
-          nodeData.status === "failed" ? (nodeData.error ?? existingNode?.error) : nodeData.error,
-        executedAt: new Date().toISOString(),
-      });
+      newNodes.set(nodeData.nodeId, mergedNode);
 
       return {
         ...state,
         nodes: newNodes,
+        nodeExecutions: upsertNodeExecutionInstance(state.nodeExecutions, nodeData),
       };
     }
 
     case "BATCH_NODE_UPDATE": {
       const newNodes = new Map(state.nodes);
+      let newNodeExecutions = state.nodeExecutions;
       let newStatus = state.status;
       let completedAt = state.completedAt;
 
@@ -104,21 +142,14 @@ function executionReducer(state: ExecutionState, action: ExecutionAction): Execu
         if (!nodeData) continue;
 
         const existingNode = newNodes.get(nodeData.nodeId);
-        newNodes.set(nodeData.nodeId, {
-          ...existingNode,
-          ...nodeData,
-          input: nodeData.input ?? existingNode?.input,
-          output: nodeData.output ?? existingNode?.output,
-          parameters: nodeData.parameters ?? existingNode?.parameters,
-          error:
-            nodeData.status === "failed" ? (nodeData.error ?? existingNode?.error) : nodeData.error,
-          executedAt: new Date().toISOString(),
-        });
+        newNodes.set(nodeData.nodeId, mergeNodeExecution(existingNode, nodeData));
+        newNodeExecutions = upsertNodeExecutionInstance(newNodeExecutions, nodeData);
       }
 
       return {
         ...state,
         nodes: newNodes,
+        nodeExecutions: newNodeExecutions,
         status: newStatus,
         completedAt,
       };
@@ -149,6 +180,7 @@ function executionReducer(state: ExecutionState, action: ExecutionAction): Execu
     case "LOAD_STATE": {
       return {
         ...action.state,
+        nodeExecutions: action.state.nodeExecutions ?? new Map(),
         isHistorical: true,
       };
     }
@@ -164,6 +196,7 @@ interface ExecutionContextValue {
   dispatch: Dispatch<ExecutionAction>;
   // Convenience methods
   getNodeExecution: (nodeId: string) => NodeExecutionData | undefined;
+  getNodeExecutions: (nodeId: string) => NodeExecutionData[];
   isNodeRunning: (nodeId: string) => boolean;
   isNodeCompleted: (nodeId: string) => boolean;
   isNodeFailed: (nodeId: string) => boolean;
@@ -179,6 +212,10 @@ export function ExecutionProvider({ children }: { children: ReactNode }) {
   const [state, dispatch] = useReducer(executionReducer, initialExecutionState);
 
   const getNodeExecution = useCallback((nodeId: string) => state.nodes.get(nodeId), [state.nodes]);
+  const getNodeExecutions = useCallback(
+    (nodeId: string) => state.nodeExecutions.get(nodeId) ?? [],
+    [state.nodeExecutions],
+  );
 
   const isNodeRunning = useCallback(
     (nodeId: string) => state.nodes.get(nodeId)?.status === "running",
@@ -202,12 +239,21 @@ export function ExecutionProvider({ children }: { children: ReactNode }) {
       state,
       dispatch,
       getNodeExecution,
+      getNodeExecutions,
       isNodeRunning,
       isNodeCompleted,
       isNodeFailed,
       isExecutionActive,
     }),
-    [state, getNodeExecution, isNodeRunning, isNodeCompleted, isNodeFailed, isExecutionActive],
+    [
+      state,
+      getNodeExecution,
+      getNodeExecutions,
+      isNodeRunning,
+      isNodeCompleted,
+      isNodeFailed,
+      isExecutionActive,
+    ],
   );
 
   return <ExecutionContext.Provider value={value}>{children}</ExecutionContext.Provider>;
@@ -241,6 +287,12 @@ export function useNodeExecution(nodeId: string): NodeExecutionData | undefined 
   const context = useContext(ExecutionContext);
   if (!context) return undefined;
   return context.getNodeExecution(nodeId);
+}
+
+export function useNodeExecutions(nodeId: string): NodeExecutionData[] {
+  const context = useContext(ExecutionContext);
+  if (!context) return [];
+  return context.getNodeExecutions(nodeId);
 }
 
 /**

--- a/apps/web/src/features/canvas/hooks/useVariableInput.ts
+++ b/apps/web/src/features/canvas/hooks/useVariableInput.ts
@@ -464,11 +464,22 @@ export function useVariableInput({ value, onChange }: UseVariableInputOptions) {
   const [cursorPosition, setCursorPosition] = useState(0);
   const [autocompleteLeft, setAutocompleteLeft] = useState(0);
   const editableRef = useRef<HTMLDivElement | null>(null);
+  const lastCursorOffsetRef = useRef<number>(value.length);
   // Track whether the last value change came from user typing (internal)
   // vs an external source (picker, parent prop change, etc.)
   const isInternalChangeRef = useRef(false);
 
   const segments = useMemo(() => segmentValue(value), [value]);
+
+  const rememberCursorPosition = useCallback(() => {
+    const el = editableRef.current;
+    if (!el) return;
+    const pos = getCursorOffset(el);
+    if (pos >= 0) {
+      lastCursorOffsetRef.current = pos;
+      setCursorPosition(pos);
+    }
+  }, []);
 
   const handleInput = useCallback(() => {
     const el = editableRef.current;
@@ -483,6 +494,7 @@ export function useVariableInput({ value, onChange }: UseVariableInputOptions) {
     // Detect $ to trigger autocomplete
     const pos = getCursorOffset(el);
     if (pos >= 0) {
+      lastCursorOffsetRef.current = pos;
       setCursorPosition(pos);
       const beforeCursor = newValue.slice(0, pos);
       const dollarIdx = beforeCursor.lastIndexOf("$");
@@ -565,9 +577,11 @@ export function useVariableInput({ value, onChange }: UseVariableInputOptions) {
     (path: string) => {
       const el = editableRef.current;
       const pos = el ? getCursorOffset(el) : -1;
-      const effectivePos = pos >= 0 ? pos : value.length;
+      const rememberedPos = Math.max(0, Math.min(lastCursorOffsetRef.current, value.length));
+      const effectivePos = pos >= 0 ? pos : rememberedPos;
       const newValue = value.slice(0, effectivePos) + path + value.slice(effectivePos);
       const newCursorRawPos = effectivePos + path.length;
+      lastCursorOffsetRef.current = newCursorRawPos;
       onChange(newValue);
 
       requestAnimationFrame(() => {
@@ -589,6 +603,7 @@ export function useVariableInput({ value, onChange }: UseVariableInputOptions) {
     editableRef,
     isInternalChangeRef,
     handleInput,
+    rememberCursorPosition,
     insertVariable,
     insertFromPicker,
     setShowAutocomplete,

--- a/apps/web/src/features/canvas/lib/executionConversion.test.ts
+++ b/apps/web/src/features/canvas/lib/executionConversion.test.ts
@@ -137,9 +137,77 @@ describe("executionConversion", () => {
       nodeId: "a",
       status: "success",
       output: { ok: true },
-      error: { message: "boom", code: "ERR" },
+      error: { message: "boom", code: "ERR", details: undefined },
       executedAt: "2026-03-29T12:00:01Z",
       durationMs: 150,
     });
+    expect(state.nodeExecutions.get("a")).toEqual([
+      {
+        nodeId: "a",
+        status: "success",
+        output: { ok: true },
+        error: { message: "boom", code: "ERR", details: undefined },
+        executedAt: "2026-03-29T12:00:01Z",
+        durationMs: 150,
+        lineageHash: undefined,
+        branchId: undefined,
+        itemIndex: undefined,
+        totalItems: undefined,
+      },
+    ]);
+  });
+
+  it("preserves split lineage executions for per-item runtime data", () => {
+    const sanitized = {
+      nodes: [{ id: "log-1", position: { x: 0, y: 0 }, type: "log", data: {} }],
+      edges: [],
+    };
+
+    workflowDataToCanvasMock.mockReturnValue(sanitized);
+    sanitizeGraphMock.mockReturnValue(sanitized);
+
+    const state = rtesDocToExecutionState({
+      execution_id: "exec-42",
+      workflow_id: "12",
+      status: "completed",
+      nodes: {
+        "log-1": {
+          position: [0, 0],
+          latest: {
+            status: "completed",
+            output: { item: 1 },
+            item_index: 1,
+            total_items: 2,
+          },
+          lineages: {
+            branch0: {
+              status: "completed",
+              input: { id: 0 },
+              output: { item: 0 },
+              lineage_hash: "branch0",
+              branch_id: "exec_split_0",
+              item_index: 0,
+              total_items: 2,
+            },
+            branch1: {
+              status: "completed",
+              input: { id: 1 },
+              output: { item: 1 },
+              lineage_hash: "branch1",
+              branch_id: "exec_split_1",
+              item_index: 1,
+              total_items: 2,
+            },
+          },
+        },
+      },
+      edges: [],
+    });
+
+    expect(state.nodes.get("log-1")?.output).toEqual({ item: 1 });
+    expect(state.nodeExecutions.get("log-1")?.map((execution) => execution.output)).toEqual([
+      { item: 0 },
+      { item: 1 },
+    ]);
   });
 });

--- a/apps/web/src/features/canvas/lib/executionConversion.test.ts
+++ b/apps/web/src/features/canvas/lib/executionConversion.test.ts
@@ -17,6 +17,7 @@ vi.mock("./autoLayout", () => ({
 }));
 
 import { extractGraphSnapshot, rtesDocToExecutionState } from "./executionConversion";
+import { nodeExecutionInstanceKey } from "../types/execution";
 
 describe("executionConversion", () => {
   beforeEach(() => {
@@ -209,5 +210,43 @@ describe("executionConversion", () => {
       { item: 0 },
       { item: 1 },
     ]);
+  });
+
+  it("produces the same instance key for historical and live split executions", () => {
+    const sanitized = {
+      nodes: [{ id: "log-1", position: { x: 0, y: 0 }, type: "log", data: {} }],
+      edges: [],
+    };
+
+    workflowDataToCanvasMock.mockReturnValue(sanitized);
+    sanitizeGraphMock.mockReturnValue(sanitized);
+
+    const state = rtesDocToExecutionState({
+      execution_id: "exec-42",
+      workflow_id: "12",
+      status: "completed",
+      nodes: {
+        "log-1": {
+          position: [0, 0],
+          latest: { status: "completed", output: { item: 2 } },
+          lineages: {
+            branch2: {
+              status: "completed",
+              output: { item: 2 },
+              split_node_id: "split-1",
+              branch_id: "exec_split_2",
+              item_index: 2,
+              total_items: 3,
+            },
+          },
+        },
+      },
+      edges: [],
+    });
+
+    const historicalExecution = state.nodeExecutions.get("log-1")?.[0];
+    expect(historicalExecution).toBeDefined();
+    // Must match the key a live WebSocket update with lineage_stack would produce
+    expect(nodeExecutionInstanceKey(historicalExecution!)).toBe("stack:split-1:2");
   });
 });

--- a/apps/web/src/features/canvas/lib/executionConversion.ts
+++ b/apps/web/src/features/canvas/lib/executionConversion.ts
@@ -6,6 +6,7 @@ import type {
   WorkflowGraphSnapshot,
 } from "../types/execution";
 import { parseNodeStatus } from "../types/execution";
+import type { RtesNodeExecutionInstance } from "@/lib/api/rtes";
 import { workflowDataToCanvas, type WorkflowNode, type WorkflowEdge } from "@/lib/workflow-dsl";
 import { sanitizeGraph } from "./graphIO";
 import { applyAutoLayout } from "./autoLayout";
@@ -80,26 +81,57 @@ export function extractGraphSnapshot(
   };
 }
 
+function rtesInstanceToNodeExecution(
+  nodeId: string,
+  instance: RtesNodeExecutionInstance,
+  lineageHash?: string,
+): NodeExecutionData {
+  return {
+    nodeId,
+    status: parseNodeStatus(instance.status),
+    input: instance.input,
+    output: instance.output,
+    parameters: instance.parameters,
+    error: instance.error
+      ? {
+          message: instance.error.message,
+          code: instance.error.code,
+          details: instance.error.details,
+        }
+      : undefined,
+    executedAt: instance.executed_at,
+    durationMs: instance.duration_ms,
+    lineageHash: instance.lineage_hash ?? lineageHash,
+    splitNodeId: instance.split_node_id ?? undefined,
+    branchId: instance.branch_id ?? undefined,
+    itemIndex: instance.item_index ?? undefined,
+    totalItems: instance.total_items ?? undefined,
+  };
+}
+
 /**
  * Convert RTES ExecutionDocument to frontend ExecutionState
  */
 export function rtesDocToExecutionState(doc: RtesExecutionDocument): ExecutionState {
   const nodesMap = new Map<string, NodeExecutionData>();
+  const nodeExecutionsMap = new Map<string, NodeExecutionData[]>();
 
   // Convert nodes from RTES format
   for (const [nodeId, hydratedNode] of Object.entries(doc.nodes)) {
+    const lineageExecutions = Object.entries(hydratedNode.lineages ?? {}).map(
+      ([lineageHash, instance]) => rtesInstanceToNodeExecution(nodeId, instance, lineageHash),
+    );
+    if (lineageExecutions.length > 0) {
+      nodeExecutionsMap.set(nodeId, lineageExecutions);
+    }
+
     const latest = hydratedNode.latest;
     if (latest) {
-      nodesMap.set(nodeId, {
-        nodeId,
-        status: parseNodeStatus(latest.status),
-        output: latest.output,
-        error: latest.error
-          ? { message: latest.error.message, code: latest.error.code }
-          : undefined,
-        executedAt: latest.executed_at,
-        durationMs: latest.duration_ms,
-      });
+      const latestExecution = rtesInstanceToNodeExecution(nodeId, latest);
+      nodesMap.set(nodeId, latestExecution);
+      if (lineageExecutions.length === 0) {
+        nodeExecutionsMap.set(nodeId, [latestExecution]);
+      }
     }
   }
 
@@ -110,6 +142,7 @@ export function rtesDocToExecutionState(doc: RtesExecutionDocument): ExecutionSt
     workflowId: parseInt(doc.workflow_id, 10),
     status: (doc.status as WorkflowExecutionStatus) || "idle",
     nodes: nodesMap,
+    nodeExecutions: nodeExecutionsMap,
     startedAt: doc.created_at,
     isHistorical: true,
     graphSnapshot,

--- a/apps/web/src/features/canvas/lib/executionConversion.ts
+++ b/apps/web/src/features/canvas/lib/executionConversion.ts
@@ -86,6 +86,25 @@ function rtesInstanceToNodeExecution(
   instance: RtesNodeExecutionInstance,
   lineageHash?: string,
 ): NodeExecutionData {
+  const splitNodeId = instance.split_node_id ?? undefined;
+  const itemIndex = instance.item_index ?? undefined;
+
+  // Synthesize lineageStack from flat fields so historical executions produce
+  // the same "stack:" instance key as live RTES WebSocket updates.
+  // Without this, live item 3 of split-1 maps to "stack:split-1:3" while the
+  // same item loaded from history maps to "split:split-1:item:3".
+  const lineageStack =
+    splitNodeId !== undefined && itemIndex !== undefined
+      ? [
+          {
+            split_node_id: splitNodeId,
+            branch_id: instance.branch_id ?? "",
+            item_index: itemIndex,
+            total_items: instance.total_items ?? 0,
+          },
+        ]
+      : undefined;
+
   return {
     nodeId,
     status: parseNodeStatus(instance.status),
@@ -102,9 +121,10 @@ function rtesInstanceToNodeExecution(
     executedAt: instance.executed_at,
     durationMs: instance.duration_ms,
     lineageHash: instance.lineage_hash ?? lineageHash,
-    splitNodeId: instance.split_node_id ?? undefined,
+    lineageStack,
+    splitNodeId,
     branchId: instance.branch_id ?? undefined,
-    itemIndex: instance.item_index ?? undefined,
+    itemIndex,
     totalItems: instance.total_items ?? undefined,
   };
 }

--- a/apps/web/src/features/canvas/lib/nodeRegistry.test.ts
+++ b/apps/web/src/features/canvas/lib/nodeRegistry.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from "vitest";
+import { getNodeDefaults } from "./nodeRegistry";
+
+describe("nodeRegistry defaults", () => {
+  it("keeps example-like configuration values out of new node data", () => {
+    expect(getNodeDefaults("http").data.url).toBeUndefined();
+
+    const smtpDefaults = getNodeDefaults("smtp").data;
+    expect(smtpDefaults.from).toBeUndefined();
+    expect(smtpDefaults.to).toBeUndefined();
+
+    const editDefaults = getNodeDefaults("edit").data;
+    expect(editDefaults.assignments?.[0]?.name).toBe("");
+  });
+});

--- a/apps/web/src/features/canvas/lib/nodeRegistry.ts
+++ b/apps/web/src/features/canvas/lib/nodeRegistry.ts
@@ -166,7 +166,6 @@ export const NODE_REGISTRY: NodeRegistry = {
     defaults: {
       label: "HTTP",
       method: "GET",
-      url: "https://api.example.com",
       raise_on_status: "4xx,5xx",
       retry: 0,
       retry_delay: 0,
@@ -190,8 +189,6 @@ export const NODE_REGISTRY: NodeRegistry = {
     dimensions: { width: 220, height: 80 },
     defaults: {
       label: "SMTP",
-      from: "sender@example.com",
-      to: "recipient@example.com",
       subject: "",
       body: "",
     },
@@ -352,7 +349,7 @@ export const NODE_REGISTRY: NodeRegistry = {
     defaults: {
       label: "Edit",
       mode: "assignments",
-      assignments: [{ name: "newField", value: "", type: "string" }],
+      assignments: [{ name: "", value: "", type: "string" }],
     },
     schema: { inputs: ["input"], outputs: ["output"] },
     group: "transform",

--- a/apps/web/src/features/canvas/lib/variableSchema.test.ts
+++ b/apps/web/src/features/canvas/lib/variableSchema.test.ts
@@ -48,4 +48,30 @@ describe("jsonToVariableTree", () => {
     expect(posts?.type).toBe("array");
     expect(posts?.children).toEqual([]);
   });
+
+  it("keeps deeply nested fields reachable", () => {
+    const tree = jsonToVariableTree(
+      {
+        one: {
+          two: {
+            three: {
+              four: {
+                five: {
+                  six: {
+                    value: "reachable",
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+      "$Deep",
+    );
+
+    const valueNode =
+      tree[0].children?.[0].children?.[0].children?.[0].children?.[0].children?.[0].children?.[0];
+
+    expect(valueNode?.path).toBe("$Deep.one.two.three.four.five.six.value");
+  });
 });

--- a/apps/web/src/features/canvas/lib/variableSchema.ts
+++ b/apps/web/src/features/canvas/lib/variableSchema.ts
@@ -47,7 +47,7 @@ function inferType(value: unknown): VariableTreeNode["type"] {
 export function jsonToVariableTree(
   data: unknown,
   parentPath: string,
-  maxDepth = 5,
+  maxDepth = 50,
   currentDepth = 0,
 ): VariableTreeNode[] {
   if (currentDepth >= maxDepth) return [];

--- a/apps/web/src/features/canvas/nodes/HttpNode.tsx
+++ b/apps/web/src/features/canvas/nodes/HttpNode.tsx
@@ -18,7 +18,7 @@ export const HttpNode = memo(function HttpNode({ id, data }: NodeProps<Node<Http
     >
       <div className="flex items-center justify-between">
         <span className="truncate text-xs text-muted-foreground">
-          {data.url ?? "https://api.example.com"}
+          {data.url?.trim() ? data.url : "Configure URL"}
         </span>
         <span className="ml-2 rounded bg-muted/40 px-2 py-0.5 text-xs text-muted-foreground">
           {(data.method ?? "GET").toUpperCase()}

--- a/apps/web/src/features/canvas/nodes/SmtpNode.tsx
+++ b/apps/web/src/features/canvas/nodes/SmtpNode.tsx
@@ -6,6 +6,20 @@ import { Mail, Key, AlertCircle } from "lucide-react";
 import { BaseNode } from "./BaseNode";
 import type { SmtpData } from "../types";
 
+const LEGACY_SMTP_EXAMPLES = new Set([
+  "sender@example.com",
+  "recipient@example.com",
+  "cc@example.com",
+  "bcc@example.com",
+  "Email subject line",
+  "Email message body",
+]);
+
+function hasConfiguredValue(value: string | undefined): value is string {
+  const trimmed = value?.trim();
+  return !!trimmed && !LEGACY_SMTP_EXAMPLES.has(trimmed);
+}
+
 export const SmtpNode = memo(function SmtpNode({ id, data }: NodeProps<Node<SmtpData>>) {
   const hasCredential = !!data.credential;
 
@@ -30,16 +44,14 @@ export const SmtpNode = memo(function SmtpNode({ id, data }: NodeProps<Node<Smtp
             <span className="truncate">No credential</span>
           </div>
         )}
-        {data.from && (
-          <div className="truncate text-xs text-muted-foreground">
-            From: {data.from ?? "sender@example.com"}
-          </div>
+        {hasConfiguredValue(data.from) && (
+          <div className="truncate text-xs text-muted-foreground">From: {data.from}</div>
         )}
         <div className="truncate text-xs text-muted-foreground">
-          To: {data.to ?? "recipient@example.com"}
+          {hasConfiguredValue(data.to) ? `To: ${data.to}` : "Add recipient"}
         </div>
         <div className="truncate text-xs text-muted-foreground">
-          Subj: {data.subject || "(no subject)"}
+          Subj: {hasConfiguredValue(data.subject) ? data.subject : "(no subject)"}
         </div>
       </div>
     </BaseNode>

--- a/apps/web/src/features/canvas/nodes/SmtpNode.tsx
+++ b/apps/web/src/features/canvas/nodes/SmtpNode.tsx
@@ -5,19 +5,11 @@ import { type Node, type NodeProps } from "@xyflow/react";
 import { Mail, Key, AlertCircle } from "lucide-react";
 import { BaseNode } from "./BaseNode";
 import type { SmtpData } from "../types";
-
-const LEGACY_SMTP_EXAMPLES = new Set([
-  "sender@example.com",
-  "recipient@example.com",
-  "cc@example.com",
-  "bcc@example.com",
-  "Email subject line",
-  "Email message body",
-]);
+import { LEGACY_SMTP_PLACEHOLDER_VALUES } from "@/lib/workflow-dsl";
 
 function hasConfiguredValue(value: string | undefined): value is string {
   const trimmed = value?.trim();
-  return !!trimmed && !LEGACY_SMTP_EXAMPLES.has(trimmed);
+  return !!trimmed && !LEGACY_SMTP_PLACEHOLDER_VALUES.has(trimmed);
 }
 
 export const SmtpNode = memo(function SmtpNode({ id, data }: NodeProps<Node<SmtpData>>) {

--- a/apps/web/src/features/canvas/nodes/SplitNode.tsx
+++ b/apps/web/src/features/canvas/nodes/SplitNode.tsx
@@ -16,7 +16,7 @@ export const SplitNode = memo(function SplitNode({ id, data }: NodeProps<Node<Sp
       borderColor="--node-transform-border"
       pinned={data.pinned}
     >
-      <div className="text-xs text-muted-foreground">
+      <div className="min-w-0 truncate text-xs text-muted-foreground" title={data.array_field}>
         {data.array_field ? `Split: ${data.array_field}` : "Configure array field"}
       </div>
     </BaseNode>

--- a/apps/web/src/features/canvas/types/execution.test.ts
+++ b/apps/web/src/features/canvas/types/execution.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "vitest";
+import {
+  isSameNodeExecutionInstance,
+  nodeExecutionInstanceKey,
+  rtesUpdateToNodeData,
+  type NodeExecutionData,
+} from "./execution";
+
+function execution(overrides: Partial<NodeExecutionData>): NodeExecutionData {
+  return {
+    nodeId: "log-1",
+    status: "running",
+    ...overrides,
+  };
+}
+
+describe("execution instance identity", () => {
+  it("keeps split item identity stable as RTES sends richer lineage metadata", () => {
+    const pending = execution({ itemIndex: 3, totalItems: 5 });
+    const completed = execution({
+      status: "success",
+      lineageHash: "abc123",
+      splitNodeId: "split-1",
+      branchId: "branch-3",
+      itemIndex: 3,
+      totalItems: 5,
+    });
+
+    expect(isSameNodeExecutionInstance(pending, completed)).toBe(true);
+  });
+
+  it("does not merge different split items", () => {
+    expect(
+      isSameNodeExecutionInstance(
+        execution({ splitNodeId: "split-1", itemIndex: 3, totalItems: 5 }),
+        execution({ splitNodeId: "split-1", itemIndex: 4, totalItems: 5 }),
+      ),
+    ).toBe(false);
+  });
+
+  it("derives split item metadata from lineage stack updates", () => {
+    const nodeData = rtesUpdateToNodeData({
+      node_id: "log-1",
+      status: "running",
+      lineage_hash: "lineage-1",
+      lineage_stack: [
+        {
+          split_node_id: "split-1",
+          branch_id: "branch-3",
+          item_index: 3,
+          total_items: 5,
+        },
+      ],
+    });
+
+    expect(nodeData).not.toBeNull();
+    if (!nodeData) return;
+
+    expect(nodeData).toMatchObject({
+      splitNodeId: "split-1",
+      branchId: "branch-3",
+      itemIndex: 3,
+      totalItems: 5,
+    });
+    expect(nodeExecutionInstanceKey(nodeData)).toBe("stack:split-1:3");
+  });
+});

--- a/apps/web/src/features/canvas/types/execution.ts
+++ b/apps/web/src/features/canvas/types/execution.ts
@@ -31,6 +31,8 @@ export interface NodeExecutionData {
   durationMs?: number;
   // For split node support (TODO(ash): remember this)
   lineageHash?: string;
+  lineageStack?: RtesStackFrame[];
+  splitNodeId?: string;
   branchId?: string;
   itemIndex?: number;
   totalItems?: number;
@@ -42,6 +44,7 @@ export interface ExecutionState {
   workflowId: number | null;
   status: WorkflowExecutionStatus;
   nodes: Map<string, NodeExecutionData>;
+  nodeExecutions: Map<string, NodeExecutionData[]>;
   error?: string;
   startedAt?: string;
   completedAt?: string;
@@ -157,6 +160,11 @@ export function parseWorkflowStatus(status: string | null | undefined): Workflow
 export function rtesUpdateToNodeData(update: RtesNodeUpdate): NodeExecutionData | null {
   if (!update.node_id) return null;
 
+  const latestLineageFrame =
+    update.lineage_stack && update.lineage_stack.length > 0
+      ? update.lineage_stack[update.lineage_stack.length - 1]
+      : undefined;
+
   return {
     nodeId: update.node_id,
     status: parseNodeStatus(update.status),
@@ -167,10 +175,43 @@ export function rtesUpdateToNodeData(update: RtesNodeUpdate): NodeExecutionData 
       ? { message: update.error.message, code: update.error.code, details: update.error.details }
       : undefined,
     lineageHash: update.lineage_hash ?? undefined,
-    branchId: update.branch_id ?? undefined,
-    itemIndex: update.item_index ?? undefined,
-    totalItems: update.total_items ?? undefined,
+    lineageStack: update.lineage_stack ?? undefined,
+    splitNodeId: update.split_node_id ?? latestLineageFrame?.split_node_id,
+    branchId: update.branch_id ?? latestLineageFrame?.branch_id,
+    itemIndex: update.item_index ?? latestLineageFrame?.item_index,
+    totalItems: update.total_items ?? latestLineageFrame?.total_items,
   };
+}
+
+export function nodeExecutionInstanceKey(execution: NodeExecutionData): string {
+  if (execution.lineageStack && execution.lineageStack.length > 0) {
+    return `stack:${execution.lineageStack
+      .map((frame) => `${frame.split_node_id}:${frame.item_index}`)
+      .join("/")}`;
+  }
+  if (execution.splitNodeId && execution.itemIndex !== undefined) {
+    return `split:${execution.splitNodeId}:item:${execution.itemIndex}`;
+  }
+  if (execution.branchId && execution.itemIndex !== undefined) {
+    return `branch:${execution.branchId}:item:${execution.itemIndex}`;
+  }
+  if (execution.lineageHash) return `lineage:${execution.lineageHash}`;
+  if (execution.branchId) return `branch:${execution.branchId}`;
+  if (execution.itemIndex !== undefined) return `item:${execution.itemIndex}`;
+  return "default";
+}
+
+export function isSameNodeExecutionInstance(a: NodeExecutionData, b: NodeExecutionData): boolean {
+  if (a.nodeId !== b.nodeId) return false;
+  if (nodeExecutionInstanceKey(a) === nodeExecutionInstanceKey(b)) return true;
+  if (a.itemIndex === undefined || b.itemIndex === undefined) return false;
+  if (a.itemIndex !== b.itemIndex) return false;
+  if (a.totalItems !== undefined && b.totalItems !== undefined && a.totalItems !== b.totalItems) {
+    return false;
+  }
+  if (a.splitNodeId && b.splitNodeId && a.splitNodeId !== b.splitNodeId) return false;
+
+  return true;
 }
 
 /**
@@ -189,4 +230,5 @@ export const initialExecutionState: ExecutionState = {
   workflowId: null,
   status: "idle",
   nodes: new Map(),
+  nodeExecutions: new Map(),
 };

--- a/apps/web/src/lib/api/rtes.ts
+++ b/apps/web/src/lib/api/rtes.ts
@@ -49,6 +49,11 @@ export interface RtesNodeExecutionInstance {
   };
   executed_at?: string;
   duration_ms?: number;
+  lineage_hash?: string | null;
+  branch_id?: string | null;
+  split_node_id?: string | null;
+  item_index?: number | null;
+  total_items?: number | null;
   node_type?: string;
   name?: string;
 }

--- a/apps/web/src/lib/workflow-dsl.test.ts
+++ b/apps/web/src/lib/workflow-dsl.test.ts
@@ -35,6 +35,23 @@ describe("workflow DSL helpers", () => {
     expect(() => canvasToWorkflowData([smtpNode], [])).toThrow(MissingNodeCredentialsError);
   });
 
+  it("does not serialize legacy SMTP placeholder values", () => {
+    const smtpNode = createNode("smtp-1", "smtp", {
+      label: "Send Email",
+      credential: { id: "cred-1", name: "SMTP", type: "smtp" },
+      from: "sender@example.com",
+      to: "recipient@example.com",
+      cc: "cc@example.com",
+      bcc: "bcc@example.com",
+      subject: "Email subject line",
+      body: "Email message body",
+    });
+
+    const { nodes } = canvasToWorkflowData([smtpNode], []);
+
+    expect(nodes[0].parameters).toEqual({});
+  });
+
   it("converts switch routes and sanitizes node names", () => {
     const switchNode = createNode("switch-1", "switch", {
       label: "123 Bad Label",

--- a/apps/web/src/lib/workflow-dsl.ts
+++ b/apps/web/src/lib/workflow-dsl.ts
@@ -127,6 +127,7 @@ function nodeName(n: CanvasNode): string {
 
 // Helper to convert comma-separated email string to array
 function emailStringToArray(value: string | undefined): string[] | string | undefined {
+  if (isLegacyPlaceholderValue(value)) return undefined;
   if (!value || !value.trim()) return undefined;
   const emails = value
     .split(",")
@@ -144,6 +145,19 @@ function emailArrayToString(value: unknown): string | undefined {
     return emails.length > 0 ? emails.join(", ") : undefined;
   }
   return undefined;
+}
+
+const LEGACY_PLACEHOLDER_VALUES = new Set([
+  "sender@example.com",
+  "recipient@example.com",
+  "cc@example.com",
+  "bcc@example.com",
+  "Email subject line",
+  "Email message body",
+]);
+
+function isLegacyPlaceholderValue(value: unknown): boolean {
+  return typeof value === "string" && LEGACY_PLACEHOLDER_VALUES.has(value.trim());
 }
 
 // Build parameter objects for supported node types
@@ -262,12 +276,12 @@ function toWorkerParameters(n: CanvasNode, edges: RFEdge[]): Record<string, unkn
     case "smtp": {
       const d = (n.data || {}) as SmtpData;
       const params: Record<string, unknown> = {};
-      if (d.from) params.from = String(d.from);
+      if (d.from && !isLegacyPlaceholderValue(d.from)) params.from = String(d.from);
       if (d.to) params.to = emailStringToArray(d.to);
       if (d.cc) params.cc = emailStringToArray(d.cc);
       if (d.bcc) params.bcc = emailStringToArray(d.bcc);
-      if (d.subject) params.subject = String(d.subject);
-      if (d.body) params.body = String(d.body);
+      if (d.subject && !isLegacyPlaceholderValue(d.subject)) params.subject = String(d.subject);
+      if (d.body && !isLegacyPlaceholderValue(d.body)) params.body = String(d.body);
       return params;
     }
     case "wait": {

--- a/apps/web/src/lib/workflow-dsl.ts
+++ b/apps/web/src/lib/workflow-dsl.ts
@@ -127,7 +127,7 @@ function nodeName(n: CanvasNode): string {
 
 // Helper to convert comma-separated email string to array
 function emailStringToArray(value: string | undefined): string[] | string | undefined {
-  if (isLegacyPlaceholderValue(value)) return undefined;
+  if (isLegacySmtpPlaceholder(value)) return undefined;
   if (!value || !value.trim()) return undefined;
   const emails = value
     .split(",")
@@ -147,7 +147,7 @@ function emailArrayToString(value: unknown): string | undefined {
   return undefined;
 }
 
-const LEGACY_PLACEHOLDER_VALUES = new Set([
+export const LEGACY_SMTP_PLACEHOLDER_VALUES = new Set([
   "sender@example.com",
   "recipient@example.com",
   "cc@example.com",
@@ -156,8 +156,8 @@ const LEGACY_PLACEHOLDER_VALUES = new Set([
   "Email message body",
 ]);
 
-function isLegacyPlaceholderValue(value: unknown): boolean {
-  return typeof value === "string" && LEGACY_PLACEHOLDER_VALUES.has(value.trim());
+export function isLegacySmtpPlaceholder(value: unknown): boolean {
+  return typeof value === "string" && LEGACY_SMTP_PLACEHOLDER_VALUES.has(value.trim());
 }
 
 // Build parameter objects for supported node types
@@ -276,12 +276,12 @@ function toWorkerParameters(n: CanvasNode, edges: RFEdge[]): Record<string, unkn
     case "smtp": {
       const d = (n.data || {}) as SmtpData;
       const params: Record<string, unknown> = {};
-      if (d.from && !isLegacyPlaceholderValue(d.from)) params.from = String(d.from);
+      if (d.from && !isLegacySmtpPlaceholder(d.from)) params.from = String(d.from);
       if (d.to) params.to = emailStringToArray(d.to);
       if (d.cc) params.cc = emailStringToArray(d.cc);
       if (d.bcc) params.bcc = emailStringToArray(d.bcc);
-      if (d.subject && !isLegacyPlaceholderValue(d.subject)) params.subject = String(d.subject);
-      if (d.body && !isLegacyPlaceholderValue(d.body)) params.body = String(d.body);
+      if (d.subject && !isLegacySmtpPlaceholder(d.subject)) params.subject = String(d.subject);
+      if (d.body && !isLegacySmtpPlaceholder(d.body)) params.body = String(d.body);
       return params;
     }
     case "wait": {


### PR DESCRIPTION
Improves variable picker and canvas configuration UX across node inspectors, runtime output viewing, and node previews.

This fixes variable picker insertion so selected variables are inserted at the cursor position properly, makes variable pills
fit better in compact single-line and multiline fields, removes the variable tree’s shallow nesting limitation (fixes #496), and improves
runtime data viewing with expanded output plus tree/JSON modes. 

SMTP address fields now support variable picking, and long Split node paths are truncated in the canvas preview.

This also fixes #505 by removing example-like values from new node defaults so placeholders remain hints instead of becoming real configuration and fixes #561 by having inspectors keep context of every item on split, instead of them being overwritten.