### PR TITLE
fix: normalize persisted timestamps to UTC

### DIFF
--- a/services/api/migrations/versions/2026_04_29_1200_e7f8a9b0c1d2_use_utc_timestamps.py
+++ b/services/api/migrations/versions/2026_04_29_1200_e7f8a9b0c1d2_use_utc_timestamps.py
@@ -1,0 +1,57 @@
+"""use utc-aware timestamps
+
+Revision ID: e7f8a9b0c1d2
+Revises: d1e2f3a4b5c6
+Create Date: 2026-04-29 12:00:00.000000
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+
+# Revision identifiers
+revision: str = "e7f8a9b0c1d2"
+down_revision: Union[str, None] = "d1e2f3a4b5c6"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+TIMESTAMP_COLUMNS = {
+    "samlconfiguration": ("created_at", "updated_at"),
+    "workflows": ("created_at", "updated_at"),
+    "workflow_versions": ("created_at",),
+    "workflow_users": ("created_at", "updated_at"),
+    "workflow_templates": ("created_at", "updated_at"),
+    "workflow_credentials": ("created_at", "updated_at"),
+    "workflow_credential_links": ("created_at", "updated_at"),
+    "credential_shares": ("created_at", "updated_at"),
+    "users": ("created_at", "updated_at", "last_login_at"),
+    "executions": ("created_at", "updated_at", "completed_at"),
+    "scheduled_workflows": ("created_at", "updated_at", "next_run_at"),
+}
+
+
+def _alter_columns(timezone_aware: bool) -> None:
+    bind = op.get_bind()
+    if bind.dialect.name != "postgresql":
+        return
+
+    target_type = (
+        "TIMESTAMP WITH TIME ZONE" if timezone_aware else "TIMESTAMP WITHOUT TIME ZONE"
+    )
+    using_suffix = "AT TIME ZONE 'UTC'"
+
+    for table, columns in TIMESTAMP_COLUMNS.items():
+        for column in columns:
+            op.execute(
+                f'ALTER TABLE "{table}" ALTER COLUMN "{column}" '
+                f'TYPE {target_type} USING "{column}" {using_suffix}'
+            )
+
+
+def upgrade() -> None:
+    _alter_columns(timezone_aware=True)
+
+
+def downgrade() -> None:
+    _alter_columns(timezone_aware=False)

--- a/services/api/src/auth/saml/provisioning.py
+++ b/services/api/src/auth/saml/provisioning.py
@@ -1,9 +1,8 @@
-from datetime import datetime
-
 from sqlmodel import select
 from sqlmodel.ext.asyncio.session import AsyncSession
 
 from src.auth.saml.schemas import SAMLAttributes
+from src.core.datetime import utc_now
 from src.db.models import AuthProvider, SAMLConfiguration, User, UserRole
 
 
@@ -25,7 +24,7 @@ class SAMLProvisioningService:
 
         In all cases ``last_login_at`` is refreshed.
         """
-        now = datetime.now()
+        now = utc_now()
 
         # ------------------------------------------------------------------
         # 1. Primary lookup: NameID + config

--- a/services/api/src/core/datetime.py
+++ b/services/api/src/core/datetime.py
@@ -1,0 +1,35 @@
+from datetime import datetime, timezone
+from typing import Any
+
+from sqlalchemy.types import DateTime, TypeDecorator
+
+
+def utc_now() -> datetime:
+    """Return the current time as a timezone-aware UTC datetime."""
+    return datetime.now(timezone.utc)
+
+
+def ensure_utc(value: datetime | None) -> datetime | None:
+    """Normalize datetimes to UTC, treating legacy naive values as UTC."""
+    if value is None:
+        return None
+    if value.tzinfo is None:
+        return value.replace(tzinfo=timezone.utc)
+    return value.astimezone(timezone.utc)
+
+
+class UTCDateTime(TypeDecorator):
+    """Store datetimes in UTC and always return timezone-aware values."""
+
+    impl = DateTime(timezone=True)
+    cache_ok = True
+
+    def process_bind_param(
+        self, value: datetime | None, dialect: Any
+    ) -> datetime | None:
+        return ensure_utc(value)
+
+    def process_result_value(
+        self, value: datetime | None, dialect: Any
+    ) -> datetime | None:
+        return ensure_utc(value)

--- a/services/api/src/core/token.py
+++ b/services/api/src/core/token.py
@@ -1,10 +1,11 @@
 import secrets
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timedelta
 
 import jwt
 from sqlmodel.ext.asyncio.session import AsyncSession
 
 from src.core.config import get_settings
+from src.core.datetime import utc_now
 from src.core.exceptions import InvalidTokenError, TokenExpiredError
 from src.db.models import User
 
@@ -21,12 +22,12 @@ async def create_access_token(user: User, db: "AsyncSession" = None) -> str:
 
     # Update last_login_at if db session is available
     if db is not None:
-        user.last_login_at = datetime.now()
+        user.last_login_at = utc_now()
         db.add(user)
         await db.commit()
         await db.refresh(user)
 
-    now = datetime.now(timezone.utc)
+    now = utc_now()
     expires_delta = timedelta(minutes=settings.access_token_expire_minutes)
     expire = now + expires_delta
 

--- a/services/api/src/db/models.py
+++ b/services/api/src/db/models.py
@@ -7,6 +7,8 @@ from sqlalchemy import Enum as SQLAlchemyEnum
 from sqlalchemy.dialects.postgresql import JSONB
 from sqlmodel import Field, Relationship, SQLModel
 
+from src.core.datetime import UTCDateTime, utc_now
+
 
 class UserRole(str, Enum):
     """User role enumeration."""
@@ -54,10 +56,15 @@ class AuthProvider(str, Enum):
 class TimestampModel(SQLModel):
     """Base model with created_at and updated_at timestamps."""
 
-    created_at: datetime = Field(default_factory=datetime.now)
+    created_at: datetime = Field(
+        default_factory=utc_now,
+        sa_type=UTCDateTime(),
+        sa_column_kwargs={"nullable": False},
+    )
     updated_at: datetime = Field(
-        default_factory=datetime.now,
-        sa_column_kwargs={"onupdate": datetime.now},
+        default_factory=utc_now,
+        sa_type=UTCDateTime(),
+        sa_column_kwargs={"nullable": False, "onupdate": utc_now},
     )
 
 
@@ -150,7 +157,10 @@ class User(TimestampModel, table=True):
         default=None, foreign_key="samlconfiguration.id"
     )
     is_active: bool = Field(default=True)
-    last_login_at: Optional[datetime] = None
+    last_login_at: Optional[datetime] = Field(
+        default=None,
+        sa_column=Column(UTCDateTime(), nullable=True),
+    )
     must_change_password: bool = Field(
         default=False,
         description="Flag indicating user must change their password",
@@ -250,7 +260,10 @@ class WorkflowVersion(SQLModel, table=True):
         default=None,
         description="User-provided message describing the saved revision",
     )
-    created_at: datetime = Field(default_factory=datetime.now)
+    created_at: datetime = Field(
+        default_factory=utc_now,
+        sa_column=Column(UTCDateTime(), nullable=False),
+    )
 
 
 class WorkflowUser(TimestampModel, table=True):
@@ -414,7 +427,10 @@ class ScheduledWorkflow(TimestampModel, table=True):
         unique=True,
     )
     interval_seconds: int
-    next_run_at: datetime = Field(default_factory=datetime.now)
+    next_run_at: datetime = Field(
+        default_factory=utc_now,
+        sa_column=Column(UTCDateTime(), nullable=False),
+    )
 
     workflow: "Workflow" = Relationship(back_populates="schedule")
 
@@ -430,7 +446,10 @@ class Execution(TimestampModel, table=True):
             SQLAlchemyEnum(ExecutionStatus, name="execution_status", native_enum=True),
         ),
     )
-    completed_at: Optional[datetime] = Field(default=None)
+    completed_at: Optional[datetime] = Field(
+        default=None,
+        sa_column=Column(UTCDateTime(), nullable=True),
+    )
     total_duration_ms: Optional[int] = Field(default=None)
     failure_reason: Optional[str] = Field(default=None)
 

--- a/services/api/src/workflow/service.py
+++ b/services/api/src/workflow/service.py
@@ -4,13 +4,13 @@ import json
 import re
 import uuid
 import zipfile
-from datetime import datetime
 from typing import Any
 
 from sqlalchemy.exc import IntegrityError
 from sqlmodel import col, delete, select
 from sqlmodel.ext.asyncio.session import AsyncSession
 
+from src.core.datetime import utc_now
 from src.core.exceptions import BadRequest, Forbidden, NotFound
 from src.credentials.encryption import get_encryptor
 from src.db.models import (
@@ -698,13 +698,13 @@ class WorkflowService:
                 ScheduledWorkflow(
                     workflow_id=workflow_id,
                     interval_seconds=interval_seconds,
-                    next_run_at=datetime.now(),
+                    next_run_at=utc_now(),
                 )
             )
         else:
             if existing.interval_seconds != interval_seconds:
                 existing.interval_seconds = interval_seconds
-                existing.next_run_at = datetime.now()
+                existing.next_run_at = utc_now()
 
     async def _lock_workflow(self, workflow_id: int) -> Workflow:
         statement = select(Workflow).where(Workflow.id == workflow_id).with_for_update()

--- a/services/api/test/core/test_datetime.py
+++ b/services/api/test/core/test_datetime.py
@@ -1,0 +1,37 @@
+from datetime import datetime, timedelta, timezone
+
+from src.core.datetime import ensure_utc, utc_now
+from src.db.models import Execution, User
+
+
+def test_utc_now_returns_aware_utc_datetime():
+    now = utc_now()
+
+    assert now.tzinfo is timezone.utc
+    assert now.utcoffset() == timedelta(0)
+
+
+def test_ensure_utc_treats_naive_legacy_values_as_utc():
+    value = datetime(2026, 3, 10, 12, 30, 0)
+
+    normalized = ensure_utc(value)
+
+    assert normalized == datetime(2026, 3, 10, 12, 30, 0, tzinfo=timezone.utc)
+
+
+def test_ensure_utc_converts_offsets_to_utc():
+    value = datetime(2026, 3, 10, 14, 30, 0, tzinfo=timezone(timedelta(hours=2)))
+
+    normalized = ensure_utc(value)
+
+    assert normalized == datetime(2026, 3, 10, 12, 30, 0, tzinfo=timezone.utc)
+
+
+def test_model_timestamp_defaults_are_utc_aware():
+    user = User(name="Test User", email="test@example.com", hashed_password="hash")
+    execution = Execution(id="exec-1", workflow_id=1)
+
+    assert user.created_at.tzinfo is timezone.utc
+    assert user.updated_at.tzinfo is timezone.utc
+    assert execution.created_at.tzinfo is timezone.utc
+    assert execution.updated_at.tzinfo is timezone.utc

--- a/services/archivist/src/datetime_utils.py
+++ b/services/archivist/src/datetime_utils.py
@@ -1,0 +1,31 @@
+from datetime import datetime, timezone
+from typing import Any
+
+from sqlalchemy.types import DateTime, TypeDecorator
+
+
+def utc_now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def ensure_utc(value: datetime | None) -> datetime | None:
+    if value is None:
+        return None
+    if value.tzinfo is None:
+        return value.replace(tzinfo=timezone.utc)
+    return value.astimezone(timezone.utc)
+
+
+class UTCDateTime(TypeDecorator):
+    impl = DateTime(timezone=True)
+    cache_ok = True
+
+    def process_bind_param(
+        self, value: datetime | None, dialect: Any
+    ) -> datetime | None:
+        return ensure_utc(value)
+
+    def process_result_value(
+        self, value: datetime | None, dialect: Any
+    ) -> datetime | None:
+        return ensure_utc(value)

--- a/services/archivist/src/models.py
+++ b/services/archivist/src/models.py
@@ -7,6 +7,8 @@ from sqlalchemy import Column
 from sqlalchemy import Enum as SQLAlchemyEnum
 from sqlmodel import Field, SQLModel
 
+from src.datetime_utils import UTCDateTime, ensure_utc, utc_now
+
 # Inline minimal model to avoid importing from the API service.
 # Must stay in sync with services/api/src/db/models.py Execution model.
 
@@ -29,12 +31,18 @@ class Execution(SQLModel, table=True):
             SQLAlchemyEnum(ExecutionStatus, name="execution_status", native_enum=True),
         ),
     )
-    created_at: datetime = Field(default_factory=datetime.now)
-    updated_at: datetime = Field(
-        default_factory=datetime.now,
-        sa_column_kwargs={"onupdate": datetime.now},
+    created_at: datetime = Field(
+        default_factory=utc_now,
+        sa_column=Column(UTCDateTime(), nullable=False),
     )
-    completed_at: Optional[datetime] = Field(default=None)
+    updated_at: datetime = Field(
+        default_factory=utc_now,
+        sa_column=Column(UTCDateTime(), nullable=False, onupdate=utc_now),
+    )
+    completed_at: Optional[datetime] = Field(
+        default=None,
+        sa_column=Column(UTCDateTime(), nullable=True),
+    )
     total_duration_ms: Optional[int] = Field(default=None)
     failure_reason: Optional[str] = Field(default=None)
 
@@ -48,13 +56,7 @@ class CompletionMessage(BaseModel):
     total_duration_ms: int
     failure_reason: Optional[str] = None
 
-    # TODO: We should consider using a custom deserializer that can handle timezone-aware datetimes
-    # and store them as UTC in the database, rather than stripping timezone info here.
-    # This would allow us to preserve timezone information if needed in the future.
     @field_validator("completed_at")
     @classmethod
-    def strip_timezone(cls, v: datetime) -> datetime:
-        """Strip timezone info so the value is compatible with TIMESTAMP WITHOUT TIME ZONE columns."""
-        if v.tzinfo is not None:
-            return v.replace(tzinfo=None)
-        return v
+    def normalize_completed_at(cls, v: datetime) -> datetime:
+        return ensure_utc(v)

--- a/services/rune-worker/pkg/executor/node_handlers.go
+++ b/services/rune-worker/pkg/executor/node_handlers.go
@@ -21,7 +21,7 @@ func (e *Executor) handleWaitNode(ctx context.Context, msg *messages.NodeExecuti
 		Status:           messages.StatusWaiting,
 		Parameters:       params,
 		Output:           output,
-		ExecutedAt:       time.Now(),
+		ExecutedAt:       time.Now().UTC(),
 		DurationMs:       duration.Milliseconds(),
 		AllUsedInputKeys: usedKeys,
 		UsedInputs:       usedInputs,
@@ -63,7 +63,7 @@ func (e *Executor) handleNodeCreationFailure(ctx context.Context, msg *messages.
 		},
 		AllUsedInputKeys: usedKeys,
 		UsedInputs:       usedInputs,
-		ExecutedAt:       time.Now(),
+		ExecutedAt:       time.Now().UTC(),
 		DurationMs:       duration.Milliseconds(),
 	}
 
@@ -97,7 +97,7 @@ func (e *Executor) handleNodeFailure(ctx context.Context, msg *messages.NodeExec
 		},
 		AllUsedInputKeys: usedKeys,
 		UsedInputs:       usedInputs,
-		ExecutedAt:       time.Now(),
+		ExecutedAt:       time.Now().UTC(),
 		DurationMs:       duration.Milliseconds(),
 	}
 
@@ -154,7 +154,7 @@ func (e *Executor) handleNodeSuccess(ctx context.Context, msg *messages.NodeExec
 		Status:           messages.StatusSuccess,
 		Parameters:       params,
 		Output:           output,
-		ExecutedAt:       time.Now(),
+		ExecutedAt:       time.Now().UTC(),
 		DurationMs:       duration.Milliseconds(),
 		AllUsedInputKeys: usedKeys,
 		UsedInputs:       usedInputs,

--- a/services/rune-worker/pkg/executor/publisher.go
+++ b/services/rune-worker/pkg/executor/publisher.go
@@ -22,7 +22,7 @@ func (e *Executor) publishRunningStatus(ctx context.Context, msg *messages.NodeE
 		Parameters:       params,
 		AllUsedInputKeys: usedKeys,
 		UsedInputs:       usedInputs,
-		ExecutedAt:       time.Now(),
+		ExecutedAt:       time.Now().UTC(),
 		DurationMs:       0,
 	}
 
@@ -88,7 +88,7 @@ func (e *Executor) publishCompletion(ctx context.Context, msg *messages.NodeExec
 		ExecutionID:     msg.ExecutionID,
 		Status:          status,
 		FinalContext:    finalContext,
-		CompletedAt:     time.Now(),
+		CompletedAt:     time.Now().UTC(),
 		TotalDurationMs: totalDuration.Milliseconds(),
 	}
 

--- a/services/rune-worker/pkg/messages/completion_message.go
+++ b/services/rune-worker/pkg/messages/completion_message.go
@@ -102,7 +102,7 @@ func NewCompletedMessage(workflowID, executionID string, finalContext map[string
 		ExecutionID:     executionID,
 		Status:          CompletionStatusCompleted,
 		FinalContext:    finalContext,
-		CompletedAt:     time.Now(),
+		CompletedAt:     time.Now().UTC(),
 		TotalDurationMs: totalDurationMs,
 	}
 }
@@ -114,7 +114,7 @@ func NewFailedMessage(workflowID, executionID string, finalContext map[string]in
 		ExecutionID:     executionID,
 		Status:          CompletionStatusFailed,
 		FinalContext:    finalContext,
-		CompletedAt:     time.Now(),
+		CompletedAt:     time.Now().UTC(),
 		TotalDurationMs: totalDurationMs,
 		FailureReason:   reason,
 	}
@@ -127,7 +127,7 @@ func NewHaltedMessage(workflowID, executionID string, finalContext map[string]in
 		ExecutionID:     executionID,
 		Status:          CompletionStatusHalted,
 		FinalContext:    finalContext,
-		CompletedAt:     time.Now(),
+		CompletedAt:     time.Now().UTC(),
 		TotalDurationMs: totalDurationMs,
 		FailureReason:   reason,
 	}

--- a/services/rune-worker/pkg/messages/node_status_message.go
+++ b/services/rune-worker/pkg/messages/node_status_message.go
@@ -135,7 +135,7 @@ func NewRunningStatus(workflowID, executionID, nodeID, nodeName string) *NodeSta
 		NodeID:      nodeID,
 		NodeName:    nodeName,
 		Status:      StatusRunning,
-		ExecutedAt:  time.Now(),
+		ExecutedAt:  time.Now().UTC(),
 		DurationMs:  0,
 	}
 }
@@ -149,7 +149,7 @@ func NewSuccessStatus(workflowID, executionID, nodeID, nodeName string, output m
 		NodeName:    nodeName,
 		Status:      StatusSuccess,
 		Output:      output,
-		ExecutedAt:  time.Now(),
+		ExecutedAt:  time.Now().UTC(),
 		DurationMs:  durationMs,
 	}
 }
@@ -163,7 +163,7 @@ func NewFailedStatus(workflowID, executionID, nodeID, nodeName string, err *Node
 		NodeName:    nodeName,
 		Status:      StatusFailed,
 		Error:       err,
-		ExecutedAt:  time.Now(),
+		ExecutedAt:  time.Now().UTC(),
 		DurationMs:  durationMs,
 	}
 }

--- a/services/rune-worker/pkg/messaging/resume_consumer.go
+++ b/services/rune-worker/pkg/messaging/resume_consumer.go
@@ -181,7 +181,7 @@ func (c *ResumeConsumer) publishWaitSuccessStatus(ctx context.Context, msg *mess
 		Status:      messages.StatusSuccess,
 		Parameters:  params,
 		Output:      output,
-		ExecutedAt:  time.Now(),
+		ExecutedAt:  time.Now().UTC(),
 		DurationMs:  0,
 	}
 

--- a/services/scheduler/src/db.py
+++ b/services/scheduler/src/db.py
@@ -1,5 +1,5 @@
 import asyncio
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
 from src.config import log
 
@@ -25,7 +25,7 @@ UPDATE_NEXT_RUN = """
 
 async def poll(conn, api_client) -> None:
     """Single poll iteration: fetch due schedules and process them."""
-    now = datetime.now()
+    now = datetime.now(timezone.utc)
 
     async with conn.transaction():
         rows = await conn.fetch(FETCH_DUE_SCHEDULES, now)


### PR DESCRIPTION
This normalizes backend timestamp handling around UTC-aware datetimes across the API, archivist, scheduler, and worker. 

Also added a migration that converts existing persisted timestamp columns to timezone-aware Postgres timestamps while treating legacy naive values as UTC.

One tiny quirk: `datetime` and `datetime_utils` are basically replicas atp, I decided it would be safe to keep them this way to not break service isolation. A cleaner way would be a shared internal package for cross-service utils, but I don't think this is urgent especially for this case.

Fixes #417

