### PR TITLE
fix(canvas): add library nodes at viewport center

### DIFF
--- a/apps/web/src/features/canvas/hooks/useAddNode.test.ts
+++ b/apps/web/src/features/canvas/hooks/useAddNode.test.ts
@@ -1,0 +1,55 @@
+import type { ReactFlowInstance } from "@xyflow/react";
+import { describe, expect, it, vi } from "vitest";
+import type { CanvasNode } from "../types";
+import { calculateNodePosition } from "./useAddNode";
+
+function createContainer(rect: Partial<DOMRect>): HTMLDivElement {
+  const container = document.createElement("div");
+  vi.spyOn(container, "getBoundingClientRect").mockReturnValue({
+    x: rect.left ?? 0,
+    y: rect.top ?? 0,
+    left: rect.left ?? 0,
+    top: rect.top ?? 0,
+    right: rect.right ?? 0,
+    bottom: rect.bottom ?? 0,
+    width: rect.width ?? 0,
+    height: rect.height ?? 0,
+    toJSON: () => ({}),
+  } as DOMRect);
+  return container;
+}
+
+function createReactFlowInstance() {
+  return {
+    screenToFlowPosition: vi.fn((position: { x: number; y: number }) => ({
+      x: position.x / 2,
+      y: position.y / 2,
+    })),
+  } as unknown as ReactFlowInstance<CanvasNode>;
+}
+
+describe("calculateNodePosition", () => {
+  it("uses the pointer position for drag and drop", () => {
+    const container = createContainer({ left: 100, top: 50, width: 800, height: 600 });
+    const rfInstance = createReactFlowInstance();
+
+    const position = calculateNodePosition(rfInstance, container, 300, 250);
+
+    expect(rfInstance.screenToFlowPosition).toHaveBeenCalledWith({ x: 200, y: 200 });
+    expect(position).toEqual({ x: 100, y: 100 });
+  });
+
+  it("uses the current viewport center when no pointer position is provided", () => {
+    const container = createContainer({ left: 100, top: 50, width: 800, height: 600 });
+    const rfInstance = createReactFlowInstance();
+
+    const position = calculateNodePosition(rfInstance, container);
+
+    expect(rfInstance.screenToFlowPosition).toHaveBeenCalledWith({ x: 400, y: 300 });
+    expect(position).toEqual({ x: 200, y: 150 });
+  });
+
+  it("falls back when the canvas is not initialized", () => {
+    expect(calculateNodePosition(null, null)).toEqual({ x: 100, y: 100 });
+  });
+});

--- a/apps/web/src/features/canvas/hooks/useAddNode.ts
+++ b/apps/web/src/features/canvas/hooks/useAddNode.ts
@@ -8,17 +8,19 @@ import { sanitizeNodeLabel } from "../utils/nodeLabels";
 import type { Edge, ReactFlowInstance } from "@xyflow/react";
 
 // Helper function to calculate the node's position.
-function calculateNodePosition(
+export function calculateNodePosition(
   rfInstance: ReactFlowInstance<CanvasNode, Edge> | null,
   container: HTMLDivElement | null,
   clientX?: number,
   clientY?: number,
 ) {
-  if (container && rfInstance && typeof clientX === "number" && typeof clientY === "number") {
+  if (container && rfInstance) {
     const rect = container.getBoundingClientRect();
+    const x = typeof clientX === "number" ? clientX - rect.left : rect.width / 2;
+    const y = typeof clientY === "number" ? clientY - rect.top : rect.height / 2;
     const position = rfInstance.screenToFlowPosition({
-      x: clientX - rect.left,
-      y: clientY - rect.top,
+      x,
+      y,
     });
     return position;
   }


### PR DESCRIPTION
Clicking a library node used to drop the node to the center of the canvas wrt ReactFlow, this change ensures nodes are dropped into the user-visible viewport instead.