### PR TITLE
feat(web): polish agent inspector canvas ui

### DIFF
--- a/apps/web/src/components/shared/CredentialSelector.tsx
+++ b/apps/web/src/components/shared/CredentialSelector.tsx
@@ -18,7 +18,7 @@ import type { CredentialRef } from "@/lib/credentials";
 import { CREDENTIAL_CHANGED_EVENT } from "@/hooks/useCredentialEvents";
 
 interface CredentialSelectorProps {
-  credentialType: CredentialType | CredentialType[];
+  credentialType: CredentialType | ReadonlyArray<CredentialType>;
   value: CredentialRef | null | undefined;
   onChange: (credential: CredentialRef | null) => void;
   label?: string;
@@ -37,7 +37,7 @@ export function CredentialSelector({
   showHelp = false,
 }: CredentialSelectorProps) {
   const [credentials, setCredentials] = useState<CredentialResponseDropDown[]>([]);
-  const [isLoading, setIsLoading] = useState(false);
+  const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [isCreateDialogOpen, setIsCreateDialogOpen] = useState(false);
 
@@ -149,6 +149,7 @@ export function CredentialSelector({
 
   const selectedValue = value?.id ?? "none";
   const isMissing = !!(
+    !isLoading &&
     value?.id &&
     value.id !== "none" &&
     !credentials.some((c) => c.id.toString() === value.id)
@@ -175,9 +176,7 @@ export function CredentialSelector({
         onValueChange={handleValueChange}
         disabled={isLoading}
         onOpenChange={(open) => {
-          if (open) {
-            void fetchCredentials();
-          }
+          if (open && !isLoading) void fetchCredentials();
         }}
       >
         <SelectTrigger

--- a/apps/web/src/features/canvas/components/inspectors/AgentInspector.tsx
+++ b/apps/web/src/features/canvas/components/inspectors/AgentInspector.tsx
@@ -101,28 +101,6 @@ export function AgentInspector({ node, updateData, isExpanded }: AgentInspectorP
     }
   }, [tabRequest, node.id]);
 
-  useEffect(() => {
-    let changed = false;
-    const messages = data.messages?.map((message) => {
-      if (message.ui_id) return message;
-      changed = true;
-      return { ...message, ui_id: createUiId("message") };
-    });
-    const tools = data.tools?.map((tool) => {
-      if (tool.ui_id) return tool;
-      changed = true;
-      return { ...tool, ui_id: createUiId("tool") };
-    });
-
-    if (changed) {
-      updateData(node.id, "agent", (current) => ({
-        ...current,
-        ...(messages && { messages }),
-        ...(tools && { tools }),
-      }));
-    }
-  }, [data.messages, data.tools, node.id, updateData]);
-
   const toolCount = data.tools?.length ?? 0;
   const mcpCount = data.mcp_servers?.length ?? 0;
 

--- a/apps/web/src/features/canvas/components/inspectors/AgentInspector.tsx
+++ b/apps/web/src/features/canvas/components/inspectors/AgentInspector.tsx
@@ -221,7 +221,12 @@ function ModelTab({
             setIsCustomModel(false);
             update((d) => ({
               ...d,
-              model: { ...DEFAULT_GEMINI_MODEL, ...(d.model ?? model), provider: "gemini", name: v },
+              model: {
+                ...DEFAULT_GEMINI_MODEL,
+                ...(d.model ?? model),
+                provider: "gemini",
+                name: v,
+              },
             }));
           }}
         >

--- a/apps/web/src/features/canvas/components/inspectors/AgentInspector.tsx
+++ b/apps/web/src/features/canvas/components/inspectors/AgentInspector.tsx
@@ -26,7 +26,7 @@ import type { CredentialRef } from "@/lib/credentials";
 import type { CredentialType } from "@/client/types.gen";
 import { VariableInput } from "../variable-picker/VariableInput";
 import { ToolCard } from "./agent/ToolCard";
-import { agentTabStore } from "../../stores/agentTabStore";
+import { agentTabStore, isAgentTab, type AgentTab } from "../../stores/agentTabStore";
 
 const GEMINI_BACKEND_LABELS: Record<GeminiBackend, string> = {
   ai_studio: "Google AI Studio",
@@ -49,6 +49,13 @@ const GEMINI_MODEL_PRESETS = [
 ] as const;
 
 const CUSTOM_MODEL_VALUE = "__custom__";
+
+const DEFAULT_GEMINI_MODEL = {
+  provider: "gemini" as AgentProvider,
+  name: GEMINI_MODEL_PRESETS[0],
+  backend: "ai_studio" as GeminiBackend,
+  temperature: 0.2,
+};
 
 function resolveModelSelectValue(name: string | undefined): string {
   if (!name) return GEMINI_MODEL_PRESETS[0];
@@ -76,8 +83,12 @@ export function AgentInspector({ node, updateData, isExpanded }: AgentInspectorP
     updateData(node.id, "agent", updater);
   };
 
-  const tabRequest = useSyncExternalStore(agentTabStore.subscribe, agentTabStore.getSnapshot);
-  const [activeTab, setActiveTab] = useState("model");
+  const tabRequest = useSyncExternalStore(
+    agentTabStore.subscribe,
+    agentTabStore.getSnapshot,
+    agentTabStore.getServerSnapshot,
+  );
+  const [activeTab, setActiveTab] = useState<AgentTab>("model");
 
   useEffect(() => {
     if (tabRequest?.nodeId === node.id) {
@@ -90,7 +101,12 @@ export function AgentInspector({ node, updateData, isExpanded }: AgentInspectorP
   const mcpCount = data.mcp_servers?.length ?? 0;
 
   return (
-    <Tabs value={activeTab} onValueChange={setActiveTab}>
+    <Tabs
+      value={activeTab}
+      onValueChange={(value) => {
+        if (isAgentTab(value)) setActiveTab(value);
+      }}
+    >
       <TabsList className="grid w-full grid-cols-4 h-8">
         <TabsTrigger value="model" className="text-[11px] px-1">
           Model
@@ -150,12 +166,24 @@ function ModelTab({
   isExpanded: boolean;
 }) {
   const data = node.data;
-  const model = data.model ?? {
-    provider: "gemini" as AgentProvider,
-    name: GEMINI_MODEL_PRESETS[0],
-    backend: "ai_studio" as GeminiBackend,
-    temperature: 0.2,
-  };
+  const model =
+    data.model?.provider === "gemini"
+      ? data.model
+      : { ...DEFAULT_GEMINI_MODEL, name: data.model?.name ?? DEFAULT_GEMINI_MODEL.name };
+
+  useEffect(() => {
+    if (data.model?.provider && data.model.provider !== "gemini") {
+      update((d) => ({
+        ...d,
+        model: {
+          ...DEFAULT_GEMINI_MODEL,
+          name: d.model?.name ?? DEFAULT_GEMINI_MODEL.name,
+          temperature: d.model?.temperature ?? DEFAULT_GEMINI_MODEL.temperature,
+        },
+        credential: null,
+      }));
+    }
+  }, [data.model?.provider, update]);
 
   const modelSelectValue = resolveModelSelectValue(model.name);
   const [isCustomModel, setIsCustomModel] = useState(() => modelSelectValue === CUSTOM_MODEL_VALUE);
@@ -191,7 +219,10 @@ function ModelTab({
               return;
             }
             setIsCustomModel(false);
-            update((d) => ({ ...d, model: { ...(d.model ?? model), name: v } }));
+            update((d) => ({
+              ...d,
+              model: { ...DEFAULT_GEMINI_MODEL, ...(d.model ?? model), provider: "gemini", name: v },
+            }));
           }}
         >
           <SelectTrigger className="h-auto min-h-8 py-1.5 text-xs font-mono">
@@ -214,7 +245,15 @@ function ModelTab({
             className="mt-1.5 w-full rounded-[calc(var(--radius)-0.25rem)] border border-input bg-muted/30 px-2 py-1 text-sm font-mono"
             value={model.name ?? ""}
             onChange={(e) =>
-              update((d) => ({ ...d, model: { ...(d.model ?? model), name: e.target.value } }))
+              update((d) => ({
+                ...d,
+                model: {
+                  ...DEFAULT_GEMINI_MODEL,
+                  ...(d.model ?? model),
+                  provider: "gemini",
+                  name: e.target.value,
+                },
+              }))
             }
             placeholder="e.g. gemini-2.0-flash"
             autoFocus
@@ -230,7 +269,12 @@ function ModelTab({
           onValueChange={(v) =>
             update((d) => ({
               ...d,
-              model: { ...(d.model ?? model), backend: v as GeminiBackend },
+              model: {
+                ...DEFAULT_GEMINI_MODEL,
+                ...(d.model ?? model),
+                provider: "gemini",
+                backend: v as GeminiBackend,
+              },
             }))
           }
         >
@@ -265,7 +309,12 @@ function ModelTab({
           onChange={(e) =>
             update((d) => ({
               ...d,
-              model: { ...(d.model ?? model), temperature: Number(e.target.value) },
+              model: {
+                ...DEFAULT_GEMINI_MODEL,
+                ...(d.model ?? model),
+                provider: "gemini",
+                temperature: Number(e.target.value),
+              },
             }))
           }
         />

--- a/apps/web/src/features/canvas/components/inspectors/AgentInspector.tsx
+++ b/apps/web/src/features/canvas/components/inspectors/AgentInspector.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect, useSyncExternalStore } from "react";
+import { useState, useEffect, useRef, useSyncExternalStore } from "react";
 import type { Node } from "@xyflow/react";
 import { Trash2, Plus } from "lucide-react";
 import {
@@ -57,6 +57,10 @@ const DEFAULT_GEMINI_MODEL = {
   temperature: 0.2,
 };
 
+function createUiId(prefix: string): string {
+  return `${prefix}_${crypto.randomUUID()}`;
+}
+
 function resolveModelSelectValue(name: string | undefined): string {
   if (!name) return GEMINI_MODEL_PRESETS[0];
   return (GEMINI_MODEL_PRESETS as readonly string[]).includes(name) ? name : CUSTOM_MODEL_VALUE;
@@ -96,6 +100,28 @@ export function AgentInspector({ node, updateData, isExpanded }: AgentInspectorP
       agentTabStore.consume();
     }
   }, [tabRequest, node.id]);
+
+  useEffect(() => {
+    let changed = false;
+    const messages = data.messages?.map((message) => {
+      if (message.ui_id) return message;
+      changed = true;
+      return { ...message, ui_id: createUiId("message") };
+    });
+    const tools = data.tools?.map((tool) => {
+      if (tool.ui_id) return tool;
+      changed = true;
+      return { ...tool, ui_id: createUiId("tool") };
+    });
+
+    if (changed) {
+      updateData(node.id, "agent", (current) => ({
+        ...current,
+        ...(messages && { messages }),
+        ...(tools && { tools }),
+      }));
+    }
+  }, [data.messages, data.tools, node.id, updateData]);
 
   const toolCount = data.tools?.length ?? 0;
   const mcpCount = data.mcp_servers?.length ?? 0;
@@ -187,10 +213,12 @@ function ModelTab({
 
   const modelSelectValue = resolveModelSelectValue(model.name);
   const [isCustomModel, setIsCustomModel] = useState(() => modelSelectValue === CUSTOM_MODEL_VALUE);
+  const lastCustomModelRef = useRef(modelSelectValue === CUSTOM_MODEL_VALUE ? model.name : "");
 
   useEffect(() => {
     setIsCustomModel(modelSelectValue === CUSTOM_MODEL_VALUE);
-  }, [modelSelectValue, node.id]);
+    if (modelSelectValue === CUSTOM_MODEL_VALUE) lastCustomModelRef.current = model.name;
+  }, [model.name, modelSelectValue, node.id]);
 
   return (
     <div className="space-y-4">
@@ -216,6 +244,15 @@ function ModelTab({
           onValueChange={(v) => {
             if (v === CUSTOM_MODEL_VALUE) {
               setIsCustomModel(true);
+              update((d) => ({
+                ...d,
+                model: {
+                  ...DEFAULT_GEMINI_MODEL,
+                  ...(d.model ?? model),
+                  provider: "gemini",
+                  name: lastCustomModelRef.current,
+                },
+              }));
               return;
             }
             setIsCustomModel(false);
@@ -249,7 +286,8 @@ function ModelTab({
             type="text"
             className="mt-1.5 w-full rounded-[calc(var(--radius)-0.25rem)] border border-input bg-muted/30 px-2 py-1 text-sm font-mono"
             value={model.name ?? ""}
-            onChange={(e) =>
+            onChange={(e) => {
+              lastCustomModelRef.current = e.target.value;
               update((d) => ({
                 ...d,
                 model: {
@@ -258,8 +296,8 @@ function ModelTab({
                   provider: "gemini",
                   name: e.target.value,
                 },
-              }))
-            }
+              }));
+            }}
             placeholder="e.g. gemini-2.0-flash"
             autoFocus
           />
@@ -358,7 +396,8 @@ function PromptTab({
   const updateMsg = (idx: number, patch: Partial<AgentMessage>) =>
     onMessagesChange(messages.map((m, i) => (i === idx ? { ...m, ...patch } : m)));
   const removeMsg = (idx: number) => onMessagesChange(messages.filter((_, i) => i !== idx));
-  const addMsg = () => onMessagesChange([...messages, { role: "user", content: "" }]);
+  const addMsg = () =>
+    onMessagesChange([...messages, { ui_id: createUiId("message"), role: "user", content: "" }]);
 
   return (
     <div className="space-y-4">
@@ -384,7 +423,10 @@ function PromptTab({
           </p>
         )}
         {messages.map((msg, idx) => (
-          <div key={idx} className="space-y-1 rounded border border-border/40 p-2">
+          <div
+            key={msg.ui_id ?? `${msg.role}-${msg.content}`}
+            className="space-y-1 rounded border border-border/40 p-2"
+          >
             <div className="flex items-center gap-2">
               <Select
                 value={msg.role}
@@ -443,6 +485,7 @@ function ToolsTab({
     onChange([
       ...tools,
       {
+        ui_id: createUiId("tool"),
         type: "http_request",
         name: `tool_${tools.length + 1}`,
         description: "",
@@ -466,7 +509,7 @@ function ToolsTab({
       )}
       {tools.map((tool, idx) => (
         <ToolCard
-          key={idx}
+          key={tool.ui_id ?? tool.name}
           tool={tool}
           nodeId={nodeId}
           onChange={(next) => update(idx, next)}

--- a/apps/web/src/features/canvas/components/inspectors/AgentInspector.tsx
+++ b/apps/web/src/features/canvas/components/inspectors/AgentInspector.tsx
@@ -1,9 +1,9 @@
 "use client";
 
+import { useState, useEffect, useSyncExternalStore } from "react";
 import type { Node } from "@xyflow/react";
 import { Trash2, Plus } from "lucide-react";
 import {
-  AGENT_PROVIDERS,
   GEMINI_BACKENDS,
   type AgentData,
   type AgentMcpServer,
@@ -20,17 +20,13 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { CredentialSelector } from "@/components/shared/CredentialSelector";
 import type { CredentialRef } from "@/lib/credentials";
 import type { CredentialType } from "@/client/types.gen";
 import { VariableInput } from "../variable-picker/VariableInput";
-import { HttpToolConfig } from "./agent/HttpToolConfig";
-
-const PROVIDER_LABELS: Record<AgentProvider, string> = {
-  gemini: "Gemini",
-  openai: "OpenAI (coming soon)",
-  anthropic: "Anthropic (coming soon)",
-};
+import { ToolCard } from "./agent/ToolCard";
+import { agentTabStore } from "../../stores/agentTabStore";
 
 const GEMINI_BACKEND_LABELS: Record<GeminiBackend, string> = {
   ai_studio: "Google AI Studio",
@@ -39,9 +35,34 @@ const GEMINI_BACKEND_LABELS: Record<GeminiBackend, string> = {
 
 const MODEL_CREDENTIAL_TYPES_BY_PROVIDER: Record<AgentProvider, CredentialType[]> = {
   gemini: ["gemini_api_key"],
-  openai: ["api_key"], // placeholder until openai_api_key exists
-  anthropic: ["api_key"], // placeholder until anthropic_api_key exists
+  openai: ["api_key"],
+  anthropic: ["api_key"],
 };
+
+const GEMINI_MODEL_PRESETS = [
+  "gemini-3.1-pro-preview",
+  "gemini-3-flash-preview",
+  "gemini-3.1-flash-lite-preview",
+  "gemini-2.5-pro",
+  "gemini-2.5-flash",
+  "gemini-2.5-flash-lite",
+] as const;
+
+const CUSTOM_MODEL_VALUE = "__custom__";
+
+function resolveModelSelectValue(name: string | undefined): string {
+  if (!name) return GEMINI_MODEL_PRESETS[0];
+  return (GEMINI_MODEL_PRESETS as readonly string[]).includes(name) ? name : CUSTOM_MODEL_VALUE;
+}
+
+function TabCount({ count }: { count: number }) {
+  if (count === 0) return null;
+  return (
+    <span className="rounded-full bg-muted px-1 py-px text-[9px] tabular-nums leading-none">
+      {count}
+    </span>
+  );
+}
 
 type AgentInspectorProps = {
   node: Node<AgentData>;
@@ -55,186 +76,265 @@ export function AgentInspector({ node, updateData, isExpanded }: AgentInspectorP
     updateData(node.id, "agent", updater);
   };
 
+  const tabRequest = useSyncExternalStore(agentTabStore.subscribe, agentTabStore.getSnapshot);
+  const [activeTab, setActiveTab] = useState("model");
+
+  useEffect(() => {
+    if (tabRequest?.nodeId === node.id) {
+      setActiveTab(tabRequest.tab);
+      agentTabStore.consume();
+    }
+  }, [tabRequest, node.id]);
+
+  const toolCount = data.tools?.length ?? 0;
+  const mcpCount = data.mcp_servers?.length ?? 0;
+
+  return (
+    <Tabs value={activeTab} onValueChange={setActiveTab}>
+      <TabsList className="grid w-full grid-cols-4 h-8">
+        <TabsTrigger value="model" className="text-[11px] px-1">
+          Model
+        </TabsTrigger>
+        <TabsTrigger value="prompt" className="text-[11px] px-1">
+          Prompt
+        </TabsTrigger>
+        <TabsTrigger value="tools" className="text-[11px] px-1 gap-1">
+          Tools
+          <TabCount count={toolCount} />
+        </TabsTrigger>
+        <TabsTrigger value="mcp" className="text-[11px] px-1 gap-1">
+          MCP
+          <TabCount count={mcpCount} />
+        </TabsTrigger>
+      </TabsList>
+
+      <TabsContent value="model" className="mt-3">
+        <ModelTab node={node} update={update} isExpanded={isExpanded} />
+      </TabsContent>
+
+      <TabsContent value="prompt" className="mt-3">
+        <PromptTab
+          systemPrompt={data.system_prompt ?? ""}
+          messages={data.messages ?? []}
+          nodeId={node.id}
+          onSystemPromptChange={(v) => update((d) => ({ ...d, system_prompt: v }))}
+          onMessagesChange={(messages) => update((d) => ({ ...d, messages }))}
+        />
+      </TabsContent>
+
+      <TabsContent value="tools" className="mt-3">
+        <ToolsTab
+          tools={data.tools ?? []}
+          nodeId={node.id}
+          onChange={(tools) => update((d) => ({ ...d, tools }))}
+        />
+      </TabsContent>
+
+      <TabsContent value="mcp" className="mt-3">
+        <McpTab
+          servers={data.mcp_servers ?? []}
+          onChange={(mcp_servers) => update((d) => ({ ...d, mcp_servers }))}
+        />
+      </TabsContent>
+    </Tabs>
+  );
+}
+
+function ModelTab({
+  node,
+  update,
+  isExpanded,
+}: {
+  node: Node<AgentData>;
+  update: (updater: (d: AgentData) => AgentData) => void;
+  isExpanded: boolean;
+}) {
+  const data = node.data;
   const model = data.model ?? {
     provider: "gemini" as AgentProvider,
-    name: "gemini-3.1-flash-lite-preview",
+    name: GEMINI_MODEL_PRESETS[0],
     backend: "ai_studio" as GeminiBackend,
     temperature: 0.2,
   };
 
+  const modelSelectValue = resolveModelSelectValue(model.name);
+  const [isCustomModel, setIsCustomModel] = useState(() => modelSelectValue === CUSTOM_MODEL_VALUE);
+
+  useEffect(() => {
+    setIsCustomModel(modelSelectValue === CUSTOM_MODEL_VALUE);
+  }, [modelSelectValue, node.id]);
+
   return (
-    <div className="space-y-3">
-      <details
-        className="rounded-[calc(var(--radius)-0.25rem)] border border-border/60 bg-muted/20 p-2"
-        open
-      >
-        <summary className="cursor-pointer text-xs text-muted-foreground">Model</summary>
-        <div className="mt-2 space-y-2">
-          <div className="grid grid-cols-2 gap-2">
-            <div>
-              <label className="block text-xs text-muted-foreground">Provider</label>
-              <Select
-                value={model.provider}
-                onValueChange={(v) =>
-                  update((d) => {
-                    const provider = v as AgentProvider;
-                    // The saved credential may be the wrong type for the new provider; clear it.
-                    return {
-                      ...d,
-                      model: { ...(d.model ?? model), provider },
-                      credential: provider === d.model?.provider ? d.credential : null,
-                    };
-                  })
-                }
-              >
-                <SelectTrigger className="h-8 text-sm">
-                  <SelectValue />
-                </SelectTrigger>
-                <SelectContent>
-                  {AGENT_PROVIDERS.map((p) => (
-                    <SelectItem key={p} value={p} disabled={p !== "gemini"}>
-                      {PROVIDER_LABELS[p]}
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
-            </div>
-            <div>
-              <label className="block text-xs text-muted-foreground">Model name</label>
-              <input
-                type="text"
-                className="w-full rounded-[calc(var(--radius)-0.25rem)] border border-input bg-muted/30 px-2 py-1 text-sm font-mono"
-                value={model.name ?? ""}
-                onChange={(e) =>
-                  update((d) => ({
-                    ...d,
-                    model: { ...(d.model ?? model), name: e.target.value },
-                  }))
-                }
-                placeholder="gemini-3.1-flash-lite-preview"
-              />
-            </div>
-          </div>
-          {model.provider === "gemini" && (
-            <div>
-              <label className="block text-xs text-muted-foreground">Backend</label>
-              <Select
-                value={model.backend ?? "ai_studio"}
-                onValueChange={(v) =>
-                  update((d) => ({
-                    ...d,
-                    model: { ...(d.model ?? model), backend: v as GeminiBackend },
-                  }))
-                }
-              >
-                <SelectTrigger className="h-8 text-sm">
-                  <SelectValue />
-                </SelectTrigger>
-                <SelectContent>
-                  {GEMINI_BACKENDS.map((b) => (
-                    <SelectItem key={b} value={b}>
-                      {GEMINI_BACKEND_LABELS[b]}
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
-            </div>
-          )}
-          <div>
-            <label className="block text-xs text-muted-foreground">Temperature</label>
-            <input
-              type="number"
-              step="0.1"
-              min={0}
-              max={2}
-              className="w-full rounded-[calc(var(--radius)-0.25rem)] border border-input bg-muted/30 px-2 py-1 text-sm"
-              value={model.temperature ?? 0.2}
-              onChange={(e) =>
-                update((d) => ({
-                  ...d,
-                  model: { ...(d.model ?? model), temperature: Number(e.target.value) },
-                }))
-              }
-            />
-          </div>
-          <CredentialSelector
-            credentialType={MODEL_CREDENTIAL_TYPES_BY_PROVIDER[model.provider]}
-            value={data.credential}
-            onChange={(credential: CredentialRef | null) => update((d) => ({ ...d, credential }))}
-            label="API Key"
-            placeholder="Select API key credential"
-            showHelp={isExpanded}
+    <div className="space-y-4">
+      {/* Provider */}
+      <div>
+        <label className="block text-xs text-muted-foreground mb-1.5">Provider</label>
+        <Select value="gemini" onValueChange={() => {}}>
+          <SelectTrigger className="h-8 text-sm">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="gemini">Gemini</SelectItem>
+          </SelectContent>
+        </Select>
+        <p className="mt-1.5 text-[11px] text-muted-foreground/70">More providers coming soon.</p>
+      </div>
+
+      {/* Model name */}
+      <div>
+        <label className="block text-xs text-muted-foreground mb-1.5">Model</label>
+        <Select
+          value={isCustomModel ? CUSTOM_MODEL_VALUE : modelSelectValue}
+          onValueChange={(v) => {
+            if (v === CUSTOM_MODEL_VALUE) {
+              setIsCustomModel(true);
+              return;
+            }
+            setIsCustomModel(false);
+            update((d) => ({ ...d, model: { ...(d.model ?? model), name: v } }));
+          }}
+        >
+          <SelectTrigger className="h-auto min-h-8 py-1.5 text-xs font-mono">
+            <SelectValue className="truncate" />
+          </SelectTrigger>
+          <SelectContent>
+            {GEMINI_MODEL_PRESETS.map((m) => (
+              <SelectItem key={m} value={m} className="font-mono text-xs">
+                {m}
+              </SelectItem>
+            ))}
+            <SelectItem value={CUSTOM_MODEL_VALUE} className="text-xs">
+              Custom…
+            </SelectItem>
+          </SelectContent>
+        </Select>
+        {isCustomModel && (
+          <input
+            type="text"
+            className="mt-1.5 w-full rounded-[calc(var(--radius)-0.25rem)] border border-input bg-muted/30 px-2 py-1 text-sm font-mono"
+            value={model.name ?? ""}
+            onChange={(e) =>
+              update((d) => ({ ...d, model: { ...(d.model ?? model), name: e.target.value } }))
+            }
+            placeholder="e.g. gemini-2.0-flash"
+            autoFocus
           />
+        )}
+      </div>
+
+      {/* Backend (Gemini-specific) */}
+      <div>
+        <label className="block text-xs text-muted-foreground mb-1.5">Backend</label>
+        <Select
+          value={model.backend ?? "ai_studio"}
+          onValueChange={(v) =>
+            update((d) => ({
+              ...d,
+              model: { ...(d.model ?? model), backend: v as GeminiBackend },
+            }))
+          }
+        >
+          <SelectTrigger className="h-8 text-sm">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            {GEMINI_BACKENDS.map((b) => (
+              <SelectItem key={b} value={b}>
+                {GEMINI_BACKEND_LABELS[b]}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
+
+      {/* Temperature slider */}
+      <div>
+        <div className="flex items-center justify-between mb-1.5">
+          <label className="text-xs text-muted-foreground">Temperature</label>
+          <span className="text-xs tabular-nums text-muted-foreground">
+            {(model.temperature ?? 0.2).toFixed(1)}
+          </span>
         </div>
-      </details>
-
-      <details
-        className="rounded-[calc(var(--radius)-0.25rem)] border border-border/60 bg-muted/20 p-2"
-        open={isExpanded}
-      >
-        <summary className="cursor-pointer text-xs text-muted-foreground">System prompt</summary>
-        <div className="mt-2">
-          <VariableInput
-            value={data.system_prompt ?? ""}
-            onChange={(v) => update((d) => ({ ...d, system_prompt: v }))}
-            placeholder="You are a helpful assistant…"
-            nodeId={node.id}
-          />
+        <input
+          type="range"
+          min={0}
+          max={2}
+          step={0.1}
+          className="w-full accent-ring"
+          value={model.temperature ?? 0.2}
+          onChange={(e) =>
+            update((d) => ({
+              ...d,
+              model: { ...(d.model ?? model), temperature: Number(e.target.value) },
+            }))
+          }
+        />
+        <div className="flex justify-between text-[10px] text-muted-foreground/60">
+          <span>Precise</span>
+          <span>Creative</span>
         </div>
-      </details>
+      </div>
 
-      <MessagesSection
-        messages={data.messages ?? []}
-        nodeId={node.id}
-        onChange={(messages) => update((d) => ({ ...d, messages }))}
-      />
-
-      <ToolsSection
-        tools={data.tools ?? []}
-        nodeId={node.id}
-        onChange={(tools) => update((d) => ({ ...d, tools }))}
-      />
-
-      <McpSection
-        servers={data.mcp_servers ?? []}
-        onChange={(mcp_servers) => update((d) => ({ ...d, mcp_servers }))}
+      {/* API Key */}
+      <CredentialSelector
+        credentialType={MODEL_CREDENTIAL_TYPES_BY_PROVIDER[model.provider]}
+        value={data.credential}
+        onChange={(credential: CredentialRef | null) => update((d) => ({ ...d, credential }))}
+        label="API Key"
+        placeholder="Select API key credential"
+        showHelp={isExpanded}
       />
     </div>
   );
 }
 
-function MessagesSection({
+function PromptTab({
+  systemPrompt,
   messages,
   nodeId,
-  onChange,
+  onSystemPromptChange,
+  onMessagesChange,
 }: {
+  systemPrompt: string;
   messages: AgentMessage[];
   nodeId: string;
-  onChange: (next: AgentMessage[]) => void;
+  onSystemPromptChange: (v: string) => void;
+  onMessagesChange: (next: AgentMessage[]) => void;
 }) {
-  const update = (idx: number, patch: Partial<AgentMessage>) =>
-    onChange(messages.map((m, i) => (i === idx ? { ...m, ...patch } : m)));
-  const remove = (idx: number) => onChange(messages.filter((_, i) => i !== idx));
-  const add = () => onChange([...messages, { role: "user", content: "" }]);
+  const updateMsg = (idx: number, patch: Partial<AgentMessage>) =>
+    onMessagesChange(messages.map((m, i) => (i === idx ? { ...m, ...patch } : m)));
+  const removeMsg = (idx: number) => onMessagesChange(messages.filter((_, i) => i !== idx));
+  const addMsg = () => onMessagesChange([...messages, { role: "user", content: "" }]);
 
   return (
-    <details
-      className="rounded-[calc(var(--radius)-0.25rem)] border border-border/60 bg-muted/20 p-2"
-      open
-    >
-      <summary className="cursor-pointer text-xs text-muted-foreground">Messages</summary>
-      <div className="mt-2 space-y-3">
+    <div className="space-y-4">
+      <div>
+        <label className="block text-xs text-muted-foreground">System prompt</label>
+        <div className="mt-1">
+          <VariableInput
+            value={systemPrompt}
+            onChange={onSystemPromptChange}
+            placeholder="You are a helpful assistant…"
+            nodeId={nodeId}
+          />
+        </div>
+      </div>
+
+      <div className="border-t border-border/40" />
+
+      <div className="space-y-2">
+        <label className="block text-xs text-muted-foreground">Messages</label>
         {messages.length === 0 && (
-          <div className="text-xs text-muted-foreground/70">
+          <p className="text-xs text-muted-foreground/70">
             Add at least one user message — it becomes the agent&apos;s next turn.
-          </div>
+          </p>
         )}
         {messages.map((msg, idx) => (
           <div key={idx} className="space-y-1 rounded border border-border/40 p-2">
             <div className="flex items-center gap-2">
               <Select
                 value={msg.role}
-                onValueChange={(v) => update(idx, { role: v as AgentMessage["role"] })}
+                onValueChange={(v) => updateMsg(idx, { role: v as AgentMessage["role"] })}
               >
                 <SelectTrigger className="h-7 w-24 text-xs">
                   <SelectValue />
@@ -247,7 +347,7 @@ function MessagesSection({
               <button
                 type="button"
                 className="ml-auto rounded p-1 text-muted-foreground hover:bg-muted hover:text-foreground"
-                onClick={() => remove(idx)}
+                onClick={() => removeMsg(idx)}
                 aria-label="Remove message"
               >
                 <Trash2 className="h-3.5 w-3.5" />
@@ -255,7 +355,7 @@ function MessagesSection({
             </div>
             <VariableInput
               value={msg.content}
-              onChange={(v) => update(idx, { content: v })}
+              onChange={(v) => updateMsg(idx, { content: v })}
               placeholder="Message content (supports $Node refs)"
               nodeId={nodeId}
             />
@@ -263,17 +363,17 @@ function MessagesSection({
         ))}
         <button
           type="button"
-          onClick={add}
+          onClick={addMsg}
           className="inline-flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground"
         >
           <Plus className="h-3 w-3" /> Add message
         </button>
       </div>
-    </details>
+    </div>
   );
 }
 
-function ToolsSection({
+function ToolsTab({
   tools,
   nodeId,
   onChange,
@@ -304,50 +404,29 @@ function ToolsSection({
     ]);
 
   return (
-    <details
-      className="rounded-[calc(var(--radius)-0.25rem)] border border-border/60 bg-muted/20 p-2"
-      open
-    >
-      <summary className="cursor-pointer text-xs text-muted-foreground">Tools</summary>
-      <div className="mt-2 space-y-3">
-        {tools.length === 0 && (
-          <div className="text-xs text-muted-foreground/70">No tools defined.</div>
-        )}
-        {tools.map((tool, idx) => (
-          <details
-            key={idx}
-            className="rounded border border-border/40 bg-background/40"
-            open={tool.name === "" || tool.description === ""}
-          >
-            <summary className="flex cursor-pointer items-center gap-2 px-2 py-1 text-xs">
-              <span className="font-mono">{tool.name || "(unnamed)"}</span>
-              <span className="text-muted-foreground/70">— http_request</span>
-              <button
-                type="button"
-                className="ml-auto rounded p-1 text-muted-foreground hover:bg-muted hover:text-foreground"
-                onClick={(e) => {
-                  e.preventDefault();
-                  remove(idx);
-                }}
-                aria-label="Remove tool"
-              >
-                <Trash2 className="h-3.5 w-3.5" />
-              </button>
-            </summary>
-            <div className="border-t border-border/40 p-2">
-              <HttpToolConfig tool={tool} onChange={(next) => update(idx, next)} nodeId={nodeId} />
-            </div>
-          </details>
-        ))}
-        <button
-          type="button"
-          onClick={add}
-          className="inline-flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground"
-        >
-          <Plus className="h-3 w-3" /> Add http_request tool
-        </button>
-      </div>
-    </details>
+    <div className="space-y-3">
+      {tools.length === 0 && (
+        <p className="text-xs text-muted-foreground/70">
+          No tools defined. Tools let the agent call external APIs during a run.
+        </p>
+      )}
+      {tools.map((tool, idx) => (
+        <ToolCard
+          key={idx}
+          tool={tool}
+          nodeId={nodeId}
+          onChange={(next) => update(idx, next)}
+          onRemove={() => remove(idx)}
+        />
+      ))}
+      <button
+        type="button"
+        onClick={add}
+        className="inline-flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground"
+      >
+        <Plus className="h-3 w-3" /> Add tool
+      </button>
+    </div>
   );
 }
 
@@ -358,7 +437,7 @@ const MCP_CRED_TYPES: ("header" | "token" | "api_key" | "basic_auth")[] = [
   "basic_auth",
 ];
 
-function McpSection({
+function McpTab({
   servers,
   onChange,
 }: {
@@ -380,69 +459,75 @@ function McpSection({
     ]);
 
   return (
-    <details className="rounded-[calc(var(--radius)-0.25rem)] border border-border/60 bg-muted/20 p-2">
-      <summary className="cursor-pointer text-xs text-muted-foreground">MCP Servers</summary>
-      <div className="mt-2 space-y-3">
-        {servers.length === 0 && (
-          <div className="text-xs text-muted-foreground/70">No MCP servers defined.</div>
-        )}
-        {servers.map((s, idx) => (
-          <div key={idx} className="space-y-2 rounded border border-border/40 p-2">
-            <div className="flex items-center gap-2">
-              <input
-                type="text"
-                className="flex-1 rounded-[calc(var(--radius)-0.25rem)] border border-input bg-muted/30 px-2 py-1 text-sm"
-                value={s.name}
-                onChange={(e) => update(idx, { name: e.target.value })}
-                placeholder="Server name"
-              />
-              <button
-                type="button"
-                className="rounded p-1 text-muted-foreground hover:bg-muted hover:text-foreground"
-                onClick={() => remove(idx)}
-                aria-label="Remove server"
-              >
-                <Trash2 className="h-3.5 w-3.5" />
-              </button>
-            </div>
-            <div className="grid grid-cols-2 gap-2">
-              <Select
-                value={s.transport}
-                onValueChange={(v) => update(idx, { transport: v as AgentMcpServer["transport"] })}
-              >
-                <SelectTrigger className="h-7 text-xs">
-                  <SelectValue />
-                </SelectTrigger>
-                <SelectContent>
-                  <SelectItem value="streamable_http">Streamable HTTP</SelectItem>
-                  <SelectItem value="sse">SSE</SelectItem>
-                </SelectContent>
-              </Select>
-              <input
-                type="text"
-                className="rounded-[calc(var(--radius)-0.25rem)] border border-input bg-muted/30 px-2 py-1 text-sm font-mono"
-                value={s.url}
-                onChange={(e) => update(idx, { url: e.target.value })}
-                placeholder="https://example.com/mcp"
-              />
-            </div>
-            <CredentialSelector
-              credentialType={MCP_CRED_TYPES}
-              value={s.credential ?? undefined}
-              onChange={(credential) => update(idx, { credential })}
-              label="Authentication"
-              placeholder="Optional credential"
+    <div className="space-y-3">
+      {servers.length === 0 && (
+        <p className="text-xs text-muted-foreground/70">
+          No MCP servers defined. Connect MCP servers to give the agent access to external tools.
+        </p>
+      )}
+      {servers.map((s, idx) => (
+        <div key={idx} className="space-y-2 rounded border border-border/40 p-2">
+          <div className="flex items-center gap-2">
+            <input
+              type="text"
+              className="flex-1 rounded-[calc(var(--radius)-0.25rem)] border border-input bg-muted/30 px-2 py-1 text-sm"
+              value={s.name}
+              onChange={(e) => update(idx, { name: e.target.value })}
+              placeholder="Server name"
+            />
+            <button
+              type="button"
+              className="rounded p-1 text-muted-foreground hover:bg-muted hover:text-foreground"
+              onClick={() => remove(idx)}
+              aria-label="Remove server"
+            >
+              <Trash2 className="h-3.5 w-3.5" />
+            </button>
+          </div>
+
+          <div>
+            <label className="block text-xs text-muted-foreground">Transport</label>
+            <Select
+              value={s.transport}
+              onValueChange={(v) => update(idx, { transport: v as AgentMcpServer["transport"] })}
+            >
+              <SelectTrigger className="h-7 text-xs">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="streamable_http">Streamable HTTP</SelectItem>
+                <SelectItem value="sse">SSE</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+
+          <div>
+            <label className="block text-xs text-muted-foreground">URL</label>
+            <input
+              type="text"
+              className="w-full rounded-[calc(var(--radius)-0.25rem)] border border-input bg-muted/30 px-2 py-1 text-sm font-mono"
+              value={s.url}
+              onChange={(e) => update(idx, { url: e.target.value })}
+              placeholder="https://example.com/mcp"
             />
           </div>
-        ))}
-        <button
-          type="button"
-          onClick={add}
-          className="inline-flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground"
-        >
-          <Plus className="h-3 w-3" /> Add MCP server
-        </button>
-      </div>
-    </details>
+
+          <CredentialSelector
+            credentialType={MCP_CRED_TYPES}
+            value={s.credential ?? undefined}
+            onChange={(credential) => update(idx, { credential })}
+            label="Authentication"
+            placeholder="Optional credential"
+          />
+        </div>
+      ))}
+      <button
+        type="button"
+        onClick={add}
+        className="inline-flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground"
+      >
+        <Plus className="h-3 w-3" /> Add MCP server
+      </button>
+    </div>
   );
 }

--- a/apps/web/src/features/canvas/components/inspectors/HttpInspector.tsx
+++ b/apps/web/src/features/canvas/components/inspectors/HttpInspector.tsx
@@ -1,5 +1,5 @@
 import type { Node } from "@xyflow/react";
-import { HTTP_METHODS, isHttpMethod, type HttpData } from "../../types";
+import { HTTP_METHODS, HTTP_CREDENTIAL_TYPES, isHttpMethod, type HttpData } from "../../types";
 import { useUpdateNodeData } from "../../hooks/useUpdateNodeData";
 import { JsonField } from "../JsonField";
 import { KeyValueVariableEditor } from "../KeyValueVariableEditor";
@@ -14,13 +14,6 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 
-const HTTP_CREDENTIAL_TYPES: ("basic_auth" | "header" | "api_key" | "oauth2" | "token")[] = [
-  "basic_auth",
-  "header",
-  "api_key",
-  "oauth2",
-  "token",
-];
 
 type HttpInspectorProps = {
   node: Node<HttpData>;

--- a/apps/web/src/features/canvas/components/inspectors/HttpInspector.tsx
+++ b/apps/web/src/features/canvas/components/inspectors/HttpInspector.tsx
@@ -14,7 +14,6 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 
-
 type HttpInspectorProps = {
   node: Node<HttpData>;
   updateData: ReturnType<typeof useUpdateNodeData>;

--- a/apps/web/src/features/canvas/components/inspectors/agent/FieldWithModeToggle.tsx
+++ b/apps/web/src/features/canvas/components/inspectors/agent/FieldWithModeToggle.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useLayoutEffect, useRef } from "react";
 import {
   AGENT_FIELD_TYPES,
   type AgentFieldMode,
@@ -24,7 +25,11 @@ type FieldWithModeToggleProps = {
   allowedAgentTypes?: readonly AgentFieldType[];
 };
 
-/** Both branches' state is preserved when toggling so users don't lose work. */
+/**
+ * Toggles between a fixed value and an agent-supplied parameter slot.
+ * Both branches' last-known state is preserved in refs so users don't lose
+ * work when switching back and forth.
+ */
 export function FieldWithModeToggle({
   value,
   onChange,
@@ -34,15 +39,19 @@ export function FieldWithModeToggle({
 }: FieldWithModeToggleProps) {
   const isAgent = value.mode === "agent";
 
+  const fixedSnapshot = useRef<AgentFieldMode>({ mode: "fixed", value: "" });
+  const agentSnapshot = useRef<AgentFieldMode>({
+    mode: "agent",
+    agent: { description: "", type: allowedAgentTypes[0] ?? "string", required: true },
+  });
+
+  useLayoutEffect(() => {
+    if (value.mode === "fixed") fixedSnapshot.current = value;
+    else agentSnapshot.current = value;
+  });
+
   const flipMode = () => {
-    if (isAgent) {
-      onChange({ mode: "fixed", value: "" });
-    } else {
-      onChange({
-        mode: "agent",
-        agent: { description: "", type: allowedAgentTypes[0] ?? "string", required: true },
-      });
-    }
+    onChange(isAgent ? fixedSnapshot.current : agentSnapshot.current);
   };
 
   return (

--- a/apps/web/src/features/canvas/components/inspectors/agent/FieldWithModeToggle.tsx
+++ b/apps/web/src/features/canvas/components/inspectors/agent/FieldWithModeToggle.tsx
@@ -25,6 +25,13 @@ type FieldWithModeToggleProps = {
   allowedAgentTypes?: readonly AgentFieldType[];
 };
 
+function fixedDisplayValue(value: unknown): string {
+  if (typeof value === "string" || typeof value === "number" || typeof value === "boolean") {
+    return String(value);
+  }
+  return "";
+}
+
 /**
  * Toggles between a fixed value and an agent-supplied parameter slot.
  * Both branches' last-known state is preserved in refs so users don't lose
@@ -84,7 +91,7 @@ export function FieldWithModeToggle({
         />
       ) : (
         <VariableInput
-          value={typeof value.value === "string" ? value.value : ""}
+          value={fixedDisplayValue(value.value)}
           onChange={(v) => onChange({ mode: "fixed", value: v })}
           placeholder={fixedPlaceholder}
           nodeId={nodeId}

--- a/apps/web/src/features/canvas/components/inspectors/agent/HttpToolConfig.tsx
+++ b/apps/web/src/features/canvas/components/inspectors/agent/HttpToolConfig.tsx
@@ -2,6 +2,7 @@
 
 import { Trash2 } from "lucide-react";
 import {
+  HTTP_CREDENTIAL_TYPES,
   HTTP_METHODS,
   isHttpMethod,
   type AgentHttpToolConfig,
@@ -19,13 +20,6 @@ import {
 } from "@/components/ui/select";
 import { FieldWithModeToggle } from "./FieldWithModeToggle";
 
-const HTTP_CREDENTIAL_TYPES: ("basic_auth" | "header" | "api_key" | "oauth2" | "token")[] = [
-  "basic_auth",
-  "header",
-  "api_key",
-  "oauth2",
-  "token",
-];
 
 type HttpToolConfigProps = {
   tool: AgentTool;
@@ -33,7 +27,6 @@ type HttpToolConfigProps = {
   nodeId: string;
 };
 
-/** Mirrors HttpInspector but routes toggleable fields through FieldWithModeToggle. */
 export function HttpToolConfig({ tool, onChange, nodeId }: HttpToolConfigProps) {
   const cfg = tool.config;
   const patchCfg = (patch: Partial<AgentHttpToolConfig>) => {
@@ -46,29 +39,6 @@ export function HttpToolConfig({ tool, onChange, nodeId }: HttpToolConfigProps) 
 
   return (
     <div className="space-y-3">
-      <div className="space-y-1">
-        <label className="block text-xs text-muted-foreground">Tool name (LLM-visible)</label>
-        <input
-          type="text"
-          className="w-full rounded-[calc(var(--radius)-0.25rem)] border border-input bg-muted/30 px-2 py-1 text-sm font-mono"
-          value={tool.name}
-          onChange={(e) =>
-            onChange({ ...tool, name: e.target.value.replace(/[^a-zA-Z0-9_]/g, "_") })
-          }
-          placeholder="e.g. get_weather"
-        />
-      </div>
-      <div className="space-y-1">
-        <label className="block text-xs text-muted-foreground">Description (LLM-visible)</label>
-        <textarea
-          className="w-full rounded-[calc(var(--radius)-0.25rem)] border border-input bg-muted/30 px-2 py-1 text-sm"
-          rows={2}
-          value={tool.description}
-          onChange={(e) => onChange({ ...tool, description: e.target.value })}
-          placeholder="Describe when the agent should call this tool"
-        />
-      </div>
-
       <CredentialSelector
         credentialType={HTTP_CREDENTIAL_TYPES}
         value={tool.credential ?? undefined}

--- a/apps/web/src/features/canvas/components/inspectors/agent/HttpToolConfig.tsx
+++ b/apps/web/src/features/canvas/components/inspectors/agent/HttpToolConfig.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useEffect } from "react";
 import { Trash2 } from "lucide-react";
 import {
   HTTP_CREDENTIAL_TYPES,
@@ -25,6 +26,10 @@ type HttpToolConfigProps = {
   onChange: (next: AgentTool) => void;
   nodeId: string;
 };
+
+function createFieldUiId(): string {
+  return `field_${crypto.randomUUID()}`;
+}
 
 export function HttpToolConfig({ tool, onChange, nodeId }: HttpToolConfigProps) {
   const cfg = tool.config;
@@ -176,11 +181,21 @@ function KVList({
   keyPlaceholder,
   allowedAgentTypes,
 }: KVListProps) {
+  useEffect(() => {
+    if (items.some((item) => !item.ui_id)) {
+      onChange(items.map((item) => (item.ui_id ? item : { ...item, ui_id: createFieldUiId() })));
+    }
+  }, [items, onChange]);
+
   const update = (idx: number, patch: Partial<AgentKVField>) => {
     onChange(items.map((it, i) => (i === idx ? { ...it, ...patch } : it)));
   };
   const remove = (idx: number) => onChange(items.filter((_, i) => i !== idx));
-  const add = () => onChange([...items, { key: "", value: { mode: "fixed", value: "" } }]);
+  const add = () =>
+    onChange([
+      ...items,
+      { ui_id: createFieldUiId(), key: "", value: { mode: "fixed", value: "" } },
+    ]);
 
   return (
     <details className="rounded-[calc(var(--radius)-0.25rem)] border border-border/60 bg-muted/20 p-2">
@@ -190,7 +205,10 @@ function KVList({
           <div className="text-xs text-muted-foreground/70">No {title.toLowerCase()} defined.</div>
         )}
         {items.map((item, idx) => (
-          <div key={idx} className="space-y-1 rounded border border-border/40 p-2">
+          <div
+            key={item.ui_id ?? item.key}
+            className="space-y-1 rounded border border-border/40 p-2"
+          >
             <div className="flex items-center gap-2">
               <input
                 type="text"

--- a/apps/web/src/features/canvas/components/inspectors/agent/HttpToolConfig.tsx
+++ b/apps/web/src/features/canvas/components/inspectors/agent/HttpToolConfig.tsx
@@ -20,7 +20,6 @@ import {
 } from "@/components/ui/select";
 import { FieldWithModeToggle } from "./FieldWithModeToggle";
 
-
 type HttpToolConfigProps = {
   tool: AgentTool;
   onChange: (next: AgentTool) => void;

--- a/apps/web/src/features/canvas/components/inspectors/agent/HttpToolConfig.tsx
+++ b/apps/web/src/features/canvas/components/inspectors/agent/HttpToolConfig.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { useEffect } from "react";
 import { Trash2 } from "lucide-react";
 import {
   HTTP_CREDENTIAL_TYPES,
@@ -181,12 +180,6 @@ function KVList({
   keyPlaceholder,
   allowedAgentTypes,
 }: KVListProps) {
-  useEffect(() => {
-    if (items.some((item) => !item.ui_id)) {
-      onChange(items.map((item) => (item.ui_id ? item : { ...item, ui_id: createFieldUiId() })));
-    }
-  }, [items, onChange]);
-
   const update = (idx: number, patch: Partial<AgentKVField>) => {
     onChange(items.map((it, i) => (i === idx ? { ...it, ...patch } : it)));
   };

--- a/apps/web/src/features/canvas/components/inspectors/agent/ToolCard.tsx
+++ b/apps/web/src/features/canvas/components/inspectors/agent/ToolCard.tsx
@@ -151,12 +151,35 @@ function updateFixedSection(
   updatedFixed: AgentKVField[],
 ): AgentTool {
   const cfg = tool.config;
-  const agentItems = (cfg[section] ?? []).filter((item) => item.value.mode === "agent");
-  return { ...tool, config: { ...cfg, [section]: [...updatedFixed, ...agentItems] } };
+  const nextItems: AgentKVField[] = [];
+  let fixedIdx = 0;
+
+  for (const item of cfg[section] ?? []) {
+    if (item.value.mode === "agent") {
+      nextItems.push(item);
+      continue;
+    }
+
+    const updated = updatedFixed[fixedIdx];
+    fixedIdx += 1;
+    if (updated) nextItems.push(updated);
+  }
+
+  return {
+    ...tool,
+    config: { ...cfg, [section]: [...nextItems, ...updatedFixed.slice(fixedIdx)] },
+  };
 }
 
 function fixedStr(mode: AgentHttpToolConfig["url"] | AgentKVField["value"]): string {
-  if (mode.mode === "fixed" && typeof mode.value === "string") return mode.value;
+  if (
+    mode.mode === "fixed" &&
+    (typeof mode.value === "string" ||
+      typeof mode.value === "number" ||
+      typeof mode.value === "boolean")
+  ) {
+    return String(mode.value);
+  }
   return "";
 }
 
@@ -392,7 +415,7 @@ const SOURCE_BADGE: Record<string, string> = {
 
 function sourceLabel(source: ParamSource): string {
   if (source === "url") return "url";
-  return source.section === "headers" ? "header" : source.section;
+  return source.section;
 }
 
 function ParameterRow({

--- a/apps/web/src/features/canvas/components/inspectors/agent/ToolCard.tsx
+++ b/apps/web/src/features/canvas/components/inspectors/agent/ToolCard.tsx
@@ -185,7 +185,12 @@ export function ToolCard({ tool, nodeId, onChange, onRemove }: ToolCardProps) {
   const hintTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const params = deriveParams(tool.config);
 
-  useEffect(() => () => { if (hintTimerRef.current) clearTimeout(hintTimerRef.current); }, []);
+  useEffect(
+    () => () => {
+      if (hintTimerRef.current) clearTimeout(hintTimerRef.current);
+    },
+    [],
+  );
 
   const handleNameChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const raw = e.target.value;
@@ -237,12 +242,7 @@ export function ToolCard({ tool, nodeId, onChange, onRemove }: ToolCardProps) {
         />
       </div>
 
-      <ParametersSection
-        tool={tool}
-        params={params}
-        nodeId={nodeId}
-        onChange={onChange}
-      />
+      <ParametersSection tool={tool} params={params} nodeId={nodeId} onChange={onChange} />
 
       <RequestSection tool={tool} nodeId={nodeId} onChange={onChange} />
     </div>
@@ -340,10 +340,7 @@ function ParametersSection({
                 }}
               />
             )}
-            <Select
-              value={newSection}
-              onValueChange={(v) => setNewSection(v as AddSection)}
-            >
+            <Select value={newSection} onValueChange={(v) => setNewSection(v as AddSection)}>
               <SelectTrigger className="h-7 w-32 text-xs">
                 <SelectValue />
               </SelectTrigger>
@@ -363,7 +360,10 @@ function ParametersSection({
             </button>
             <button
               type="button"
-              onClick={() => { setIsAdding(false); setNewName(""); }}
+              onClick={() => {
+                setIsAdding(false);
+                setNewName("");
+              }}
               className="text-[10px] text-muted-foreground hover:text-foreground"
             >
               Cancel
@@ -434,16 +434,11 @@ function ParameterRow({
             type="text"
             className="min-w-0 flex-1 rounded border border-transparent bg-transparent px-1 font-mono text-xs hover:border-input focus:border-input focus:outline-none"
             value={param.name}
-            onChange={(e) =>
-              onUpdate({ name: e.target.value.replace(/[^a-zA-Z0-9_]/g, "_") })
-            }
+            onChange={(e) => onUpdate({ name: e.target.value.replace(/[^a-zA-Z0-9_]/g, "_") })}
             placeholder="param_name"
           />
         )}
-        <Select
-          value={param.type}
-          onValueChange={(v) => onUpdate({ type: v as AgentFieldType })}
-        >
+        <Select value={param.type} onValueChange={(v) => onUpdate({ type: v as AgentFieldType })}>
           <SelectTrigger className="h-6 w-18 text-[10px]">
             <SelectValue />
           </SelectTrigger>
@@ -675,9 +670,7 @@ function FixedKVSection({
         )}
       </summary>
       <div className="mt-2 space-y-2">
-        {items.length === 0 && (
-          <p className="text-xs text-muted-foreground/70">None defined.</p>
-        )}
+        {items.length === 0 && <p className="text-xs text-muted-foreground/70">None defined.</p>}
         {items.map((item, idx) => (
           <div key={idx} className="flex items-start gap-1.5">
             <input

--- a/apps/web/src/features/canvas/components/inspectors/agent/ToolCard.tsx
+++ b/apps/web/src/features/canvas/components/inspectors/agent/ToolCard.tsx
@@ -1,0 +1,717 @@
+"use client";
+
+import { useState, useRef, useEffect } from "react";
+import { Trash2, Plus, ChevronRight } from "lucide-react";
+import {
+  AGENT_FIELD_TYPES,
+  HTTP_CREDENTIAL_TYPES,
+  HTTP_METHODS,
+  isHttpMethod,
+  type AgentFieldType,
+  type AgentHttpToolConfig,
+  type AgentKVField,
+  type AgentTool,
+} from "@/features/canvas/types";
+import { CredentialSelector } from "@/components/shared/CredentialSelector";
+import type { CredentialRef } from "@/lib/credentials";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { VariableInput } from "../../variable-picker/VariableInput";
+import { cn } from "@/lib/cn";
+
+type KVSection = "headers" | "query" | "body";
+type AddSection = KVSection | "url";
+
+type ParamSource = "url" | { section: KVSection; idx: number };
+
+type DerivedParam = {
+  id: string;
+  name: string;
+  source: ParamSource;
+  description: string;
+  type: AgentFieldType;
+  required: boolean;
+};
+
+function deriveParams(cfg: AgentHttpToolConfig): DerivedParam[] {
+  const params: DerivedParam[] = [];
+
+  if (cfg.url.mode === "agent") {
+    params.push({
+      id: "url",
+      name: "url",
+      source: "url",
+      description: cfg.url.agent.description,
+      type: cfg.url.agent.type,
+      required: cfg.url.agent.required,
+    });
+  }
+
+  for (const section of ["headers", "query", "body"] as const) {
+    (cfg[section] ?? []).forEach((field, idx) => {
+      if (field.value.mode === "agent") {
+        params.push({
+          id: `${section}-${idx}`,
+          name: field.key,
+          source: { section, idx },
+          description: field.value.agent.description,
+          type: field.value.agent.type,
+          required: field.value.agent.required,
+        });
+      }
+    });
+  }
+
+  return params;
+}
+
+function patchParam(
+  tool: AgentTool,
+  source: ParamSource,
+  patch: Partial<{ name: string; description: string; type: AgentFieldType; required: boolean }>,
+): AgentTool {
+  const cfg = tool.config;
+
+  if (source === "url") {
+    if (cfg.url.mode !== "agent") return tool;
+    return {
+      ...tool,
+      config: {
+        ...cfg,
+        url: {
+          mode: "agent",
+          agent: {
+            ...cfg.url.agent,
+            ...(patch.description !== undefined && { description: patch.description }),
+            ...(patch.type !== undefined && { type: patch.type }),
+            ...(patch.required !== undefined && { required: patch.required }),
+          },
+        },
+      },
+    };
+  }
+
+  const { section, idx } = source;
+  const items = [...(cfg[section] ?? [])];
+  const item = items[idx];
+  if (!item || item.value.mode !== "agent") return tool;
+
+  items[idx] = {
+    key: patch.name !== undefined ? patch.name : item.key,
+    value: {
+      mode: "agent",
+      agent: {
+        ...item.value.agent,
+        ...(patch.description !== undefined && { description: patch.description }),
+        ...(patch.type !== undefined && { type: patch.type }),
+        ...(patch.required !== undefined && { required: patch.required }),
+      },
+    },
+  };
+
+  return { ...tool, config: { ...cfg, [section]: items } };
+}
+
+function removeParam(tool: AgentTool, source: ParamSource): AgentTool {
+  const cfg = tool.config;
+  if (source === "url") {
+    return { ...tool, config: { ...cfg, url: { mode: "fixed", value: "" } } };
+  }
+  const { section, idx } = source;
+  const items = (cfg[section] ?? []).filter((_, i) => i !== idx);
+  return { ...tool, config: { ...cfg, [section]: items } };
+}
+
+function addParam(tool: AgentTool, name: string, section: AddSection): AgentTool {
+  const cfg = tool.config;
+  if (section === "url") {
+    return {
+      ...tool,
+      config: {
+        ...cfg,
+        url: { mode: "agent", agent: { description: "", type: "string", required: true } },
+      },
+    };
+  }
+  const newField: AgentKVField = {
+    key: name,
+    value: { mode: "agent", agent: { description: "", type: "string", required: true } },
+  };
+  return { ...tool, config: { ...cfg, [section]: [...(cfg[section] ?? []), newField] } };
+}
+
+function updateFixedSection(
+  tool: AgentTool,
+  section: KVSection,
+  updatedFixed: AgentKVField[],
+): AgentTool {
+  const cfg = tool.config;
+  const agentItems = (cfg[section] ?? []).filter((item) => item.value.mode === "agent");
+  return { ...tool, config: { ...cfg, [section]: [...updatedFixed, ...agentItems] } };
+}
+
+function fixedStr(mode: AgentHttpToolConfig["url"] | AgentKVField["value"]): string {
+  if (mode.mode === "fixed" && typeof mode.value === "string") return mode.value;
+  return "";
+}
+
+function urlSummary(url: AgentHttpToolConfig["url"]): string {
+  if (url.mode === "agent") return "param";
+  const v = typeof url.value === "string" ? url.value : "";
+  if (!v) return "—";
+  try {
+    const u = new URL(v);
+    const path = u.pathname !== "/" ? u.pathname : "";
+    return (u.hostname + path).slice(0, 28);
+  } catch {
+    return v.slice(0, 28);
+  }
+}
+
+type ToolCardProps = {
+  tool: AgentTool;
+  nodeId: string;
+  onChange: (next: AgentTool) => void;
+  onRemove: () => void;
+};
+
+export function ToolCard({ tool, nodeId, onChange, onRemove }: ToolCardProps) {
+  const [sanitizeHint, setSanitizeHint] = useState(false);
+  const hintTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const params = deriveParams(tool.config);
+
+  useEffect(() => () => { if (hintTimerRef.current) clearTimeout(hintTimerRef.current); }, []);
+
+  const handleNameChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const raw = e.target.value;
+    const sanitized = raw.replace(/[^a-zA-Z0-9_]/g, "_");
+    if (sanitized !== raw) {
+      setSanitizeHint(true);
+      if (hintTimerRef.current) clearTimeout(hintTimerRef.current);
+      hintTimerRef.current = setTimeout(() => setSanitizeHint(false), 2000);
+    }
+    onChange({ ...tool, name: sanitized });
+  };
+
+  return (
+    <div className="rounded-[calc(var(--radius)-0.25rem)] border border-border/40 bg-background/40">
+      <div className="flex items-center gap-2 px-2 py-1.5">
+        <MethodBadge method={tool.config.method ?? "GET"} />
+        <input
+          type="text"
+          className="min-w-0 flex-1 rounded border border-transparent bg-transparent px-1 font-mono text-xs hover:border-input focus:border-input focus:outline-none"
+          value={tool.name}
+          onChange={handleNameChange}
+          placeholder="tool_name"
+        />
+        <span className="max-w-24 shrink-0 truncate text-[10px] text-muted-foreground/60">
+          {urlSummary(tool.config.url)}
+        </span>
+        <button
+          type="button"
+          className="shrink-0 rounded p-1 text-muted-foreground hover:bg-muted hover:text-foreground"
+          onClick={onRemove}
+          aria-label="Remove tool"
+        >
+          <Trash2 className="h-3.5 w-3.5" />
+        </button>
+      </div>
+
+      <div className="border-t border-border/40 px-2 py-2">
+        {sanitizeHint && (
+          <p className="mb-1 text-[10px] text-muted-foreground/70">
+            Special characters replaced with _
+          </p>
+        )}
+        <textarea
+          className="w-full rounded-[calc(var(--radius)-0.25rem)] border border-input bg-muted/30 px-2 py-1 text-xs"
+          rows={2}
+          value={tool.description}
+          onChange={(e) => onChange({ ...tool, description: e.target.value })}
+          placeholder="Describe when the agent should call this tool…"
+        />
+      </div>
+
+      <ParametersSection
+        tool={tool}
+        params={params}
+        nodeId={nodeId}
+        onChange={onChange}
+      />
+
+      <RequestSection tool={tool} nodeId={nodeId} onChange={onChange} />
+    </div>
+  );
+}
+
+const METHOD_COLORS: Record<string, string> = {
+  GET: "bg-emerald-500/10 text-emerald-400 border-emerald-500/20",
+  POST: "bg-blue-500/10 text-blue-400 border-blue-500/20",
+  PUT: "bg-amber-500/10 text-amber-400 border-amber-500/20",
+  PATCH: "bg-orange-500/10 text-orange-400 border-orange-500/20",
+  DELETE: "bg-red-500/10 text-red-400 border-red-500/20",
+};
+
+function MethodBadge({ method }: { method: string }) {
+  return (
+    <span
+      className={cn(
+        "shrink-0 rounded border px-1.5 py-0.5 text-[10px] font-mono font-medium",
+        METHOD_COLORS[method] ?? "bg-muted/30 text-muted-foreground border-border/40",
+      )}
+    >
+      {method}
+    </span>
+  );
+}
+
+function ParametersSection({
+  tool,
+  params,
+  nodeId,
+  onChange,
+}: {
+  tool: AgentTool;
+  params: DerivedParam[];
+  nodeId: string;
+  onChange: (next: AgentTool) => void;
+}) {
+  const [isAdding, setIsAdding] = useState(false);
+  const [newName, setNewName] = useState("");
+  const [newSection, setNewSection] = useState<AddSection>("query");
+  const urlIsParam = tool.config.url.mode === "agent";
+
+  const handleAdd = () => {
+    const name = newSection === "url" ? "url" : newName.trim().replace(/[^a-zA-Z0-9_]/g, "_");
+    if (!name) return;
+    onChange(addParam(tool, name, newSection));
+    setNewName("");
+    setIsAdding(false);
+  };
+
+  return (
+    <details className="border-t border-border/40" open>
+      <summary className="flex cursor-pointer list-none items-center gap-1.5 px-2 py-1.5 text-xs text-muted-foreground hover:text-foreground">
+        <ChevronRight className="h-3 w-3 shrink-0 transition-transform in-[[open]]:rotate-90" />
+        <span>Parameters</span>
+        {params.length > 0 && (
+          <span className="rounded bg-muted px-1 py-0.5 text-[10px] tabular-nums text-muted-foreground">
+            {params.length}
+          </span>
+        )}
+        <span className="ml-auto text-[10px] text-muted-foreground/60">agent-supplied</span>
+      </summary>
+
+      <div className="space-y-2 px-2 pb-2">
+        {params.length === 0 && !isAdding && (
+          <p className="text-xs text-muted-foreground/70">
+            No parameters yet — the agent will call this tool with fixed inputs only.
+          </p>
+        )}
+
+        {params.map((param) => (
+          <ParameterRow
+            key={param.id}
+            param={param}
+            nodeId={nodeId}
+            onUpdate={(patch) => onChange(patchParam(tool, param.source, patch))}
+            onRemove={() => onChange(removeParam(tool, param.source))}
+          />
+        ))}
+
+        {isAdding ? (
+          <div className="flex flex-wrap items-center gap-1.5">
+            {newSection !== "url" && (
+              <input
+                type="text"
+                autoFocus
+                className="w-28 rounded-[calc(var(--radius)-0.25rem)] border border-input bg-muted/30 px-2 py-1 font-mono text-xs"
+                value={newName}
+                onChange={(e) => setNewName(e.target.value.replace(/[^a-zA-Z0-9_]/g, "_"))}
+                placeholder="param_name"
+                onKeyDown={(e) => {
+                  if (e.key === "Enter") handleAdd();
+                  if (e.key === "Escape") setIsAdding(false);
+                }}
+              />
+            )}
+            <Select
+              value={newSection}
+              onValueChange={(v) => setNewSection(v as AddSection)}
+            >
+              <SelectTrigger className="h-7 w-32 text-xs">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="query">Query param</SelectItem>
+                <SelectItem value="body">Body field</SelectItem>
+                <SelectItem value="headers">Header</SelectItem>
+                {!urlIsParam && <SelectItem value="url">URL</SelectItem>}
+              </SelectContent>
+            </Select>
+            <button
+              type="button"
+              onClick={handleAdd}
+              className="rounded bg-ring px-2 py-1 text-[10px] font-medium text-background hover:opacity-90"
+            >
+              Add
+            </button>
+            <button
+              type="button"
+              onClick={() => { setIsAdding(false); setNewName(""); }}
+              className="text-[10px] text-muted-foreground hover:text-foreground"
+            >
+              Cancel
+            </button>
+          </div>
+        ) : (
+          <button
+            type="button"
+            onClick={() => setIsAdding(true)}
+            className="inline-flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground"
+          >
+            <Plus className="h-3 w-3" /> Add parameter
+          </button>
+        )}
+      </div>
+    </details>
+  );
+}
+
+const SOURCE_BADGE: Record<string, string> = {
+  url: "bg-violet-500/10 text-violet-400 border-violet-500/20",
+  query: "bg-emerald-500/10 text-emerald-400 border-emerald-500/20",
+  body: "bg-blue-500/10 text-blue-400 border-blue-500/20",
+  headers: "bg-amber-500/10 text-amber-400 border-amber-500/20",
+};
+
+function sourceLabel(source: ParamSource): string {
+  if (source === "url") return "url";
+  return source.section === "headers" ? "header" : source.section;
+}
+
+function ParameterRow({
+  param,
+  nodeId,
+  onUpdate,
+  onRemove,
+}: {
+  param: DerivedParam;
+  nodeId: string;
+  onUpdate: (
+    patch: Partial<{
+      name: string;
+      description: string;
+      type: AgentFieldType;
+      required: boolean;
+    }>,
+  ) => void;
+  onRemove: () => void;
+}) {
+  const isUrl = param.source === "url";
+  const label = sourceLabel(param.source);
+
+  return (
+    <div className="space-y-1.5 rounded border border-border/40 bg-muted/10 p-2">
+      <div className="flex items-center gap-1.5">
+        <span
+          className={cn(
+            "shrink-0 rounded border px-1.5 py-0.5 text-[10px] font-mono",
+            SOURCE_BADGE[label] ?? "bg-muted/20 text-muted-foreground border-border/40",
+          )}
+        >
+          {label}
+        </span>
+        {isUrl ? (
+          <span className="flex-1 font-mono text-xs text-muted-foreground">url</span>
+        ) : (
+          <input
+            type="text"
+            className="min-w-0 flex-1 rounded border border-transparent bg-transparent px-1 font-mono text-xs hover:border-input focus:border-input focus:outline-none"
+            value={param.name}
+            onChange={(e) =>
+              onUpdate({ name: e.target.value.replace(/[^a-zA-Z0-9_]/g, "_") })
+            }
+            placeholder="param_name"
+          />
+        )}
+        <Select
+          value={param.type}
+          onValueChange={(v) => onUpdate({ type: v as AgentFieldType })}
+        >
+          <SelectTrigger className="h-6 w-18 text-[10px]">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            {AGENT_FIELD_TYPES.map((t) => (
+              <SelectItem key={t} value={t} className="text-xs">
+                {t}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+        <label className="flex shrink-0 items-center gap-1 text-[10px] text-muted-foreground">
+          <input
+            type="checkbox"
+            checked={param.required}
+            onChange={(e) => onUpdate({ required: e.target.checked })}
+          />
+          req
+        </label>
+        <button
+          type="button"
+          className="shrink-0 rounded p-0.5 text-muted-foreground hover:bg-muted hover:text-foreground"
+          onClick={onRemove}
+          aria-label="Remove parameter"
+        >
+          <Trash2 className="h-3 w-3" />
+        </button>
+      </div>
+      <VariableInput
+        value={param.description}
+        onChange={(v: string) => onUpdate({ description: v })}
+        placeholder="Describe what the agent should provide here…"
+        nodeId={nodeId}
+      />
+    </div>
+  );
+}
+
+function RequestSection({
+  tool,
+  nodeId,
+  onChange,
+}: {
+  tool: AgentTool;
+  nodeId: string;
+  onChange: (next: AgentTool) => void;
+}) {
+  const cfg = tool.config;
+  const patchCfg = (patch: Partial<AgentHttpToolConfig>) =>
+    onChange({ ...tool, config: { ...cfg, ...patch } });
+
+  const fixedHeaders = (cfg.headers ?? []).filter((h) => h.value.mode === "fixed");
+  const fixedQuery = (cfg.query ?? []).filter((q) => q.value.mode === "fixed");
+  const fixedBody = (cfg.body ?? []).filter((b) => b.value.mode === "fixed");
+  const isUrlParam = cfg.url.mode === "agent";
+
+  return (
+    <details className="border-t border-border/40">
+      <summary className="flex cursor-pointer list-none items-center gap-1.5 px-2 py-1.5 text-xs text-muted-foreground hover:text-foreground">
+        <ChevronRight className="h-3 w-3 shrink-0 transition-transform in-[[open]]:rotate-90" />
+        <span>Request</span>
+        <span className="ml-auto text-[10px] text-muted-foreground/60">fixed config</span>
+      </summary>
+
+      <div className="space-y-3 px-2 pb-3">
+        {/* Method + URL */}
+        <div className="space-y-1">
+          <label className="block text-xs text-muted-foreground">Method & URL</label>
+          <div className="flex gap-2">
+            <Select
+              value={cfg.method ?? "GET"}
+              onValueChange={(v) => {
+                if (!isHttpMethod(v)) return;
+                patchCfg({ method: v });
+              }}
+            >
+              <SelectTrigger className="h-8 w-24 shrink-0 text-sm">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {HTTP_METHODS.map((m) => (
+                  <SelectItem key={m} value={m}>
+                    {m}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+            {isUrlParam ? (
+              <div className="flex flex-1 items-center gap-2 rounded-[calc(var(--radius)-0.25rem)] border border-dashed border-border/60 bg-muted/10 px-2 py-1 text-xs text-muted-foreground">
+                <span className="flex-1">URL is a parameter</span>
+                <button
+                  type="button"
+                  className="shrink-0 text-[10px] underline hover:text-foreground"
+                  onClick={() => patchCfg({ url: { mode: "fixed", value: "" } })}
+                >
+                  Make fixed
+                </button>
+              </div>
+            ) : (
+              <div className="min-w-0 flex-1 overflow-hidden">
+                <VariableInput
+                  value={fixedStr(cfg.url)}
+                  onChange={(v: string) => patchCfg({ url: { mode: "fixed", value: v } })}
+                  placeholder="https://api.example.com/path"
+                  nodeId={nodeId}
+                />
+              </div>
+            )}
+          </div>
+        </div>
+
+        <CredentialSelector
+          credentialType={HTTP_CREDENTIAL_TYPES}
+          value={tool.credential ?? undefined}
+          onChange={(credential: CredentialRef | null) => onChange({ ...tool, credential })}
+          label="Authentication"
+          placeholder="Select authentication"
+        />
+
+        <FixedKVSection
+          title="Fixed query params"
+          items={fixedQuery}
+          nodeId={nodeId}
+          keyPlaceholder="Param name"
+          onChange={(updated) => onChange(updateFixedSection(tool, "query", updated))}
+        />
+        <FixedKVSection
+          title="Fixed headers"
+          items={fixedHeaders}
+          nodeId={nodeId}
+          keyPlaceholder="Header name"
+          onChange={(updated) => onChange(updateFixedSection(tool, "headers", updated))}
+        />
+        <FixedKVSection
+          title="Fixed body fields"
+          items={fixedBody}
+          nodeId={nodeId}
+          keyPlaceholder="Field name"
+          onChange={(updated) => onChange(updateFixedSection(tool, "body", updated))}
+        />
+
+        <details className="rounded-[calc(var(--radius)-0.25rem)] border border-border/60 bg-muted/20 p-2">
+          <summary className="cursor-pointer text-xs text-muted-foreground">Advanced</summary>
+          <div className="mt-2 space-y-2 text-xs">
+            <div className="grid grid-cols-2 gap-2">
+              <div>
+                <label className="block text-muted-foreground">Timeout (s)</label>
+                <input
+                  type="number"
+                  className="mt-0.5 w-full rounded-[calc(var(--radius)-0.25rem)] border border-input bg-muted/30 px-2 py-1"
+                  value={cfg.timeout ?? "30"}
+                  onChange={(e) => patchCfg({ timeout: e.target.value })}
+                />
+              </div>
+              <div>
+                <label className="block text-muted-foreground">Retries</label>
+                <input
+                  type="number"
+                  min={0}
+                  className="mt-0.5 w-full rounded-[calc(var(--radius)-0.25rem)] border border-input bg-muted/30 px-2 py-1"
+                  value={cfg.retry ?? "0"}
+                  onChange={(e) => patchCfg({ retry: e.target.value })}
+                />
+              </div>
+            </div>
+            <div>
+              <label className="block text-muted-foreground">Retry delay (s)</label>
+              <input
+                type="number"
+                min={0}
+                className="mt-0.5 w-full rounded-[calc(var(--radius)-0.25rem)] border border-input bg-muted/30 px-2 py-1"
+                value={cfg.retry_delay ?? "0"}
+                onChange={(e) => patchCfg({ retry_delay: e.target.value })}
+              />
+            </div>
+            <div>
+              <label className="block text-muted-foreground">Raise on status</label>
+              <input
+                type="text"
+                className="mt-0.5 w-full rounded-[calc(var(--radius)-0.25rem)] border border-input bg-muted/30 px-2 py-1 font-mono text-[11px]"
+                value={cfg.raise_on_status ?? ""}
+                onChange={(e) =>
+                  patchCfg({
+                    raise_on_status: e.target.value.trim() === "" ? undefined : e.target.value,
+                  })
+                }
+                placeholder="e.g. 4xx, 5xx, 403"
+              />
+            </div>
+            <label className="flex items-center gap-2">
+              <input
+                type="checkbox"
+                checked={cfg.ignore_ssl ?? false}
+                onChange={(e) => patchCfg({ ignore_ssl: e.target.checked })}
+              />
+              Ignore SSL
+            </label>
+          </div>
+        </details>
+      </div>
+    </details>
+  );
+}
+
+function FixedKVSection({
+  title,
+  items,
+  nodeId,
+  keyPlaceholder,
+  onChange,
+}: {
+  title: string;
+  items: AgentKVField[];
+  nodeId: string;
+  keyPlaceholder?: string;
+  onChange: (next: AgentKVField[]) => void;
+}) {
+  const update = (idx: number, patch: Partial<AgentKVField>) =>
+    onChange(items.map((it, i) => (i === idx ? { ...it, ...patch } : it)));
+  const remove = (idx: number) => onChange(items.filter((_, i) => i !== idx));
+  const add = () => onChange([...items, { key: "", value: { mode: "fixed", value: "" } }]);
+
+  return (
+    <details className="rounded-[calc(var(--radius)-0.25rem)] border border-border/60 bg-muted/20 p-2">
+      <summary className="cursor-pointer text-xs text-muted-foreground">
+        {title}
+        {items.length > 0 && (
+          <span className="ml-1.5 tabular-nums text-muted-foreground/60">({items.length})</span>
+        )}
+      </summary>
+      <div className="mt-2 space-y-2">
+        {items.length === 0 && (
+          <p className="text-xs text-muted-foreground/70">None defined.</p>
+        )}
+        {items.map((item, idx) => (
+          <div key={idx} className="flex items-start gap-1.5">
+            <input
+              type="text"
+              className="w-24 shrink-0 rounded-[calc(var(--radius)-0.25rem)] border border-input bg-muted/30 px-2 py-1 text-xs"
+              value={item.key}
+              onChange={(e) => update(idx, { key: e.target.value })}
+              placeholder={keyPlaceholder}
+            />
+            <div className="min-w-0 flex-1 overflow-hidden">
+              <VariableInput
+                value={fixedStr(item.value)}
+                onChange={(v: string) => update(idx, { value: { mode: "fixed", value: v } })}
+                nodeId={nodeId}
+              />
+            </div>
+            <button
+              type="button"
+              className="shrink-0 rounded p-1 text-muted-foreground hover:bg-muted hover:text-foreground"
+              onClick={() => remove(idx)}
+              aria-label="Remove"
+            >
+              <Trash2 className="h-3 w-3" />
+            </button>
+          </div>
+        ))}
+        <button
+          type="button"
+          onClick={add}
+          className="text-xs text-muted-foreground hover:text-foreground"
+        >
+          + Add
+        </button>
+      </div>
+    </details>
+  );
+}

--- a/apps/web/src/features/canvas/components/inspectors/agent/ToolCard.tsx
+++ b/apps/web/src/features/canvas/components/inspectors/agent/ToolCard.tsx
@@ -684,12 +684,6 @@ function FixedKVSection({
   keyPlaceholder?: string;
   onChange: (next: AgentKVField[]) => void;
 }) {
-  useEffect(() => {
-    if (items.some((item) => !item.ui_id)) {
-      onChange(items.map((item) => (item.ui_id ? item : { ...item, ui_id: createFieldUiId() })));
-    }
-  }, [items, onChange]);
-
   const update = (idx: number, patch: Partial<AgentKVField>) =>
     onChange(items.map((it, i) => (i === idx ? { ...it, ...patch } : it)));
   const remove = (idx: number) => onChange(items.filter((_, i) => i !== idx));

--- a/apps/web/src/features/canvas/components/inspectors/agent/ToolCard.tsx
+++ b/apps/web/src/features/canvas/components/inspectors/agent/ToolCard.tsx
@@ -234,7 +234,7 @@ export function ToolCard({ tool, nodeId, onChange, onRemove }: ToolCardProps) {
           </p>
         )}
         <textarea
-          className="w-full rounded-[calc(var(--radius)-0.25rem)] border border-input bg-muted/30 px-2 py-1 text-xs"
+          className="w-full resize-y rounded-[calc(var(--radius)-0.25rem)] border border-input bg-muted/30 px-2 py-1 text-xs"
           rows={2}
           value={tool.description}
           onChange={(e) => onChange({ ...tool, description: e.target.value })}
@@ -287,7 +287,7 @@ function ParametersSection({
   const urlIsParam = tool.config.url.mode === "agent";
 
   const handleAdd = () => {
-    const name = newSection === "url" ? "url" : newName.trim().replace(/[^a-zA-Z0-9_]/g, "_");
+    const name = newSection === "url" ? "url" : newName.trim();
     if (!name) return;
     onChange(addParam(tool, name, newSection));
     setNewName("");
@@ -332,8 +332,8 @@ function ParametersSection({
                 autoFocus
                 className="w-28 rounded-[calc(var(--radius)-0.25rem)] border border-input bg-muted/30 px-2 py-1 font-mono text-xs"
                 value={newName}
-                onChange={(e) => setNewName(e.target.value.replace(/[^a-zA-Z0-9_]/g, "_"))}
-                placeholder="param_name"
+                onChange={(e) => setNewName(e.target.value)}
+                placeholder="Header-Name"
                 onKeyDown={(e) => {
                   if (e.key === "Enter") handleAdd();
                   if (e.key === "Escape") setIsAdding(false);
@@ -434,8 +434,8 @@ function ParameterRow({
             type="text"
             className="min-w-0 flex-1 rounded border border-transparent bg-transparent px-1 font-mono text-xs hover:border-input focus:border-input focus:outline-none"
             value={param.name}
-            onChange={(e) => onUpdate({ name: e.target.value.replace(/[^a-zA-Z0-9_]/g, "_") })}
-            placeholder="param_name"
+            onChange={(e) => onUpdate({ name: e.target.value })}
+            placeholder="Header-Name"
           />
         )}
         <Select value={param.type} onValueChange={(v) => onUpdate({ type: v as AgentFieldType })}>

--- a/apps/web/src/features/canvas/components/inspectors/agent/ToolCard.tsx
+++ b/apps/web/src/features/canvas/components/inspectors/agent/ToolCard.tsx
@@ -38,6 +38,10 @@ type DerivedParam = {
   required: boolean;
 };
 
+function createFieldUiId(): string {
+  return `field_${crypto.randomUUID()}`;
+}
+
 function deriveParams(cfg: AgentHttpToolConfig): DerivedParam[] {
   const params: DerivedParam[] = [];
 
@@ -56,7 +60,7 @@ function deriveParams(cfg: AgentHttpToolConfig): DerivedParam[] {
     (cfg[section] ?? []).forEach((field, idx) => {
       if (field.value.mode === "agent") {
         params.push({
-          id: `${section}-${idx}`,
+          id: field.ui_id ?? `${section}-${idx}`,
           name: field.key,
           source: { section, idx },
           description: field.value.agent.description,
@@ -139,6 +143,7 @@ function addParam(tool: AgentTool, name: string, section: AddSection): AgentTool
     };
   }
   const newField: AgentKVField = {
+    ui_id: createFieldUiId(),
     key: name,
     value: { mode: "agent", agent: { description: "", type: "string", required: true } },
   };
@@ -679,10 +684,20 @@ function FixedKVSection({
   keyPlaceholder?: string;
   onChange: (next: AgentKVField[]) => void;
 }) {
+  useEffect(() => {
+    if (items.some((item) => !item.ui_id)) {
+      onChange(items.map((item) => (item.ui_id ? item : { ...item, ui_id: createFieldUiId() })));
+    }
+  }, [items, onChange]);
+
   const update = (idx: number, patch: Partial<AgentKVField>) =>
     onChange(items.map((it, i) => (i === idx ? { ...it, ...patch } : it)));
   const remove = (idx: number) => onChange(items.filter((_, i) => i !== idx));
-  const add = () => onChange([...items, { key: "", value: { mode: "fixed", value: "" } }]);
+  const add = () =>
+    onChange([
+      ...items,
+      { ui_id: createFieldUiId(), key: "", value: { mode: "fixed", value: "" } },
+    ]);
 
   return (
     <details className="rounded-[calc(var(--radius)-0.25rem)] border border-border/60 bg-muted/20 p-2">
@@ -695,7 +710,7 @@ function FixedKVSection({
       <div className="mt-2 space-y-2">
         {items.length === 0 && <p className="text-xs text-muted-foreground/70">None defined.</p>}
         {items.map((item, idx) => (
-          <div key={idx} className="flex items-start gap-1.5">
+          <div key={item.ui_id ?? item.key} className="flex items-start gap-1.5">
             <input
               type="text"
               className="w-24 shrink-0 rounded-[calc(var(--radius)-0.25rem)] border border-input bg-muted/30 px-2 py-1 text-xs"

--- a/apps/web/src/features/canvas/lib/agentDataNormalization.ts
+++ b/apps/web/src/features/canvas/lib/agentDataNormalization.ts
@@ -1,0 +1,58 @@
+import type { AgentData, AgentKVField, AgentMessage, AgentTool } from "@/features/canvas/types";
+
+function createAgentUiId(prefix: string): string {
+  return `${prefix}_${crypto.randomUUID()}`;
+}
+
+export function stripAgentMessageUiId(message: AgentMessage): AgentMessage {
+  const next = { ...message };
+  delete next.ui_id;
+  return next;
+}
+
+export function stripAgentKvFieldUiId(field: AgentKVField): AgentKVField {
+  const next = { ...field };
+  delete next.ui_id;
+  return next;
+}
+
+export function stripAgentToolUiId(tool: AgentTool): AgentTool {
+  const next = { ...tool };
+  delete next.ui_id;
+  next.config = {
+    ...next.config,
+    headers: next.config.headers?.map(stripAgentKvFieldUiId),
+    query: next.config.query?.map(stripAgentKvFieldUiId),
+    body: next.config.body?.map(stripAgentKvFieldUiId),
+  };
+  return next;
+}
+
+export function hydrateAgentMessages(messages: unknown): AgentData["messages"] {
+  if (!Array.isArray(messages)) return undefined;
+  return (messages as AgentMessage[]).map((message) =>
+    message.ui_id ? message : { ...message, ui_id: createAgentUiId("message") },
+  );
+}
+
+export function hydrateAgentKvFields(
+  fields: AgentKVField[] | undefined,
+): AgentKVField[] | undefined {
+  return fields?.map((field) =>
+    field.ui_id ? field : { ...field, ui_id: createAgentUiId("field") },
+  );
+}
+
+export function hydrateAgentTools(tools: unknown): AgentData["tools"] {
+  if (!Array.isArray(tools)) return undefined;
+  return (tools as AgentTool[]).map((tool) => ({
+    ...tool,
+    ui_id: tool.ui_id ?? createAgentUiId("tool"),
+    config: {
+      ...tool.config,
+      headers: hydrateAgentKvFields(tool.config.headers),
+      query: hydrateAgentKvFields(tool.config.query),
+      body: hydrateAgentKvFields(tool.config.body),
+    },
+  }));
+}

--- a/apps/web/src/features/canvas/lib/nodeRegistry.ts
+++ b/apps/web/src/features/canvas/lib/nodeRegistry.ts
@@ -153,7 +153,7 @@ export const NODE_REGISTRY: NodeRegistry = {
       bg: "--node-agent-bg",
       border: "--node-agent-border",
     },
-    dimensions: { width: 220, height: 80 },
+    dimensions: { width: 260, height: 132 },
     defaults: {
       label: "Agent",
       model: {

--- a/apps/web/src/features/canvas/nodes/AgentNode.tsx
+++ b/apps/web/src/features/canvas/nodes/AgentNode.tsx
@@ -12,9 +12,12 @@ export const AgentNode = memo(function AgentNode({ id, data }: NodeProps<Node<Ag
   const toolCount = data.tools?.length ?? 0;
   const mcpCount = data.mcp_servers?.length ?? 0;
 
-  const handleBlockClick = useCallback((tab: string) => {
-    agentTabStore.request(id, tab);
-  }, [id]);
+  const handleBlockClick = useCallback(
+    (tab: string) => {
+      agentTabStore.request(id, tab);
+    },
+    [id],
+  );
 
   return (
     <BaseNode
@@ -31,9 +34,26 @@ export const AgentNode = memo(function AgentNode({ id, data }: NodeProps<Node<Ag
       <div className="mt-2 border-t border-border/40" />
 
       <div className="mt-2 grid grid-cols-3 gap-1">
-        <MiniBlock icon={<MessageSquare className="h-3 w-3" />} label="Prompt" tab="prompt" onClick={handleBlockClick} />
-        <MiniBlock icon={<Wrench className="h-3 w-3" />} label="Tools" count={toolCount} tab="tools" onClick={handleBlockClick} />
-        <MiniBlock icon={<Plug className="h-3 w-3" />} label="MCP" count={mcpCount} tab="mcp" onClick={handleBlockClick} />
+        <MiniBlock
+          icon={<MessageSquare className="h-3 w-3" />}
+          label="Prompt"
+          tab="prompt"
+          onClick={handleBlockClick}
+        />
+        <MiniBlock
+          icon={<Wrench className="h-3 w-3" />}
+          label="Tools"
+          count={toolCount}
+          tab="tools"
+          onClick={handleBlockClick}
+        />
+        <MiniBlock
+          icon={<Plug className="h-3 w-3" />}
+          label="MCP"
+          count={mcpCount}
+          tab="mcp"
+          onClick={handleBlockClick}
+        />
       </div>
     </BaseNode>
   );

--- a/apps/web/src/features/canvas/nodes/AgentNode.tsx
+++ b/apps/web/src/features/canvas/nodes/AgentNode.tsx
@@ -1,12 +1,21 @@
 "use client";
 
-import { memo } from "react";
+import { memo, useCallback, type ReactNode } from "react";
 import { type Node, type NodeProps } from "@xyflow/react";
-import { Bot } from "lucide-react";
+import { Bot, MessageSquare, Wrench, Plug } from "lucide-react";
 import { BaseNode } from "./BaseNode";
 import type { AgentData } from "../types";
+import { agentTabStore } from "../stores/agentTabStore";
 
 export const AgentNode = memo(function AgentNode({ id, data }: NodeProps<Node<AgentData>>) {
+  const modelName = data.model?.name ?? "No model configured";
+  const toolCount = data.tools?.length ?? 0;
+  const mcpCount = data.mcp_servers?.length ?? 0;
+
+  const handleBlockClick = useCallback((tab: string) => {
+    agentTabStore.request(id, tab);
+  }, [id]);
+
   return (
     <BaseNode
       nodeId={id}
@@ -15,8 +24,45 @@ export const AgentNode = memo(function AgentNode({ id, data }: NodeProps<Node<Ag
       bgClassName="bg-node-agent-bg"
       borderColor="--node-agent-border"
       pinned={data.pinned}
+      className="w-[260px] max-w-[260px]"
     >
-      <div className="text-xs text-muted-foreground">Model • Tools • Limits</div>
+      <div className="text-xs text-muted-foreground truncate">{modelName}</div>
+
+      <div className="mt-2 border-t border-border/40" />
+
+      <div className="mt-2 grid grid-cols-3 gap-1">
+        <MiniBlock icon={<MessageSquare className="h-3 w-3" />} label="Prompt" tab="prompt" onClick={handleBlockClick} />
+        <MiniBlock icon={<Wrench className="h-3 w-3" />} label="Tools" count={toolCount} tab="tools" onClick={handleBlockClick} />
+        <MiniBlock icon={<Plug className="h-3 w-3" />} label="MCP" count={mcpCount} tab="mcp" onClick={handleBlockClick} />
+      </div>
     </BaseNode>
   );
 });
+
+function MiniBlock({
+  icon,
+  label,
+  count,
+  tab,
+  onClick,
+}: {
+  icon: ReactNode;
+  label: string;
+  count?: number;
+  tab: string;
+  onClick: (tab: string) => void;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={() => onClick(tab)}
+      className="flex flex-col items-center gap-0.5 rounded border border-border/40 bg-muted/20 px-1 py-1.5 text-muted-foreground hover:bg-muted/40 hover:text-foreground transition-colors cursor-pointer"
+    >
+      {icon}
+      <span className="text-[10px] leading-none">{label}</span>
+      {count !== undefined && count > 0 && (
+        <span className="text-[9px] tabular-nums text-muted-foreground/70">({count})</span>
+      )}
+    </button>
+  );
+}

--- a/apps/web/src/features/canvas/nodes/AgentNode.tsx
+++ b/apps/web/src/features/canvas/nodes/AgentNode.tsx
@@ -6,6 +6,7 @@ import { Bot, MessageSquare, Wrench, Plug } from "lucide-react";
 import { BaseNode } from "./BaseNode";
 import type { AgentData } from "../types";
 import { agentTabStore } from "../stores/agentTabStore";
+import type { AgentTab } from "../stores/agentTabStore";
 
 export const AgentNode = memo(function AgentNode({ id, data }: NodeProps<Node<AgentData>>) {
   const modelName = data.model?.name ?? "No model configured";
@@ -13,7 +14,7 @@ export const AgentNode = memo(function AgentNode({ id, data }: NodeProps<Node<Ag
   const mcpCount = data.mcp_servers?.length ?? 0;
 
   const handleBlockClick = useCallback(
-    (tab: string) => {
+    (tab: AgentTab) => {
       agentTabStore.request(id, tab);
     },
     [id],
@@ -69,8 +70,8 @@ function MiniBlock({
   icon: ReactNode;
   label: string;
   count?: number;
-  tab: string;
-  onClick: (tab: string) => void;
+  tab: AgentTab;
+  onClick: (tab: AgentTab) => void;
 }) {
   return (
     <button

--- a/apps/web/src/features/canvas/nodes/BaseNode.tsx
+++ b/apps/web/src/features/canvas/nodes/BaseNode.tsx
@@ -16,6 +16,7 @@ type BaseNodeProps = {
   bgColor?: string;
   borderColor?: string;
   pinned?: boolean;
+  className?: string;
 };
 
 export const BaseNode = memo(function BaseNode({
@@ -27,6 +28,7 @@ export const BaseNode = memo(function BaseNode({
   bgColor,
   borderColor,
   pinned = false,
+  className,
 }: BaseNodeProps) {
   const nodeExecution = useNodeExecution(nodeId);
   const executionStatus = nodeExecution?.status ?? "idle";
@@ -50,6 +52,7 @@ export const BaseNode = memo(function BaseNode({
         bgClassName,
         executionStatus !== "idle" && executionStatus,
         executionStatus === "running" && "animate-pulse-subtle",
+        className,
       )}
       style={borderStyle}
     >

--- a/apps/web/src/features/canvas/stores/agentTabStore.ts
+++ b/apps/web/src/features/canvas/stores/agentTabStore.ts
@@ -1,0 +1,21 @@
+type TabRequest = { nodeId: string; tab: string } | null;
+
+let _request: TabRequest = null;
+const _listeners = new Set<() => void>();
+
+export const agentTabStore = {
+  request: (nodeId: string, tab: string) => {
+    _request = { nodeId, tab };
+    _listeners.forEach((l) => l());
+  },
+  consume: () => {
+    _request = null;
+  },
+  getSnapshot: (): TabRequest => _request,
+  subscribe: (listener: () => void) => {
+    _listeners.add(listener);
+    return () => {
+      _listeners.delete(listener);
+    };
+  },
+};

--- a/apps/web/src/features/canvas/stores/agentTabStore.ts
+++ b/apps/web/src/features/canvas/stores/agentTabStore.ts
@@ -1,10 +1,16 @@
-type TabRequest = { nodeId: string; tab: string } | null;
+export type AgentTab = "model" | "prompt" | "tools" | "mcp";
+
+export function isAgentTab(tab: string): tab is AgentTab {
+  return tab === "model" || tab === "prompt" || tab === "tools" || tab === "mcp";
+}
+
+type TabRequest = { nodeId: string; tab: AgentTab } | null;
 
 let _request: TabRequest = null;
 const _listeners = new Set<() => void>();
 
 export const agentTabStore = {
-  request: (nodeId: string, tab: string) => {
+  request: (nodeId: string, tab: AgentTab) => {
     _request = { nodeId, tab };
     _listeners.forEach((l) => l());
   },
@@ -12,6 +18,7 @@ export const agentTabStore = {
     _request = null;
   },
   getSnapshot: (): TabRequest => _request,
+  getServerSnapshot: (): TabRequest => null,
   subscribe: (listener: () => void) => {
     _listeners.add(listener);
     return () => {

--- a/apps/web/src/features/canvas/types.ts
+++ b/apps/web/src/features/canvas/types.ts
@@ -63,6 +63,7 @@ export type AgentFieldType = (typeof AGENT_FIELD_TYPES)[number];
 export type AgentMessageRole = "user" | "model";
 
 export type AgentMessage = {
+  ui_id?: string;
   role: AgentMessageRole;
   content: string;
 };
@@ -99,6 +100,7 @@ export type AgentHttpToolConfig = {
 };
 
 export type AgentTool = {
+  ui_id?: string;
   type: "http_request";
   name: string;
   description: string;

--- a/apps/web/src/features/canvas/types.ts
+++ b/apps/web/src/features/canvas/types.ts
@@ -40,6 +40,15 @@ export type SortRule = {
 /** Canonical list of HTTP methods for canvas + worker `http` node (includes PATCH). */
 export const HTTP_METHODS = ["GET", "POST", "PUT", "PATCH", "DELETE"] as const;
 
+export const HTTP_CREDENTIAL_TYPES = [
+  "basic_auth",
+  "header",
+  "api_key",
+  "oauth2",
+  "token",
+] as const;
+export type HttpCredentialType = (typeof HTTP_CREDENTIAL_TYPES)[number];
+
 export type HttpMethod = (typeof HTTP_METHODS)[number];
 
 export const AGENT_PROVIDERS = ["gemini", "openai", "anthropic"] as const;

--- a/apps/web/src/features/canvas/types.ts
+++ b/apps/web/src/features/canvas/types.ts
@@ -84,7 +84,7 @@ export type AgentFieldMode =
       agent: { description: string; type: AgentFieldType; required: boolean };
     };
 
-export type AgentKVField = { key: string; value: AgentFieldMode };
+export type AgentKVField = { ui_id?: string; key: string; value: AgentFieldMode };
 
 export type AgentHttpToolConfig = {
   method: HttpMethod;

--- a/apps/web/src/lib/workflow-dsl.ts
+++ b/apps/web/src/lib/workflow-dsl.ts
@@ -29,6 +29,7 @@ import {
   type AggregatorData,
   type MergeData,
   type AgentData,
+  type AgentKVField,
   type AgentMessage,
   type AgentTool,
 } from "@/features/canvas/types";
@@ -52,6 +53,18 @@ function stripAgentMessageUiId(message: AgentMessage): AgentMessage {
 
 function stripAgentToolUiId(tool: AgentTool): AgentTool {
   const next = { ...tool };
+  delete next.ui_id;
+  next.config = {
+    ...next.config,
+    headers: next.config.headers?.map(stripAgentKvFieldUiId),
+    query: next.config.query?.map(stripAgentKvFieldUiId),
+    body: next.config.body?.map(stripAgentKvFieldUiId),
+  };
+  return next;
+}
+
+function stripAgentKvFieldUiId(field: AgentKVField): AgentKVField {
+  const next = { ...field };
   delete next.ui_id;
   return next;
 }

--- a/apps/web/src/lib/workflow-dsl.ts
+++ b/apps/web/src/lib/workflow-dsl.ts
@@ -29,10 +29,13 @@ import {
   type AggregatorData,
   type MergeData,
   type AgentData,
-  type AgentKVField,
-  type AgentMessage,
-  type AgentTool,
 } from "@/features/canvas/types";
+import {
+  hydrateAgentMessages,
+  hydrateAgentTools,
+  stripAgentMessageUiId,
+  stripAgentToolUiId,
+} from "@/features/canvas/lib/agentDataNormalization";
 import type { IntegrationNodeData } from "@/features/canvas/integrations/types";
 import { isIntegrationNodeKind } from "@/features/canvas/integrations/helpers";
 import { isCredentialRef, nodeTypeRequiresCredential } from "@/lib/credentials";
@@ -44,30 +47,6 @@ import {
   switchRuleHandleId,
 } from "@/features/canvas/utils/switchHandles";
 import { sanitizeNodeLabel } from "@/features/canvas/utils/nodeLabels";
-
-function stripAgentMessageUiId(message: AgentMessage): AgentMessage {
-  const next = { ...message };
-  delete next.ui_id;
-  return next;
-}
-
-function stripAgentToolUiId(tool: AgentTool): AgentTool {
-  const next = { ...tool };
-  delete next.ui_id;
-  next.config = {
-    ...next.config,
-    headers: next.config.headers?.map(stripAgentKvFieldUiId),
-    query: next.config.query?.map(stripAgentKvFieldUiId),
-    body: next.config.body?.map(stripAgentKvFieldUiId),
-  };
-  return next;
-}
-
-function stripAgentKvFieldUiId(field: AgentKVField): AgentKVField {
-  const next = { ...field };
-  delete next.ui_id;
-  return next;
-}
 
 export interface WorkflowNode<Params = Record<string, unknown>> {
   id: string;
@@ -611,10 +590,8 @@ const nodeHydrators: Partial<Record<CanvasNode["type"], NodeHydrator>> = {
       ...base,
       model: (params.model as AgentData["model"]) ?? undefined,
       system_prompt: typeof params.system_prompt === "string" ? params.system_prompt : undefined,
-      messages: Array.isArray(params.messages)
-        ? (params.messages as AgentData["messages"])
-        : undefined,
-      tools: Array.isArray(params.tools) ? (params.tools as AgentData["tools"]) : undefined,
+      messages: hydrateAgentMessages(params.messages),
+      tools: hydrateAgentTools(params.tools),
       mcp_servers: Array.isArray(params.mcp_servers)
         ? (params.mcp_servers as AgentData["mcp_servers"])
         : undefined,

--- a/apps/web/src/lib/workflow-dsl.ts
+++ b/apps/web/src/lib/workflow-dsl.ts
@@ -29,6 +29,8 @@ import {
   type AggregatorData,
   type MergeData,
   type AgentData,
+  type AgentMessage,
+  type AgentTool,
 } from "@/features/canvas/types";
 import type { IntegrationNodeData } from "@/features/canvas/integrations/types";
 import { isIntegrationNodeKind } from "@/features/canvas/integrations/helpers";
@@ -41,6 +43,18 @@ import {
   switchRuleHandleId,
 } from "@/features/canvas/utils/switchHandles";
 import { sanitizeNodeLabel } from "@/features/canvas/utils/nodeLabels";
+
+function stripAgentMessageUiId(message: AgentMessage): AgentMessage {
+  const next = { ...message };
+  delete next.ui_id;
+  return next;
+}
+
+function stripAgentToolUiId(tool: AgentTool): AgentTool {
+  const next = { ...tool };
+  delete next.ui_id;
+  return next;
+}
 
 export interface WorkflowNode<Params = Record<string, unknown>> {
   id: string;
@@ -434,8 +448,12 @@ function toWorkerParameters(n: CanvasNode, edges: RFEdge[]): Record<string, unkn
       if (typeof d.system_prompt === "string" && d.system_prompt.length > 0) {
         params.system_prompt = d.system_prompt;
       }
-      if (Array.isArray(d.messages) && d.messages.length > 0) params.messages = d.messages;
-      if (Array.isArray(d.tools) && d.tools.length > 0) params.tools = d.tools;
+      if (Array.isArray(d.messages) && d.messages.length > 0) {
+        params.messages = d.messages.map(stripAgentMessageUiId);
+      }
+      if (Array.isArray(d.tools) && d.tools.length > 0) {
+        params.tools = d.tools.map(stripAgentToolUiId);
+      }
       if (Array.isArray(d.mcp_servers) && d.mcp_servers.length > 0) {
         params.mcp_servers = d.mcp_servers;
       }


### PR DESCRIPTION
Refactors the agent inspector into Model, Prompt, Tools, and MCP tabs; refines the tools card, and updates agent canvas nodes to show model, prompt, tool, and MCP summaries with quick tab navigation.