### PR TITLE
refactor(worker): reorganize and qualify MCP nodes by provider

### DIFF
--- a/services/rune-worker/pkg/mcp/README.md
+++ b/services/rune-worker/pkg/mcp/README.md
@@ -132,7 +132,9 @@ pkg/mcp/
 # This is a one-time dev step, NOT done at runtime
 ```
 
-### Step 2: Create the integration package with explicit ToolDefs
+### Step 2: Create the integration file with explicit ToolDefs
+
+Each provider gets one directory and one Go package. All services for that provider live as separate `.go` files inside it.
 
 ```go
 // pkg/mcp/integrations/slack/messages.go
@@ -161,13 +163,38 @@ func init() {
 }
 ```
 
-### Step 3: Add the import
+To add a second service under the same provider, create another file in the same package — no new import needed:
 
-In `pkg/registry/init_registry.go`:
+```go
+// pkg/mcp/integrations/slack/channels.go
+package slack
+
+import "rune-worker/pkg/mcp"
+
+func init() {
+    mcp.RegisterIntegration(mcp.IntegrationConfig{
+        Provider: "slack",
+        Service:  "channels",
+        URL:      "http://slack-channels-mcp:3401/mcp",
+        Tools: []mcp.ToolDef{
+            {
+                MCPName:     "create_channel",
+                Description: "Create a new Slack channel",
+            },
+        },
+    })
+}
+```
+
+### Step 3: Add the import (new providers only)
+
+In `pkg/registry/init_registry.go`, add a blank import for the provider package. One import covers all services in that package:
 
 ```go
 _ "rune-worker/pkg/mcp/integrations/slack"
 ```
+
+If you're adding a service to an existing provider (e.g., a new file under `integrations/google/`), the import is already present — skip this step.
 
 ### Step 4: Custom node names (optional)
 

--- a/services/rune-worker/pkg/mcp/README.md
+++ b/services/rune-worker/pkg/mcp/README.md
@@ -21,9 +21,8 @@ graph TB
         MGR[Manager]
 
         subgraph Integrations["pkg/mcp/integrations"]
-            GS["google/sheets<br/>(4 tools)"]
-            GM["google/gmail<br/>(4 tools)"]
-            OL["microsoft/outlook<br/>(3 tools)"]
+            G["google<br/>gmail + sheets"]
+            MS["microsoft<br/>outlook"]
         end
 
         subgraph Bridge["pkg/mcp"]
@@ -39,9 +38,8 @@ graph TB
         S3["Outlook MCP<br/>:3300"]
     end
 
-    GS -->|"init: RegisterIntegration<br/>(with ToolDefs)"| INT
-    GM -->|"init: RegisterIntegration<br/>(with ToolDefs)"| INT
-    OL -->|"init: RegisterIntegration<br/>(with ToolDefs)"| INT
+    G -->|"init: RegisterIntegration<br/>(with ToolDefs)"| INT
+    MS -->|"init: RegisterIntegration<br/>(with ToolDefs)"| INT
 
     INT -->|"RegisterAllTools<br/>(static, no MCP needed)"| REG
     MGR -->|"lazy GetOrConnect"| PRV
@@ -70,9 +68,9 @@ sequenceDiagram
     init->>fn: RegisterAllTools(registry, manager)
     fn->>int: RegisteredIntegrations()
     note over fn: Iterates ToolDefs statically
-    fn->>reg: Register("mcp.gmail.send_email", factory)
-    fn->>reg: Register("mcp.gmail.read_email", factory)
-    fn->>reg: Register("mcp.google_sheets.read_range", factory)
+    fn->>reg: Register("mcp.google.gmail.send_email", factory)
+    fn->>reg: Register("mcp.google.gmail.read_email", factory)
+    fn->>reg: Register("mcp.google.sheets.read_range", factory)
     note over fn: ... all explicitly declared tools
     init-->>main: (registry, mcpManager)
     note over main: No MCP connections opened yet!
@@ -89,11 +87,11 @@ sequenceDiagram
     participant prv as Provider
     participant srv as MCP Server
 
-    exe->>reg: Create("mcp.gmail.send_email", execCtx)
+    exe->>reg: Create("mcp.google.gmail.send_email", execCtx)
     reg-->>exe: MCPNode
     exe->>node: Execute(ctx, execCtx)
-    node->>mgr: GetOrConnect(ctx, "gmail")
-    alt First call to this provider
+    node->>mgr: GetOrConnect(ctx, "google.gmail")
+    alt First call to this integration
         mgr->>prv: NewProvider + ConnectHTTP
         prv->>srv: initialize (JSON-RPC)
         srv-->>prv: server info
@@ -119,10 +117,10 @@ pkg/mcp/
 ├── bridge_test.go                     # Integration tests with in-memory MCP server
 └── integrations/
     ├── google/
-    │   ├── sheets/sheets.go           # 4 tools: read_range, write_range, append_row, create_spreadsheet
-    │   └── gmail/gmail.go             # 4 tools: send_email, read_email, search_emails, list_labels
+    │   ├── sheets.go                  # 4 tools: read_range, write_range, append_row, create_spreadsheet
+    │   └── gmail.go                   # 4 tools: send_email, read_email, search_emails, list_labels
     └── microsoft/
-        └── outlook/outlook.go         # 3 tools: send_email, read_email, list_inbox
+        └── outlook.go                 # 3 tools: send_email, read_email, list_inbox
 ```
 
 ## How to Add an Integration
@@ -137,15 +135,16 @@ pkg/mcp/
 ### Step 2: Create the integration package with explicit ToolDefs
 
 ```go
-// pkg/mcp/integrations/slack/slack.go
+// pkg/mcp/integrations/slack/messages.go
 package slack
 
 import "rune-worker/pkg/mcp"
 
 func init() {
     mcp.RegisterIntegration(mcp.IntegrationConfig{
-        Name: "slack",
-        URL:  "http://slack-mcp:3400/mcp",
+        Provider: "slack",
+        Service:  "messages",
+        URL:      "http://slack-mcp:3400/mcp",
         Tools: []mcp.ToolDef{
             {
                 MCPName:     "send_message",
@@ -177,7 +176,7 @@ Use `NodeName` to override the default naming:
 ```go
 {
     MCPName:     "send_message_v2",  // actual tool name on MCP server
-    NodeName:    "send_message",     // becomes mcp.slack.send_message
+    NodeName:    "send_message",     // becomes mcp.slack.messages.send_message
     Description: "Send a message to a Slack channel",
 },
 ```
@@ -191,7 +190,7 @@ A single workflow can use nodes from different MCP servers:
   "nodes": [
     {
       "id": "1",
-      "type": "mcp.google_sheets.read_range",
+      "type": "mcp.google.sheets.read_range",
       "parameters": {
         "spreadsheet_id": "abc123",
         "range": "Sheet1!A1:B10"
@@ -199,7 +198,7 @@ A single workflow can use nodes from different MCP servers:
     },
     {
       "id": "2",
-      "type": "mcp.outlook.send_email",
+      "type": "mcp.microsoft.outlook.send_email",
       "parameters": {
         "to": "team@company.com",
         "subject": "Report",
@@ -213,7 +212,7 @@ A single workflow can use nodes from different MCP servers:
 ## Connection Lifecycle
 
 - **Startup**: No MCP connections. Tools registered statically from ToolDefs.
-- **First execution**: `GetOrConnect` lazily connects to the MCP server when a workflow first uses a tool from that provider.
+- **First execution**: `GetOrConnect` lazily connects to the MCP server when a workflow first uses a tool from that provider/service integration.
 - **Subsequent executions**: Reuses the cached connection.
 - **Shutdown**: `defer mcpManager.DisconnectAll()` in main.go closes all active sessions.
 
@@ -221,7 +220,8 @@ A single workflow can use nodes from different MCP servers:
 
 1. **No auto-discovery**: Tools must be explicitly declared in Go. This ensures the DSL generator knows all available tools at build time, and users only see curated tools.
 2. **Lazy connections**: MCP servers don't need to be running at worker startup. Connection failures are scoped to the specific workflow execution, not the entire worker.
-3. **Custom naming via NodeName**: The raw MCP tool name can differ from the workflow node name, allowing clean DSL types even when upstream APIs change.
+3. **Provider-qualified node types**: Workflow node types use `mcp.<provider>.<service>.<tool>` to avoid collisions between providers with similarly named services.
+4. **Custom naming via NodeName**: The raw MCP tool name can differ from the workflow node name, allowing clean DSL types even when upstream APIs change.
 
 ## How to Test
 

--- a/services/rune-worker/pkg/mcp/bridge_test.go
+++ b/services/rune-worker/pkg/mcp/bridge_test.go
@@ -71,7 +71,7 @@ func TestProviderConnect(t *testing.T) {
 
 	transport := startTestServer(t, ctx)
 
-	p := NewProvider("test")
+	p := NewProvider("test.provider")
 	if err := p.Connect(ctx, transport); err != nil {
 		t.Fatalf("connect: %v", err)
 	}
@@ -263,17 +263,17 @@ func TestMCPNodeExecute(t *testing.T) {
 	defer p.Disconnect()
 
 	m := &Manager{
-		providers: map[string]*Provider{"test": p},
+		providers: map[string]*Provider{"test.provider": p},
 		configs:   map[string]IntegrationConfig{},
 	}
 
 	execCtx := plugin.ExecutionContext{
 		NodeID:     "node_1",
-		Type:       "mcp.test.echo",
+		Type:       "mcp.test.provider.echo",
 		Parameters: map[string]interface{}{"message": "world"},
 	}
 
-	node := NewMCPNode(m, "test", "echo", execCtx)
+	node := NewMCPNode(m, "test.provider", "echo", execCtx)
 	out, err := node.Execute(ctx, execCtx)
 	if err != nil {
 		t.Fatalf("execute: %v", err)
@@ -289,20 +289,20 @@ func TestMCPNodeExecuteJSON(t *testing.T) {
 
 	transport := startTestServer(t, ctx)
 
-	p := NewProvider("test")
+	p := NewProvider("test.provider")
 	if err := p.Connect(ctx, transport); err != nil {
 		t.Fatalf("connect: %v", err)
 	}
 	defer p.Disconnect()
 
 	m := &Manager{
-		providers: map[string]*Provider{"test": p},
+		providers: map[string]*Provider{"test.provider": p},
 		configs:   map[string]IntegrationConfig{},
 	}
 
 	execCtx := plugin.ExecutionContext{
 		NodeID: "node_2",
-		Type:   "mcp.test.add",
+		Type:   "mcp.test.provider.add",
 		Parameters: map[string]interface{}{
 			"arguments": map[string]interface{}{
 				"a": 10.0,
@@ -311,7 +311,7 @@ func TestMCPNodeExecuteJSON(t *testing.T) {
 		},
 	}
 
-	node := NewMCPNode(m, "test", "add", execCtx)
+	node := NewMCPNode(m, "test.provider", "add", execCtx)
 	out, err := node.Execute(ctx, execCtx)
 	if err != nil {
 		t.Fatalf("execute: %v", err)
@@ -331,8 +331,9 @@ func TestRegisterAllTools(t *testing.T) {
 	defer ResetIntegrations()
 
 	RegisterIntegration(IntegrationConfig{
-		Name: "test",
-		URL:  "http://test:3000/mcp",
+		Provider: "test",
+		Service:  "provider",
+		URL:      "http://test:3000/mcp",
 		Tools: []ToolDef{
 			{MCPName: "echo", Description: "echo tool"},
 			{MCPName: "add", Description: "add tool"},
@@ -346,11 +347,11 @@ func TestRegisterAllTools(t *testing.T) {
 	if count != 2 {
 		t.Fatalf("expected 2 registered tools, got %d", count)
 	}
-	if !reg.types["mcp.test.echo"] {
-		t.Error("expected mcp.test.echo to be registered")
+	if !reg.types["mcp.test.provider.echo"] {
+		t.Error("expected mcp.test.provider.echo to be registered")
 	}
-	if !reg.types["mcp.test.add"] {
-		t.Error("expected mcp.test.add to be registered")
+	if !reg.types["mcp.test.provider.add"] {
+		t.Error("expected mcp.test.provider.add to be registered")
 	}
 }
 
@@ -359,8 +360,9 @@ func TestToolDefCustomNodeName(t *testing.T) {
 	defer ResetIntegrations()
 
 	RegisterIntegration(IntegrationConfig{
-		Name: "test",
-		URL:  "http://test:3000/mcp",
+		Provider: "test",
+		Service:  "provider",
+		URL:      "http://test:3000/mcp",
 		Tools: []ToolDef{
 			{MCPName: "send_email_v2", NodeName: "send_email", Description: "send email"},
 		},
@@ -373,24 +375,28 @@ func TestToolDefCustomNodeName(t *testing.T) {
 	if count != 1 {
 		t.Fatalf("expected 1 registered tool, got %d", count)
 	}
-	if !reg.types["mcp.test.send_email"] {
-		t.Error("expected mcp.test.send_email to be registered (custom NodeName)")
+	if !reg.types["mcp.test.provider.send_email"] {
+		t.Error("expected mcp.test.provider.send_email to be registered (custom NodeName)")
 	}
-	if reg.types["mcp.test.send_email_v2"] {
+	if reg.types["mcp.test.provider.send_email_v2"] {
 		t.Error("should NOT register under raw MCPName when NodeName is set")
 	}
 }
 
 func TestNodeType(t *testing.T) {
-	cfg := IntegrationConfig{Name: "google_sheets", URL: "http://test:3000/mcp"}
+	cfg := IntegrationConfig{Provider: "google", Service: "sheets", URL: "http://test:3000/mcp"}
 
 	tool := ToolDef{MCPName: "write_cell"}
-	if got := cfg.NodeType(tool); got != "mcp.google_sheets.write_cell" {
+	if got := cfg.NodeType(tool); got != "mcp.google.sheets.write_cell" {
 		t.Errorf("got %q", got)
 	}
 
 	toolAliased := ToolDef{MCPName: "write_cell_v2", NodeName: "write_cell"}
-	if got := cfg.NodeType(toolAliased); got != "mcp.google_sheets.write_cell" {
+	if got := cfg.NodeType(toolAliased); got != "mcp.google.sheets.write_cell" {
+		t.Errorf("got %q", got)
+	}
+
+	if got := cfg.Key(); got != "google.sheets" {
 		t.Errorf("got %q", got)
 	}
 }
@@ -400,15 +406,17 @@ func TestIntegrationRegistry(t *testing.T) {
 	defer ResetIntegrations()
 
 	RegisterIntegration(IntegrationConfig{
-		Name: "a",
-		URL:  "http://a:3000/mcp",
+		Provider: "provider_a",
+		Service:  "a",
+		URL:      "http://a:3000/mcp",
 		Tools: []ToolDef{
 			{MCPName: "tool1"},
 		},
 	})
 	RegisterIntegration(IntegrationConfig{
-		Name: "b",
-		URL:  "http://b:3000/mcp",
+		Provider: "provider_b",
+		Service:  "b",
+		URL:      "http://b:3000/mcp",
 		Tools: []ToolDef{
 			{MCPName: "tool2"},
 		},
@@ -418,7 +426,7 @@ func TestIntegrationRegistry(t *testing.T) {
 	if len(list) != 2 {
 		t.Fatalf("expected 2, got %d", len(list))
 	}
-	if list[0].Name != "a" || list[1].Name != "b" {
+	if list[0].Key() != "provider_a.a" || list[1].Key() != "provider_b.b" {
 		t.Errorf("unexpected names: %v", list)
 	}
 }

--- a/services/rune-worker/pkg/mcp/integration.go
+++ b/services/rune-worker/pkg/mcp/integration.go
@@ -16,7 +16,7 @@ type ToolDef struct {
 	MCPName string
 
 	// NodeName is the custom workflow node suffix (e.g. "send_email").
-	// The full node type becomes "mcp.<integration>.<NodeName>".
+	// The full node type becomes "mcp.<provider>.<service>.<NodeName>".
 	// If empty, MCPName is used.
 	NodeName string
 
@@ -35,9 +35,10 @@ func (t ToolDef) FullNodeName() string {
 // IntegrationConfig defines a single MCP-backed integration with
 // explicitly declared tools.
 type IntegrationConfig struct {
-	Name  string    // unique id, used as node namespace (e.g. "gmail")
-	URL   string    // MCP server endpoint (e.g. "http://gmail-mcp:3200/mcp")
-	Tools []ToolDef // explicitly wrapped tools
+	Provider string    // provider id, used in node namespace (e.g. "google")
+	Service  string    // service id, used in node namespace (e.g. "gmail")
+	URL      string    // MCP server endpoint (e.g. "http://gmail-mcp:3200/mcp")
+	Tools    []ToolDef // explicitly wrapped tools
 }
 
 // NodeRegistry is satisfied by nodes.Registry.
@@ -47,7 +48,12 @@ type NodeRegistry interface {
 
 // NodeType returns the full node type for a tool in this integration.
 func (c IntegrationConfig) NodeType(toolDef ToolDef) string {
-	return fmt.Sprintf("mcp.%s.%s", c.Name, toolDef.FullNodeName())
+	return fmt.Sprintf("mcp.%s.%s.%s", c.Provider, c.Service, toolDef.FullNodeName())
+}
+
+// Key returns the unique runtime key for this integration.
+func (c IntegrationConfig) Key() string {
+	return fmt.Sprintf("%s.%s", c.Provider, c.Service)
 }
 
 var (
@@ -82,11 +88,11 @@ func RegisterAllTools(registry NodeRegistry, mgr *Manager) int {
 	for _, cfg := range configs {
 		for _, tool := range cfg.Tools {
 			nodeType := cfg.NodeType(tool)
-			providerName := cfg.Name
+			integrationKey := cfg.Key()
 			mcpToolName := tool.MCPName
 
 			registry.Register(nodeType, func(execCtx plugin.ExecutionContext) plugin.Node {
-				return NewMCPNode(mgr, providerName, mcpToolName, execCtx)
+				return NewMCPNode(mgr, integrationKey, mcpToolName, execCtx)
 			})
 			total++
 		}

--- a/services/rune-worker/pkg/mcp/integrations/google/gmail.go
+++ b/services/rune-worker/pkg/mcp/integrations/google/gmail.go
@@ -1,11 +1,12 @@
-package gmail
+package google
 
 import "rune-worker/pkg/mcp"
 
 func init() {
 	mcp.RegisterIntegration(mcp.IntegrationConfig{
-		Name: "gmail",
-		URL:  "http://gmail-mcp:3200/mcp",
+		Provider: "google",
+		Service:  "gmail",
+		URL:      "http://gmail-mcp:3200/mcp",
 		Tools: []mcp.ToolDef{
 			{
 				MCPName:     "send_email",

--- a/services/rune-worker/pkg/mcp/integrations/google/sheets.go
+++ b/services/rune-worker/pkg/mcp/integrations/google/sheets.go
@@ -1,11 +1,12 @@
-package sheets
+package google
 
 import "rune-worker/pkg/mcp"
 
 func init() {
 	mcp.RegisterIntegration(mcp.IntegrationConfig{
-		Name: "google_sheets",
-		URL:  "http://google-sheets-mcp:3100/mcp",
+		Provider: "google",
+		Service:  "sheets",
+		URL:      "http://google-sheets-mcp:3100/mcp",
 		Tools: []mcp.ToolDef{
 			{
 				MCPName:     "read_range",

--- a/services/rune-worker/pkg/mcp/integrations/microsoft/outlook.go
+++ b/services/rune-worker/pkg/mcp/integrations/microsoft/outlook.go
@@ -1,11 +1,12 @@
-package outlook
+package microsoft
 
 import "rune-worker/pkg/mcp"
 
 func init() {
 	mcp.RegisterIntegration(mcp.IntegrationConfig{
-		Name: "outlook",
-		URL:  "http://outlook-mcp:3300/mcp",
+		Provider: "microsoft",
+		Service:  "outlook",
+		URL:      "http://outlook-mcp:3300/mcp",
 		Tools: []mcp.ToolDef{
 			{
 				MCPName:     "send_email",

--- a/services/rune-worker/pkg/mcp/manager.go
+++ b/services/rune-worker/pkg/mcp/manager.go
@@ -26,7 +26,7 @@ func NewManager() *Manager {
 	}
 	for _, cfg := range configs {
 		if cfg.URL != "" {
-			m.configs[cfg.Name] = cfg
+			m.configs[cfg.Key()] = cfg
 		}
 	}
 	return m
@@ -35,9 +35,9 @@ func NewManager() *Manager {
 // GetOrConnect returns an existing connected provider, or lazily connects
 // to the MCP server on first use. This is the primary entry point used
 // by MCPNode during workflow execution.
-func (m *Manager) GetOrConnect(ctx context.Context, name string) (*Provider, error) {
+func (m *Manager) GetOrConnect(ctx context.Context, key string) (*Provider, error) {
 	// Fast path: already connected
-	if p := m.GetProvider(name); p != nil && p.IsConnected() {
+	if p := m.GetProvider(key); p != nil && p.IsConnected() {
 		return p, nil
 	}
 
@@ -46,22 +46,22 @@ func (m *Manager) GetOrConnect(ctx context.Context, name string) (*Provider, err
 	defer m.mu.Unlock()
 
 	// Double-check after acquiring write lock (do not call GetProvider here — RLock while holding Lock deadlocks)
-	if p := m.getProviderLocked(name); p != nil && p.IsConnected() {
+	if p := m.getProviderLocked(key); p != nil && p.IsConnected() {
 		return p, nil
 	}
 
-	cfg, ok := m.configs[name]
+	cfg, ok := m.configs[key]
 	if !ok {
-		return nil, fmt.Errorf("mcp integration %q not configured", name)
+		return nil, fmt.Errorf("mcp integration %q not configured", key)
 	}
 
-	p := NewProvider(name)
+	p := NewProvider(key)
 	if err := p.ConnectHTTP(ctx, cfg.URL); err != nil {
-		return nil, fmt.Errorf("mcp connect %s: %w", name, err)
+		return nil, fmt.Errorf("mcp connect %s: %w", key, err)
 	}
 
-	m.providers[name] = p
-	slog.Info("mcp provider connected on-demand", "provider", name)
+	m.providers[key] = p
+	slog.Info("mcp provider connected on-demand", "integration", key)
 	return p, nil
 }
 

--- a/services/rune-worker/pkg/mcp/node.go
+++ b/services/rune-worker/pkg/mcp/node.go
@@ -12,21 +12,21 @@ import (
 // MCPNode wraps a remote MCP tool call as a workflow node.
 // The MCP connection is established lazily on first Execute().
 type MCPNode struct {
-	manager      *Manager
-	providerName string
-	toolName     string
-	arguments    map[string]any
-	timeout      time.Duration
+	manager     *Manager
+	integration string
+	toolName    string
+	arguments   map[string]any
+	timeout     time.Duration
 }
 
 // NewMCPNode builds an MCPNode from the execution context.
-func NewMCPNode(manager *Manager, provider, tool string, execCtx plugin.ExecutionContext) *MCPNode {
+func NewMCPNode(manager *Manager, integration, tool string, execCtx plugin.ExecutionContext) *MCPNode {
 	n := &MCPNode{
-		manager:      manager,
-		providerName: provider,
-		toolName:     tool,
-		arguments:    make(map[string]any),
-		timeout:      60 * time.Second,
+		manager:     manager,
+		integration: integration,
+		toolName:    tool,
+		arguments:   make(map[string]any),
+		timeout:     60 * time.Second,
 	}
 
 	// Support both explicit "arguments" map and flat params.
@@ -51,16 +51,16 @@ func NewMCPNode(manager *Manager, provider, tool string, execCtx plugin.Executio
 // Execute connects to the MCP server on-demand and calls the wrapped tool.
 func (n *MCPNode) Execute(ctx context.Context, execCtx plugin.ExecutionContext) (map[string]any, error) {
 	slog.Info("mcp call",
-		"provider", n.providerName,
+		"integration", n.integration,
 		"tool", n.toolName,
 		"node_id", execCtx.NodeID,
 	)
 
 	// Lazy connect — opens the MCP session if this is the first call
-	// to this provider in the current worker lifecycle.
-	p, err := n.manager.GetOrConnect(ctx, n.providerName)
+	// to this integration in the current worker lifecycle.
+	p, err := n.manager.GetOrConnect(ctx, n.integration)
 	if err != nil {
-		return nil, fmt.Errorf("mcp provider %q: %w", n.providerName, err)
+		return nil, fmt.Errorf("mcp integration %q: %w", n.integration, err)
 	}
 
 	callCtx, cancel := context.WithTimeout(ctx, n.timeout)
@@ -68,7 +68,7 @@ func (n *MCPNode) Execute(ctx context.Context, execCtx plugin.ExecutionContext) 
 
 	result, err := p.CallTool(callCtx, n.toolName, n.arguments)
 	if err != nil {
-		return nil, fmt.Errorf("mcp %s.%s: %w", n.providerName, n.toolName, err)
+		return nil, fmt.Errorf("mcp %s.%s: %w", n.integration, n.toolName, err)
 	}
 
 	return ExtractResult(result), nil

--- a/services/rune-worker/pkg/registry/init_registry.go
+++ b/services/rune-worker/pkg/registry/init_registry.go
@@ -5,6 +5,7 @@ import (
 
 	"rune-worker/pkg/mcp"
 	"rune-worker/pkg/nodes"
+
 	// Import all node packages to trigger their init() functions
 	_ "rune-worker/pkg/nodes/custom/aggregator"
 	_ "rune-worker/pkg/nodes/custom/conditional"
@@ -26,10 +27,9 @@ import (
 	_ "rune-worker/pkg/nodes/custom/wait"
 
 	// MCP integrations — blank imports trigger init() which registers
-	// the integration configs with their explicitly declared tools.
-	_ "rune-worker/pkg/mcp/integrations/google/gmail"
-	_ "rune-worker/pkg/mcp/integrations/google/sheets"
-	_ "rune-worker/pkg/mcp/integrations/microsoft/outlook"
+	// the integration configs including their tools.
+	_ "rune-worker/pkg/mcp/integrations/google"
+	_ "rune-worker/pkg/mcp/integrations/microsoft"
 )
 
 // InitializeRegistry creates and populates the node registry with all available node types.

--- a/services/rune-worker/pkg/registry/init_registry_test.go
+++ b/services/rune-worker/pkg/registry/init_registry_test.go
@@ -66,11 +66,11 @@ func TestInitializeRegistryIncludesMCPTools(t *testing.T) {
 
 	// These should be registered from the explicit ToolDef declarations
 	expectedMCP := []string{
-		"mcp.gmail.send_email",
-		"mcp.gmail.read_email",
-		"mcp.google_sheets.read_range",
-		"mcp.google_sheets.append_row",
-		"mcp.outlook.send_email",
+		"mcp.google.gmail.send_email",
+		"mcp.google.gmail.read_email",
+		"mcp.google.sheets.read_range",
+		"mcp.google.sheets.append_row",
+		"mcp.microsoft.outlook.send_email",
 	}
 
 	for _, expected := range expectedMCP {
@@ -78,4 +78,5 @@ func TestInitializeRegistryIncludesMCPTools(t *testing.T) {
 			t.Errorf("expected MCP tool %q to be registered, got types: %v", expected, types)
 		}
 	}
+
 }


### PR DESCRIPTION
Refactors MCP integration registration to use explicit provider and service identifiers, producing node types in the new `mcp.provider.service.tool` format. The runtime manager now keys MCP connections by `provider.service`, while tool calls still use the underlying MCP tool name.

This also flattens provider integration packages and updates registry imports accordingly.