### PR TITLE
fix(auth): surface specific API validation errors on sign-in

### DIFF
--- a/apps/web/src/components/auth/SignInForm.tsx
+++ b/apps/web/src/components/auth/SignInForm.tsx
@@ -52,8 +52,6 @@ export function SignInForm() {
           const target = getValidatedRedirectTarget(redirectParam);
           router.push(target);
           toast.success("Signed in successfully");
-        } else {
-          toast.error("Failed to sign in");
         }
       });
     });

--- a/apps/web/src/lib/api/error.ts
+++ b/apps/web/src/lib/api/error.ts
@@ -1,22 +1,14 @@
-/**
- * Extracts a human-readable message from an API error value.
- *
- * All API errors in this codebase go through the global `http_exception_handler`
- * which normalises every HTTPException into:
- *   { success: false, message: "...", data: null }
- *
- * So we only need to read `message` — there is no `detail` field on any
- * error response this backend sends to the frontend.
- */
 export function extractApiErrorMessage(
   error: unknown,
   fallback = "An unexpected error occurred. Please try again.",
 ): string {
   if (typeof error !== "object" || error === null) return fallback;
-
-  if ("message" in error && typeof (error as Record<string, unknown>).message === "string") {
-    return (error as { message: string }).message;
+  const e = error as Record<string, unknown>;
+  if (typeof e.message === "string") {
+    if (Array.isArray(e.data) && e.data.length > 0 && e.data.every((v) => typeof v === "string")) {
+      return (e.data as string[]).join(", ");
+    }
+    return e.message;
   }
-
   return fallback;
 }

--- a/apps/web/src/lib/auth.tsx
+++ b/apps/web/src/lib/auth.tsx
@@ -19,6 +19,7 @@ import {
 } from "@/lib/api/auth";
 import { toast } from "@/components/ui/toast";
 import { REFRESH_TOKEN_KEY, ACCESS_EXP_KEY } from "@/lib/auth/constants";
+import { extractApiErrorMessage } from "@/lib/api/error";
 import type { UserResponse } from "@/client/types.gen";
 
 type AuthUser = UserResponse;
@@ -218,7 +219,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
         setLoading(false);
         return true;
       } catch (error) {
-        const errorMessage = getErrorMessage(error);
+        const errorMessage = extractApiErrorMessage(error, "Authentication failed. Please try again.");
 
         // Check for SSO-only account trigger (403 with specific message)
         if (
@@ -248,7 +249,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
         // Auto-login after successful registration
         return await login(email, password);
       } catch (error) {
-        setError(getErrorMessage(error));
+        setError(extractApiErrorMessage(error, "Authentication failed. Please try again."));
         setLoading(false);
         return false;
       }
@@ -288,18 +289,4 @@ export function useAuth() {
   const ctx = useContext(AuthContext);
   if (!ctx) throw new Error("useAuth must be used within AuthProvider");
   return ctx;
-}
-
-function getErrorMessage(err: unknown): string {
-  if (typeof err === "string") return err;
-  if (err && typeof err === "object") {
-    const e = err as Record<string, unknown>;
-    // Try to extract from ApiResponse format (message field)
-    if (typeof e.message === "string") return e.message;
-    // Try to extract detail (alternative error format)
-    if (typeof e.detail === "string") return e.detail;
-    // Check for error field
-    if (typeof e.error === "string") return e.error;
-  }
-  return "Authentication failed. Please try again.";
 }

--- a/apps/web/src/lib/auth.tsx
+++ b/apps/web/src/lib/auth.tsx
@@ -219,7 +219,10 @@ export function AuthProvider({ children }: { children: ReactNode }) {
         setLoading(false);
         return true;
       } catch (error) {
-        const errorMessage = extractApiErrorMessage(error, "Authentication failed. Please try again.");
+        const errorMessage = extractApiErrorMessage(
+          error,
+          "Authentication failed. Please try again.",
+        );
 
         // Check for SSO-only account trigger (403 with specific message)
         if (


### PR DESCRIPTION
Invalid credentials and validation errors on the sign-in page were showing a generic "Validation Error(s)" message instead of the actual error (e.g. "email: value is not a valid email address") so toasts should make more sense now.

This PR updates `extractApiErrorMessage` to prefer `data` over `message` when the API returns field-level validation errors and replaces the private `getErrorMessage` in auth.tsx with the shared utility.