### PR TITLE
refactor(web): centralize Zod validation and wire auth/admin forms to RHF

### DIFF
--- a/apps/web/src/app/(app)/profile/page.tsx
+++ b/apps/web/src/app/(app)/profile/page.tsx
@@ -25,12 +25,18 @@ import { Separator } from "@/components/ui/separator";
 import { ChangePasswordForm } from "@/components/auth/ChangePasswordForm";
 
 // Zod schemas for validation
+/** Matches emoji / pictographs and regional-indicator symbols (e.g. flag pairs). */
+const EMOJI_OR_PICTOGRAPH = /\p{Extended_Pictographic}|\p{Regional_Indicator}/u;
+
 const nameSchema = z.object({
   name: z
     .string()
-    .min(1, "Name is required")
-    .min(2, "Name must be at least 2 characters")
-    .max(100, "Name must be less than 100 characters"),
+    .trim()
+    .min(3, "Name must be at least 3 characters")
+    .max(40, "Name must be 40 characters or less")
+    .refine((s: string) => !EMOJI_OR_PICTOGRAPH.test(s), {
+      message: "Name cannot contain emoji or regional-indicator symbols",
+    }),
 });
 
 const emailSchema = z.object({
@@ -45,7 +51,7 @@ export default function ProfilePage() {
   const [editingField, setEditingField] = useState<EditingField>(null);
   const [isSaving, setIsSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const [isPasswordDialogOpen, setIsPasswordDialogOpen] = useState(false);
+  const [isPasswordDialogOpen, setIsPassworsdDialogOpen] = useState(false);
   const [dialogResetKey, setDialogResetKey] = useState(0);
   const { state, logout, refetchProfile, refresh } = useAuth();
 

--- a/apps/web/src/app/(app)/profile/page.tsx
+++ b/apps/web/src/app/(app)/profile/page.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import { z } from "zod";
 import { useAuth } from "@/lib/auth";
 import { updateMyProfile } from "@/lib/api/users";
 import { getInitials } from "@/lib/initials";
@@ -23,25 +22,7 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Separator } from "@/components/ui/separator";
 import { ChangePasswordForm } from "@/components/auth/ChangePasswordForm";
-
-// Zod schemas for validation
-/** Matches emoji / pictographs and regional-indicator symbols (e.g. flag pairs). */
-const EMOJI_OR_PICTOGRAPH = /\p{Extended_Pictographic}|\p{Regional_Indicator}/u;
-
-const nameSchema = z.object({
-  name: z
-    .string()
-    .trim()
-    .min(3, "Name must be at least 3 characters")
-    .max(40, "Name must be 40 characters or less")
-    .refine((s: string) => !EMOJI_OR_PICTOGRAPH.test(s), {
-      message: "Name cannot contain emoji or regional-indicator symbols",
-    }),
-});
-
-const emailSchema = z.object({
-  email: z.string().min(1, "Email is required").email("Please enter a valid email address"),
-});
+import { profileEmailSchema, profileNameSchema } from "@/lib/validation";
 
 type EditingField = "name" | "email" | null;
 
@@ -51,7 +32,7 @@ export default function ProfilePage() {
   const [editingField, setEditingField] = useState<EditingField>(null);
   const [isSaving, setIsSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const [isPasswordDialogOpen, setIsPassworsdDialogOpen] = useState(false);
+  const [isPasswordDialogOpen, setIsPasswordDialogOpen] = useState(false);
   const [dialogResetKey, setDialogResetKey] = useState(0);
   const { state, logout, refetchProfile, refresh } = useAuth();
 
@@ -67,7 +48,7 @@ export default function ProfilePage() {
 
   const handleSaveName = async () => {
     // Validate with zod
-    const result = nameSchema.safeParse({ name: fullName });
+    const result = profileNameSchema.safeParse({ name: fullName });
     if (!result.success) {
       setError(result.error.issues[0].message);
       return;
@@ -95,7 +76,7 @@ export default function ProfilePage() {
 
   const handleSaveEmail = async () => {
     // Validate with zod
-    const result = emailSchema.safeParse({ email });
+    const result = profileEmailSchema.safeParse({ email: email });
     if (!result.success) {
       setError(result.error.issues[0].message);
       return;

--- a/apps/web/src/components/admin/InviteUserDialog.tsx
+++ b/apps/web/src/components/admin/InviteUserDialog.tsx
@@ -46,8 +46,8 @@ export function InviteUserDialog({ open, onClose, onInvite }: InviteUserDialogPr
         form.reset({ name: "", email: "", role: "user" });
         toast.success("User invited successfully");
       }
-    } catch (error) {
-      toast.error("Failed to invite user")
+    } catch (_error) {
+      toast.error("Failed to invite user");
     } finally {
       setIsSubmitting(false);
     }

--- a/apps/web/src/components/admin/InviteUserDialog.tsx
+++ b/apps/web/src/components/admin/InviteUserDialog.tsx
@@ -1,10 +1,15 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { toast } from "sonner";
+
+import { inviteUserSchema, type InviteUserFormValues } from "@/lib/validation";
 import { Card } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
-import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import { Input } from "@/components/ui/input";
 
 interface InviteUserDialogProps {
   open: boolean;
@@ -13,59 +18,56 @@ interface InviteUserDialogProps {
 }
 
 export function InviteUserDialog({ open, onClose, onInvite }: InviteUserDialogProps) {
-  const [inviteName, setInviteName] = useState("");
-  const [inviteEmail, setInviteEmail] = useState("");
-  const [inviteRole, setInviteRole] = useState<"user" | "admin">("user");
   const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const form = useForm<InviteUserFormValues>({
+    resolver: zodResolver(inviteUserSchema),
+    defaultValues: {
+      name: "",
+      email: "",
+      role: "user",
+    },
+    mode: "onChange",
+  });
+
+  useEffect(() => {
+    if (open) {
+      form.reset({ name: "", email: "", role: "user" });
+    }
+  }, [open, form]);
 
   if (!open) return null;
 
-  // Validate form fields
-  const isNameValid = inviteName.trim().length >= 3 && inviteName.trim().length <= 40;
-  // Simple email regex pattern matching backend EmailStr validation
-  const isEmailValid = /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(inviteEmail.trim());
-  const isFormValid = isNameValid && isEmailValid;
-
-  const handleInvite = async () => {
-    if (!isFormValid) return;
-
+  const onSubmit = async (values: InviteUserFormValues) => {
     setIsSubmitting(true);
     try {
-      const success = await onInvite(inviteName, inviteEmail, inviteRole);
+      const success = await onInvite(values.name, values.email, values.role);
       if (success) {
-        // Reset form only on successful submission
-        // Parent component handles closing the dialog
-        setInviteName("");
-        setInviteEmail("");
-        setInviteRole("user");
+        form.reset({ name: "", email: "", role: "user" });
+        toast.success("User invited successfully");
       }
-      // If not successful, keep form data so user can retry
     } catch (error) {
-      // Keep form data on error so user can retry
-      console.error("Failed to invite user:", error);
+      toast.error("Failed to invite user")
     } finally {
       setIsSubmitting(false);
     }
   };
 
   const handleClose = () => {
-    // Reset form when explicitly closing (Cancel/backdrop)
-    setInviteName("");
-    setInviteEmail("");
-    setInviteRole("user");
+    form.reset({ name: "", email: "", role: "user" });
     onClose();
   };
 
   const handleBackdropClick = (_e: React.MouseEvent<HTMLDivElement>) => {
-    // Prevent closing during submission
     if (isSubmitting) return;
     handleClose();
   };
 
   const handleCardClick = (e: React.MouseEvent<HTMLDivElement>) => {
-    // Prevent backdrop click from closing when clicking inside card
     e.stopPropagation();
   };
+
+  const { isValid } = form.formState;
 
   return (
     <div
@@ -75,46 +77,61 @@ export function InviteUserDialog({ open, onClose, onInvite }: InviteUserDialogPr
       <Card className="p-6 w-full max-w-md bg-background border" onClick={handleCardClick}>
         <h3 className="text-lg font-semibold mb-4">Invite User</h3>
 
-        <Input
-          type="text"
-          placeholder="Full Name"
-          className="w-full px-3 py-2 rounded-md bg-muted border text-sm mb-3"
-          value={inviteName}
-          onChange={(e) => setInviteName(e.target.value)}
-        />
+        <form className="space-y-3" onSubmit={form.handleSubmit(onSubmit)} noValidate>
+          <div>
+            <Input
+              type="text"
+              placeholder="Full Name"
+              className="w-full px-3 py-2 rounded-md bg-muted border text-sm"
+              aria-invalid={!!form.formState.errors.name}
+              {...form.register("name")}
+            />
+            {form.formState.errors.name ? (
+              <p className="text-xs text-destructive mt-1">{form.formState.errors.name.message}</p>
+            ) : null}
+          </div>
 
-        <Input
-          type="email"
-          placeholder="User email"
-          className="w-full px-3 py-2 rounded-md bg-muted border text-sm mb-4"
-          value={inviteEmail}
-          onChange={(e) => setInviteEmail(e.target.value)}
-        />
+          <div>
+            <Input
+              type="email"
+              placeholder="User email"
+              className="w-full px-3 py-2 rounded-md bg-muted border text-sm"
+              aria-invalid={!!form.formState.errors.email}
+              {...form.register("email")}
+            />
+            {form.formState.errors.email ? (
+              <p className="text-xs text-destructive mt-1">{form.formState.errors.email.message}</p>
+            ) : null}
+          </div>
 
-        <div className="mb-4">
-          <Label className="block text-sm font-medium mb-1">Role</Label>
-          <select
-            className="w-full px-3 py-2 rounded-md bg-muted border text-sm"
-            value={inviteRole}
-            onChange={(e) => setInviteRole(e.target.value as "user" | "admin")}
-          >
-            <option value="user">User</option>
-            <option value="admin">Admin</option>
-          </select>
-        </div>
+          <div>
+            <Label className="block text-sm font-medium mb-1">Role</Label>
+            <select
+              className="w-full px-3 py-2 rounded-md bg-muted border text-sm"
+              aria-invalid={!!form.formState.errors.role}
+              {...form.register("role")}
+            >
+              <option value="user">User</option>
+              <option value="admin">Admin</option>
+            </select>
+            {form.formState.errors.role ? (
+              <p className="text-xs text-destructive mt-1">{form.formState.errors.role.message}</p>
+            ) : null}
+          </div>
 
-        <div className="flex justify-end gap-2">
-          <Button variant="outline" onClick={handleClose} disabled={isSubmitting}>
-            Cancel
-          </Button>
-          <Button
-            className="bg-primary text-white"
-            onClick={handleInvite}
-            disabled={isSubmitting || !isFormValid}
-          >
-            {isSubmitting ? "Sending..." : "Send Invite"}
-          </Button>
-        </div>
+          <div className="flex justify-end gap-2 pt-2">
+            <Button type="button" variant="outline" onClick={handleClose} disabled={isSubmitting}>
+              Cancel
+            </Button>
+            <Button
+              type="submit"
+              className="bg-primary text-white"
+              disabled={isSubmitting || !isValid}
+            >
+              {isSubmitting ? "Sending..." : "Send Invite"}
+            </Button>
+          </div>
+        </form>
       </Card>
     </div>
   );

--- a/apps/web/src/components/auth/AuthForm.tsx
+++ b/apps/web/src/components/auth/AuthForm.tsx
@@ -3,7 +3,6 @@
 import { useTransition } from "react";
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
-import { z } from "zod";
 
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -11,29 +10,13 @@ import { Label } from "@/components/ui/label";
 import { PasswordInput } from "@/components/ui/password-input";
 import { toast } from "@/components/ui/toast";
 import { useAuth } from "@/lib/auth";
-
-const signUpSchema = z.object({
-  name: z
-    .string()
-    .min(3, "Name must be at least 3 characters long")
-    .max(40, "Name must be 40 characters or less"),
-  email: z.string().email("Enter a valid email"),
-  password: z
-    .string()
-    .min(8, "Password must be at least 8 characters")
-    .regex(/[A-Z]/, "Password must contain at least one uppercase letter")
-    .regex(/[a-z]/, "Password must contain at least one lowercase letter")
-    .regex(/[0-9]/, "Password must contain at least one number")
-    .regex(/[!@#$%^&*(),.?":{}|<>]/, "Password must contain at least one special character"),
-});
-
-type SignUpForm = z.infer<typeof signUpSchema>;
+import { signUpSchema, type SignUpFormValues } from "@/lib/validation";
 
 export function AuthForm() {
   const [isPending, startTransition] = useTransition();
   const { state, signUp } = useAuth();
 
-  const form = useForm<SignUpForm>({
+  const form = useForm<SignUpFormValues>({
     resolver: zodResolver(signUpSchema),
     defaultValues: {
       name: "",
@@ -42,7 +25,7 @@ export function AuthForm() {
     },
   });
 
-  function onSubmit(values: SignUpForm) {
+  function onSubmit(values: SignUpFormValues) {
     startTransition(() => {
       signUp(values.name, values.email, values.password)
         .then((ok) => {

--- a/apps/web/src/components/auth/ChangePasswordForm.tsx
+++ b/apps/web/src/components/auth/ChangePasswordForm.tsx
@@ -3,7 +3,6 @@
 import { useEffect, useState } from "react";
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
-import { z } from "zod";
 
 import { Button } from "@/components/ui/button";
 import { Label } from "@/components/ui/label";
@@ -11,25 +10,7 @@ import { PasswordInput } from "@/components/ui/password-input";
 import { toast } from "@/components/ui/toast";
 import { changeMyPassword } from "@/lib/api/auth";
 import { cn } from "@/lib/cn";
-
-const changePasswordSchema = z
-  .object({
-    oldPassword: z.string().min(1, "Current password is required"),
-    newPassword: z
-      .string()
-      .min(8, "Password must be at least 8 characters")
-      .regex(/[A-Z]/, "Password must contain at least one uppercase letter")
-      .regex(/[a-z]/, "Password must contain at least one lowercase letter")
-      .regex(/[0-9]/, "Password must contain at least one number")
-      .regex(/[!@#$%^&*(),.?":{}|<>]/, "Password must contain at least one special character"),
-    confirmPassword: z.string().min(1, "Please confirm your new password"),
-  })
-  .refine((data) => data.newPassword === data.confirmPassword, {
-    message: "Passwords do not match",
-    path: ["confirmPassword"],
-  });
-
-type ChangePasswordFormData = z.infer<typeof changePasswordSchema>;
+import { changePasswordSchema, type ChangePasswordFormValues } from "@/lib/validation";
 
 export interface ChangePasswordFormProps {
   /**
@@ -64,7 +45,7 @@ export function ChangePasswordForm({
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
-  const form = useForm<ChangePasswordFormData>({
+  const form = useForm<ChangePasswordFormValues>({
     resolver: zodResolver(changePasswordSchema),
     defaultValues: {
       oldPassword: "",
@@ -81,7 +62,7 @@ export function ChangePasswordForm({
     }
   }, [resetKey, form]);
 
-  async function onSubmit(values: ChangePasswordFormData) {
+  async function onSubmit(values: ChangePasswordFormValues) {
     setIsSubmitting(true);
     setError(null);
 

--- a/apps/web/src/components/auth/SignInForm.tsx
+++ b/apps/web/src/components/auth/SignInForm.tsx
@@ -1,14 +1,17 @@
 "use client";
 
-import { useEffect } from "react";
-
-import { useRouter, useSearchParams } from "next/navigation";
+import { startTransition, useEffect } from "react";
 import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { toast } from "sonner";
+
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { PasswordInput } from "@/components/ui/password-input";
+import { signInSchema, type SignInFormValues } from "@/lib/validation";
 import { useAuth } from "@/lib/auth";
+import { useRouter, useSearchParams } from "next/navigation";
 
 const ALLOWED_REDIRECTS = ["/create", "/create/app", "/profile", "/admin"] as const;
 const SESSION_EXPIRED_REASON = "session-expired";
@@ -27,26 +30,33 @@ export function SignInForm() {
   const searchParams = useSearchParams();
   const { state, login } = useAuth();
   const isSessionExpired = searchParams.get("reason") === SESSION_EXPIRED_REASON;
-  const { register, handleSubmit, setValue } = useForm<{
-    email: string;
-    password: string;
-  }>();
+  const form = useForm<SignInFormValues>({
+    resolver: zodResolver(signInSchema),
+    defaultValues: {
+      email: "",
+      password: "",
+    },
+  });
 
   useEffect(() => {
     if (state.isSsoOnly) {
-      setValue("password", "");
+      form.setValue("password", "");
     }
-  }, [state.isSsoOnly, setValue]);
+  }, [state.isSsoOnly, form]);
 
-  async function onSubmit(values: { email: string; password: string }) {
-    const ok = await login(values.email, values.password);
-    if (ok) {
-      // Redirect to /create - RequireAuth will handle redirecting to
-      // /change-password if the user needs to change their password
-      const redirectParam = searchParams.get("redirect");
-      const target = getValidatedRedirectTarget(redirectParam);
-      router.push(target);
-    }
+  async function onSubmit(values: SignInFormValues) {
+    startTransition(() => {
+      login(values.email, values.password).then((ok) => {
+        if (ok) {
+          const redirectParam = searchParams.get("redirect");
+          const target = getValidatedRedirectTarget(redirectParam);
+          router.push(target);
+          toast.success("Signed in successfully");
+        } else {
+          toast.error("Failed to sign in");
+        }
+      });
+    });
   }
 
   function handleSsoSignIn() {
@@ -57,7 +67,7 @@ export function SignInForm() {
   }
 
   return (
-    <form className="space-y-5" noValidate onSubmit={handleSubmit(onSubmit)}>
+    <form className="space-y-5" noValidate onSubmit={form.handleSubmit(onSubmit)}>
       {isSessionExpired ? (
         <div className="rounded-lg bg-amber-500/10 border border-amber-500/25 p-3">
           <p className="text-xs font-medium text-amber-300" role="status">
@@ -75,8 +85,12 @@ export function SignInForm() {
           type="email"
           placeholder="you@company.com"
           className="bg-input/50 border-input text-foreground placeholder:text-muted-foreground focus:border-ring focus:ring-0 rounded-xl h-11"
-          {...register("email")}
+          {...form.register("email")}
+          aria-invalid={!!form.formState.errors.email}
         />
+        {form.formState.errors.email ? (
+          <p className="text-xs text-destructive mt-1">{form.formState.errors.email.message}</p>
+        ) : null}
       </div>
       <div className="space-y-2">
         <Label htmlFor="password" className="text-muted-foreground">
@@ -86,8 +100,12 @@ export function SignInForm() {
           id="password"
           placeholder="••••••••"
           className="bg-input/50 border-input text-foreground placeholder:text-muted-foreground focus:border-ring focus:ring-0 rounded-xl h-11"
-          {...register("password")}
+          {...form.register("password")}
+          aria-invalid={!!form.formState.errors.password}
         />
+        {form.formState.errors.password ? (
+          <p className="text-xs text-destructive mt-1">{form.formState.errors.password.message}</p>
+        ) : null}
       </div>
       {state.isSsoOnly ? (
         <div className="space-y-4 pt-2">
@@ -102,6 +120,7 @@ export function SignInForm() {
             variant="outline"
             className="w-full h-11 rounded-full border-border text-foreground hover:bg-muted/50 font-medium transition-all"
             onClick={handleSsoSignIn}
+            disabled={state.loading}
           >
             Sign in with SSO
           </Button>
@@ -130,6 +149,7 @@ export function SignInForm() {
             variant="outline"
             className="w-full h-11 rounded-full border-border text-foreground hover:bg-muted/50 font-medium transition-all"
             onClick={handleSsoSignIn}
+            disabled={state.loading}
           >
             Sign in with SSO
           </Button>

--- a/apps/web/src/lib/validation/fields.ts
+++ b/apps/web/src/lib/validation/fields.ts
@@ -1,0 +1,30 @@
+import { z } from "zod";
+
+/** Matches emoji / pictographs and regional-indicator symbols (e.g. flag pairs). */
+const EMOJI_OR_PICTOGRAPH = /\p{Extended_Pictographic}|\p{Regional_Indicator}/u;
+
+/** Display name: trim, length, no emoji (profile / signup / invite). */
+export const userDisplayNameField = z
+  .string()
+  .trim()
+  .min(3, "Name must be at least 3 characters")
+  .max(40, "Name must be 40 characters or less")
+  .refine((s: string) => !EMOJI_OR_PICTOGRAPH.test(s), {
+    message: "Name cannot contain emoji or regional-indicator symbols",
+  });
+
+/** Sign-up / auth password rules. */
+export const strongPasswordField = z
+  .string()
+  .min(8, "Password must be at least 8 characters")
+  .regex(/[A-Z]/, "Password must contain at least one uppercase letter")
+  .regex(/[a-z]/, "Password must contain at least one lowercase letter")
+  .regex(/[0-9]/, "Password must contain at least one number")
+  .regex(/[!@#$%^&*(),.?":{}|<>]/, "Password must contain at least one special character");
+
+/**
+ * Email: trim, validate format, normalize to lowercase (Zod 4 check chain).
+ */
+export const userEmailField = z
+  .string()
+  .check(z.trim(), z.email("Enter a valid email"), z.toLowerCase());

--- a/apps/web/src/lib/validation/index.ts
+++ b/apps/web/src/lib/validation/index.ts
@@ -4,8 +4,10 @@ export {
   profileEmailSchema,
   profileNameSchema,
   signUpSchema,
+  signInSchema,
   inviteUserSchema,
   type ChangePasswordFormValues,
   type SignUpFormValues,
+  type SignInFormValues,
   type InviteUserFormValues,
 } from "./schemas";

--- a/apps/web/src/lib/validation/index.ts
+++ b/apps/web/src/lib/validation/index.ts
@@ -1,0 +1,9 @@
+export { strongPasswordField, userDisplayNameField, userEmailField } from "./fields";
+export {
+  changePasswordSchema,
+  profileEmailSchema,
+  profileNameSchema,
+  signUpSchema,
+  type ChangePasswordFormValues,
+  type SignUpFormValues,
+} from "./schemas";

--- a/apps/web/src/lib/validation/index.ts
+++ b/apps/web/src/lib/validation/index.ts
@@ -4,6 +4,8 @@ export {
   profileEmailSchema,
   profileNameSchema,
   signUpSchema,
+  inviteUserSchema,
   type ChangePasswordFormValues,
   type SignUpFormValues,
+  type InviteUserFormValues,
 } from "./schemas";

--- a/apps/web/src/lib/validation/schemas.ts
+++ b/apps/web/src/lib/validation/schemas.ts
@@ -27,5 +27,12 @@ export const profileEmailSchema = z.object({
   email: userEmailField,
 });
 
+export const inviteUserSchema = z.object({
+  name: userDisplayNameField,
+  email: userEmailField,
+  role: z.enum(["admin", "user"]),
+});
+
 export type SignUpFormValues = z.infer<typeof signUpSchema>;
 export type ChangePasswordFormValues = z.infer<typeof changePasswordSchema>;
+export type InviteUserFormValues = z.infer<typeof inviteUserSchema>;

--- a/apps/web/src/lib/validation/schemas.ts
+++ b/apps/web/src/lib/validation/schemas.ts
@@ -8,6 +8,11 @@ export const signUpSchema = z.object({
   password: strongPasswordField,
 });
 
+export const signInSchema = z.object({
+  email: userEmailField,
+  password: z.string().min(1, "Password is required"),
+});
+
 export const changePasswordSchema = z
   .object({
     oldPassword: z.string().min(1, "Current password is required"),
@@ -36,3 +41,4 @@ export const inviteUserSchema = z.object({
 export type SignUpFormValues = z.infer<typeof signUpSchema>;
 export type ChangePasswordFormValues = z.infer<typeof changePasswordSchema>;
 export type InviteUserFormValues = z.infer<typeof inviteUserSchema>;
+export type SignInFormValues = z.infer<typeof signInSchema>;

--- a/apps/web/src/lib/validation/schemas.ts
+++ b/apps/web/src/lib/validation/schemas.ts
@@ -1,0 +1,31 @@
+import { z } from "zod";
+
+import { strongPasswordField, userDisplayNameField, userEmailField } from "./fields";
+
+export const signUpSchema = z.object({
+  name: userDisplayNameField,
+  email: userEmailField,
+  password: strongPasswordField,
+});
+
+export const changePasswordSchema = z
+  .object({
+    oldPassword: z.string().min(1, "Current password is required"),
+    newPassword: strongPasswordField,
+    confirmPassword: z.string().min(1, "Please confirm your new password"),
+  })
+  .refine((data) => data.newPassword === data.confirmPassword, {
+    message: "Passwords do not match",
+    path: ["confirmPassword"],
+  });
+
+export const profileNameSchema = z.object({
+  name: userDisplayNameField,
+});
+
+export const profileEmailSchema = z.object({
+  email: userEmailField,
+});
+
+export type SignUpFormValues = z.infer<typeof signUpSchema>;
+export type ChangePasswordFormValues = z.infer<typeof changePasswordSchema>;

--- a/services/api/src/users/service.py
+++ b/services/api/src/users/service.py
@@ -88,10 +88,13 @@ class UserService:
         Raises:
             AlreadyExists: If email is already registered
         """
-        # Validate email uniqueness and normalize it
+        # Normalize email and validate uniqueness
         validated_email = await self._validate_email_uniqueness(
             user_data.email
         )
+        
+        # Normalize name and validate length
+        validated_name = normalize_and_validate_name(user_data.name)
 
         temp_password = generate_temporary_password()
         hashed_password = hash_password(temp_password)

--- a/services/api/src/users/service.py
+++ b/services/api/src/users/service.py
@@ -89,10 +89,8 @@ class UserService:
             AlreadyExists: If email is already registered
         """
         # Normalize email and validate uniqueness
-        validated_email = await self._validate_email_uniqueness(
-            user_data.email
-        )
-        
+        validated_email = await self._validate_email_uniqueness(user_data.email)
+
         # # Normalize name and validate length
         #  = normalize_and_validate_name(user_data.name)
 

--- a/services/api/src/users/service.py
+++ b/services/api/src/users/service.py
@@ -93,8 +93,8 @@ class UserService:
             user_data.email
         )
         
-        # Normalize name and validate length
-        validated_name = normalize_and_validate_name(user_data.name)
+        # # Normalize name and validate length
+        #  = normalize_and_validate_name(user_data.name)
 
         temp_password = generate_temporary_password()
         hashed_password = hash_password(temp_password)
@@ -102,7 +102,7 @@ class UserService:
 
         user = User(
             name=user_data.name,
-            email=normalized_email,
+            email=validated_email,
             hashed_password=hashed_password,
             role=user_data.role,
             must_change_password=must_change,

--- a/services/api/src/users/service.py
+++ b/services/api/src/users/service.py
@@ -13,7 +13,7 @@ class UserService:
         self.db = db
 
     async def _validate_email_uniqueness(
-        self, new_email: str, current_email: str
+        self, new_email: str, current_email: str = ""
     ) -> str:
         """
         Helper to validate email uniqueness and normalize it.
@@ -88,15 +88,10 @@ class UserService:
         Raises:
             AlreadyExists: If email is already registered
         """
-        # Normalize email to lowercase for case-insensitive checking
-        normalized_email = normalize_email(user_data.email)
-
-        # Check if email already exists
-        existing_user = await self.get_user_by_email(normalized_email)
-        if existing_user:
-            raise AlreadyExists(
-                detail=f"User with email {user_data.email} already exists"
-            )
+        # Validate email uniqueness and normalize it
+        validated_email = await self._validate_email_uniqueness(
+            user_data.email
+        )
 
         temp_password = generate_temporary_password()
         hashed_password = hash_password(temp_password)


### PR DESCRIPTION
### Summary
Adds `@/lib/validation` (`fields.ts`, `schemas.ts`) so shared name, email, and password rules live in one place. Auth and admin forms import schemas and inferred types instead of duplicating Zod.
### Changes
- **`fields`**: `userDisplayNameField` (trim, length, emoji/regional-indicator refine), `userEmailField` (Zod 4 `check` chain: trim, email, lowercase), `strongPasswordField`.
- **`schemas`**: `signUpSchema`, `signInSchema`, `changePasswordSchema`, `profileNameSchema`, `profileEmailSchema`, `inviteUserSchema`, plus exported `z.infer` types.
- **Updated consumers**: `AuthForm`, `ChangePasswordForm`, `SignInForm`, profile page, `InviteUserDialog` (RHF + `zodResolver`).
### Motivation
- DRY validation and consistent UX across signup, sign-in, profile, password change, and admin invite (closes / supports [#576](https://github.com/rune-org/rune/issues/576)).
- Signup and profile **name** rules align; **email** is normalized consistently on the client.
### Reviewer notes
- Profile email messaging follows the shared `userEmailField` copy; successful parse returns trimmed, lowercased email.
- Client rules should still align with API validation where it matters (e.g. whitespace / name invariants such as [#522](https://github.com/rune-org/rune/issues/522)).
### Test plan
- [x] Sign up: invalid / valid name, email, password.
- [x] Sign in: validation + successful login.
- [x] Profile: save name and email (email change + logout flow).
- [x] Change password: mismatch + success.
- [x] Admin invite: validation, submit, cancel, reopen (reset).



