### PR TITLE
fix: update webhook test fixtures to fix CI failures

### DIFF
--- a/services/api/test/webhook/fixtures.py
+++ b/services/api/test/webhook/fixtures.py
@@ -8,7 +8,13 @@ from src.workflow.service import WorkflowService
 
 WEBHOOK_WORKFLOW_DATA = {
     "nodes": [
-        {"id": "t1", "type": "webhook", "trigger": True, "name": "Webhook Trigger"},
+        {
+            "id": "t1",
+            "type": "webhook",
+            "trigger": True,
+            "name": "Webhook Trigger",
+            "webhook_guid": "123e4567-e89b-12d3-a456-426614174000",
+        },
         {"id": "a1", "type": "action", "trigger": False, "name": "Action"},
     ],
     "edges": [{"id": "e1", "src": "t1", "dst": "a1"}],

--- a/services/api/test/workflow/test_webhook_registration.py
+++ b/services/api/test/workflow/test_webhook_registration.py
@@ -8,7 +8,13 @@ from src.db.models import WebhookRegistration
 
 WEBHOOK_WORKFLOW_DATA = {
     "nodes": [
-        {"id": "t1", "type": "webhook", "trigger": True, "name": "Webhook Trigger"},
+        {
+            "id": "t1",
+            "type": "webhook",
+            "trigger": True,
+            "name": "Webhook Trigger",
+            "webhook_guid": "123e4567-e89b-12d3-a456-426614174000",
+        },
         {"id": "a1", "type": "action", "trigger": False, "name": "Action"},
     ],
     "edges": [{"id": "e1", "src": "t1", "dst": "a1"}],


### PR DESCRIPTION
Fixes API CI tests that failed after a field update in PR 594. Added the missing `webhook_guid` field to the webhook trigger node in `WEBHOOK_WORKFLOW_DATA` test fixtures to match the updated application schema and resolve `KeyError: 'webhook_guid'` exceptions.

---
*PR created automatically by Jules for task [9675249851073737174](https://jules.google.com/task/9675249851073737174) started by @ashmod*