### PR TITLE
feat(worker): add integration node framework with gmail tools and tests

### DIFF
--- a/services/rune-worker/pkg/integrations/README.md
+++ b/services/rune-worker/pkg/integrations/README.md
@@ -1,0 +1,112 @@
+# Integrations Package
+
+`pkg/integrations` is the worker-side execution layer for integration nodes using
+the kind format:
+
+`integration.<provider>.<service>.<tool>`
+
+Example: `integration.google.gmail.read_email`.
+
+## Architecture
+
+- Integration tools execute **in-process** in `rune-worker`.
+- Credentials are resolved by master and attached to the node before worker
+  execution. Tools read credentials from `plugin.ExecutionContext.GetCredentials()`.
+- Each integration tool is a stateless singleton implementing:
+  - `Kind() string`
+  - `Execute(context.Context, plugin.ExecutionContext) (map[string]any, error)`
+- All tools are stored in an internal integration registry map keyed by kind.
+- Each tool registration also wires a factory into the global node registry
+  (`pkg/nodes`) so executor can instantiate integration nodes by type.
+
+## Directory Layout
+
+```text
+pkg/integrations/
+  args.go                            # DecodeArgs helper
+  registry.go                        # Tool registry + node adapter wiring
+  loader.go                          # blank imports of service packages
+  internal/connector/connector.go    # shared httpcore-based request pipeline
+  providers/
+    google/
+      gmail/
+        gmail.go
+        send_email.go
+        read_email.go
+        search_emails.go
+        list_labels.go
+```
+
+## Dispatch Flow
+
+1. Executor receives a node with `Type = integration.<provider>.<service>.<tool>`.
+2. Global nodes registry creates an `integrationNode`.
+3. `integrationNode.Execute(...)` looks up the exact kind in integrations registry.
+4. Matched tool executes with the already-built `ExecutionContext`.
+5. Tool calls `internal/connector.Do(...)`.
+6. Connector builds URL, injects credentials via `httpcore.ApplyCredential`, and
+   calls `httpcore.Execute(...)`.
+7. Output is returned in the same envelope shape used by HTTP node:
+   `{status, status_text, body, headers, duration_ms}`.
+
+## Connector Contract
+
+`internal/connector.Spec`:
+
+- `Method`, `BaseURL`, `Path`, `PathArgs`, `Query`, `Headers`, `Body`
+- `Timeout` (defaults to 30 seconds when unset)
+- `AllowNon2xx` (default false)
+
+Default behavior:
+
+- Non-2xx responses return `*connector.Error` with `Status`, `URL`, and `Body`.
+- Transport and request-build failures bubble up as standard errors from `httpcore`.
+
+## Argument Decoding Pattern
+
+Every tool defines its own typed args struct and decodes from
+`ec.Parameters` using `DecodeArgs(...)`.
+
+```go
+type readEmailArgs struct {
+    ID string `json:"id"`
+    Format string `json:"format"`
+}
+```
+
+This keeps per-tool validation local and avoids duplicating central schemas.
+
+## Adding a New Integration Tool
+
+1. Create a new file under:
+   `pkg/integrations/providers/<provider>/<service>/<tool>.go`.
+2. Implement a stateless tool struct with `Kind()` and `Execute(...)`.
+3. Parse arguments using `DecodeArgs`.
+4. Build a connector `Spec` and call `connector.Do(...)`.
+5. Register the tool in `init()`:
+   `integrations.Register(MyTool{})`.
+6. Add unit tests using `httptest.Server`.
+7. If adding a new service package, update `pkg/integrations/loader.go` with a
+   blank import.
+
+## Testing Pattern
+
+- Use `httptest.Server` to validate URL, query, headers, auth injection, and body.
+- Use package-level `baseURL` vars in each service package and swap during tests.
+- Verify non-2xx returns `*connector.Error`.
+- Keep unit tests colocated with tool files.
+
+## Current Scope
+
+Implemented in this phase:
+
+- Gmail:
+  - `integration.google.gmail.send_email`
+  - `integration.google.gmail.read_email`
+  - `integration.google.gmail.search_emails`
+  - `integration.google.gmail.list_labels`
+
+Planned next:
+
+- Google Sheets tools
+- Microsoft Outlook tools

--- a/services/rune-worker/pkg/integrations/args.go
+++ b/services/rune-worker/pkg/integrations/args.go
@@ -1,0 +1,18 @@
+package integrations
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// DecodeArgs decodes a generic argument map into a typed args struct.
+func DecodeArgs(in map[string]any, out any) error {
+	payload, err := json.Marshal(in)
+	if err != nil {
+		return fmt.Errorf("marshal args: %w", err)
+	}
+	if err := json.Unmarshal(payload, out); err != nil {
+		return fmt.Errorf("unmarshal args: %w", err)
+	}
+	return nil
+}

--- a/services/rune-worker/pkg/integrations/args_test.go
+++ b/services/rune-worker/pkg/integrations/args_test.go
@@ -1,0 +1,31 @@
+package integrations
+
+import "testing"
+
+func TestDecodeArgs(t *testing.T) {
+	type args struct {
+		ID   string `json:"id"`
+		Flag bool   `json:"flag"`
+	}
+
+	var out args
+	err := DecodeArgs(map[string]any{"id": "abc", "flag": true}, &out)
+	if err != nil {
+		t.Fatalf("DecodeArgs() error = %v", err)
+	}
+	if out.ID != "abc" || !out.Flag {
+		t.Fatalf("unexpected decoded args: %+v", out)
+	}
+}
+
+func TestDecodeArgsTypeMismatch(t *testing.T) {
+	type args struct {
+		Max int `json:"max"`
+	}
+
+	var out args
+	err := DecodeArgs(map[string]any{"max": "not-a-number"}, &out)
+	if err == nil {
+		t.Fatal("expected decode error for invalid int")
+	}
+}

--- a/services/rune-worker/pkg/integrations/bootstrap/loader.go
+++ b/services/rune-worker/pkg/integrations/bootstrap/loader.go
@@ -1,0 +1,5 @@
+package bootstrap
+
+import (
+	_ "rune-worker/pkg/integrations/providers/google/gmail"
+)

--- a/services/rune-worker/pkg/integrations/internal/connector/connector.go
+++ b/services/rune-worker/pkg/integrations/internal/connector/connector.go
@@ -1,0 +1,132 @@
+package connector
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"strings"
+	"time"
+
+	"rune-worker/pkg/nodes/shared/httpcore"
+	"rune-worker/plugin"
+)
+
+type Spec struct {
+	Method      string
+	BaseURL     string
+	Path        string
+	PathArgs    map[string]string
+	Query       map[string]string
+	Headers     map[string]string
+	Body        any
+	Timeout     time.Duration
+	AllowNon2xx bool
+}
+
+type Error struct {
+	Status int
+	URL    string
+	Body   any
+}
+
+func (e *Error) Error() string {
+	return fmt.Sprintf("integration request failed: status=%d url=%s", e.Status, e.URL)
+}
+
+func Do(ctx context.Context, ec plugin.ExecutionContext, s Spec) (map[string]any, error) {
+	fullURL, err := buildURL(s.BaseURL, s.Path, s.PathArgs)
+	if err != nil {
+		return nil, err
+	}
+
+	headers := cloneHeaders(s.Headers)
+	httpcore.ApplyCredential(headers, ec.GetCredentials())
+
+	spec := httpcore.RequestSpec{
+		Method:  s.Method,
+		URL:     fullURL,
+		Body:    s.Body,
+		Query:   s.Query,
+		Headers: headers,
+		Timeout: s.Timeout,
+	}
+	if spec.Timeout <= 0 {
+		spec.Timeout = 30 * time.Second
+	}
+
+	raw, err := httpcore.Execute(ctx, spec)
+	if err != nil {
+		return nil, err
+	}
+
+	status, _ := raw["status"].(int)
+	if !s.AllowNon2xx && (status < 200 || status >= 300) {
+		return nil, &Error{
+			Status: status,
+			URL:    fullURL,
+			Body:   raw["body"],
+		}
+	}
+
+	return raw, nil
+}
+
+func cloneHeaders(in map[string]string) map[string]string {
+	if in == nil {
+		return map[string]string{}
+	}
+	out := make(map[string]string, len(in))
+	for k, v := range in {
+		out[k] = v
+	}
+	return out
+}
+
+func buildURL(baseURL, path string, pathArgs map[string]string) (string, error) {
+	if baseURL == "" {
+		return "", fmt.Errorf("base url is required")
+	}
+	if path == "" {
+		return "", fmt.Errorf("path is required")
+	}
+
+	resolvedPath, err := resolvePath(path, pathArgs)
+	if err != nil {
+		return "", err
+	}
+
+	base, err := url.Parse(baseURL)
+	if err != nil {
+		return "", fmt.Errorf("invalid base url: %w", err)
+	}
+	rel, err := url.Parse(resolvedPath)
+	if err != nil {
+		return "", fmt.Errorf("invalid path: %w", err)
+	}
+	return base.ResolveReference(rel).String(), nil
+}
+
+func resolvePath(path string, pathArgs map[string]string) (string, error) {
+	var b strings.Builder
+	for i := 0; i < len(path); i++ {
+		ch := path[i]
+		if ch != '{' {
+			b.WriteByte(ch)
+			continue
+		}
+
+		end := strings.IndexByte(path[i+1:], '}')
+		if end < 0 {
+			return "", fmt.Errorf("unclosed path variable in %q", path)
+		}
+		end += i + 1
+		key := path[i+1 : end]
+		val, ok := pathArgs[key]
+		if !ok {
+			return "", fmt.Errorf("missing path argument %q", key)
+		}
+		b.WriteString(url.PathEscape(val))
+		i = end
+	}
+	return b.String(), nil
+}

--- a/services/rune-worker/pkg/integrations/internal/connector/connector_test.go
+++ b/services/rune-worker/pkg/integrations/internal/connector/connector_test.go
@@ -1,0 +1,107 @@
+package connector
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"rune-worker/plugin"
+)
+
+func TestBuildURL(t *testing.T) {
+	got, err := buildURL("https://example.com", "/v1/items/{id}", map[string]string{"id": "a/b"})
+	if err != nil {
+		t.Fatalf("buildURL() error = %v", err)
+	}
+	want := "https://example.com/v1/items/a%2Fb"
+	if got != want {
+		t.Fatalf("buildURL() = %q, want %q", got, want)
+	}
+}
+
+func TestDoInjectsAuthAndQuery(t *testing.T) {
+	var auth string
+	var rawQuery string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		auth = r.Header.Get("Authorization")
+		rawQuery = r.URL.RawQuery
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{"ok": true})
+	}))
+	defer server.Close()
+
+	ec := plugin.ExecutionContext{}
+	ec.SetCredentials(map[string]any{
+		"type":         "oauth2",
+		"access_token": "tok-123",
+	})
+
+	out, err := Do(context.Background(), ec, Spec{
+		Method:  "GET",
+		BaseURL: server.URL,
+		Path:    "/v1/test",
+		Query: map[string]string{
+			"q": "foo",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Do() error = %v", err)
+	}
+	if auth != "Bearer tok-123" {
+		t.Fatalf("Authorization = %q, want Bearer tok-123", auth)
+	}
+	if !strings.Contains(rawQuery, "q=foo") {
+		t.Fatalf("query = %q, expected q=foo", rawQuery)
+	}
+	if status, _ := out["status"].(int); status != 200 {
+		t.Fatalf("status = %v, want 200", out["status"])
+	}
+}
+
+func TestDoNon2xxReturnsConnectorError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		_ = json.NewEncoder(w).Encode(map[string]any{"error": "bad_request"})
+	}))
+	defer server.Close()
+
+	_, err := Do(context.Background(), plugin.ExecutionContext{}, Spec{
+		Method:  "GET",
+		BaseURL: server.URL,
+		Path:    "/v1/test",
+	})
+	if err == nil {
+		t.Fatal("expected non-2xx error")
+	}
+	connErr, ok := err.(*Error)
+	if !ok {
+		t.Fatalf("expected *Error, got %T", err)
+	}
+	if connErr.Status != http.StatusBadRequest {
+		t.Fatalf("status = %d, want %d", connErr.Status, http.StatusBadRequest)
+	}
+}
+
+func TestDoAllowNon2xx(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		_ = json.NewEncoder(w).Encode(map[string]any{"error": "missing"})
+	}))
+	defer server.Close()
+
+	out, err := Do(context.Background(), plugin.ExecutionContext{}, Spec{
+		Method:      "GET",
+		BaseURL:     server.URL,
+		Path:        "/v1/test",
+		AllowNon2xx: true,
+	})
+	if err != nil {
+		t.Fatalf("Do() error = %v", err)
+	}
+	if status, _ := out["status"].(int); status != http.StatusNotFound {
+		t.Fatalf("status = %v, want %d", out["status"], http.StatusNotFound)
+	}
+}

--- a/services/rune-worker/pkg/integrations/providers/google/gmail/gmail.go
+++ b/services/rune-worker/pkg/integrations/providers/google/gmail/gmail.go
@@ -1,0 +1,10 @@
+package gmail
+
+const (
+	SendEmailKind    = "integration.google.gmail.send_email"
+	ReadEmailKind    = "integration.google.gmail.read_email"
+	SearchEmailsKind = "integration.google.gmail.search_emails"
+	ListLabelsKind   = "integration.google.gmail.list_labels"
+)
+
+var baseURL = "https://gmail.googleapis.com"

--- a/services/rune-worker/pkg/integrations/providers/google/gmail/helpers.go
+++ b/services/rune-worker/pkg/integrations/providers/google/gmail/helpers.go
@@ -1,0 +1,25 @@
+package gmail
+
+import "strings"
+
+func optionalQuery(key, value string) map[string]string {
+	if strings.TrimSpace(value) == "" {
+		return map[string]string{}
+	}
+	return map[string]string{key: value}
+}
+
+func splitCSV(raw string) []string {
+	if strings.TrimSpace(raw) == "" {
+		return nil
+	}
+	parts := strings.Split(raw, ",")
+	out := make([]string, 0, len(parts))
+	for _, p := range parts {
+		trimmed := strings.TrimSpace(p)
+		if trimmed != "" {
+			out = append(out, trimmed)
+		}
+	}
+	return out
+}

--- a/services/rune-worker/pkg/integrations/providers/google/gmail/list_labels.go
+++ b/services/rune-worker/pkg/integrations/providers/google/gmail/list_labels.go
@@ -1,0 +1,27 @@
+package gmail
+
+import (
+	"context"
+
+	"rune-worker/pkg/integrations"
+	"rune-worker/pkg/integrations/internal/connector"
+	"rune-worker/plugin"
+)
+
+type ListLabels struct{}
+
+func (ListLabels) Kind() string {
+	return ListLabelsKind
+}
+
+func (ListLabels) Execute(ctx context.Context, ec plugin.ExecutionContext) (map[string]any, error) {
+	return connector.Do(ctx, ec, connector.Spec{
+		Method:  "GET",
+		BaseURL: baseURL,
+		Path:    "/gmail/v1/users/me/labels",
+	})
+}
+
+func init() {
+	integrations.Register(ListLabels{})
+}

--- a/services/rune-worker/pkg/integrations/providers/google/gmail/list_labels_test.go
+++ b/services/rune-worker/pkg/integrations/providers/google/gmail/list_labels_test.go
@@ -1,0 +1,35 @@
+package gmail
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"rune-worker/plugin"
+)
+
+func TestListLabels(t *testing.T) {
+	origBaseURL := baseURL
+	defer func() { baseURL = origBaseURL }()
+
+	var gotPath string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		_ = json.NewEncoder(w).Encode(map[string]any{"labels": []any{}})
+	}))
+	defer server.Close()
+	baseURL = server.URL
+
+	out, err := ListLabels{}.Execute(context.Background(), plugin.ExecutionContext{Type: ListLabelsKind})
+	if err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	if gotPath != "/gmail/v1/users/me/labels" {
+		t.Fatalf("path = %q", gotPath)
+	}
+	if status, _ := out["status"].(int); status != 200 {
+		t.Fatalf("status = %v", out["status"])
+	}
+}

--- a/services/rune-worker/pkg/integrations/providers/google/gmail/read_email.go
+++ b/services/rune-worker/pkg/integrations/providers/google/gmail/read_email.go
@@ -1,0 +1,43 @@
+package gmail
+
+import (
+	"context"
+	"errors"
+
+	"rune-worker/pkg/integrations"
+	"rune-worker/pkg/integrations/internal/connector"
+	"rune-worker/plugin"
+)
+
+type ReadEmail struct{}
+
+type readEmailArgs struct {
+	ID     string `json:"id"`
+	Format string `json:"format"`
+}
+
+func (ReadEmail) Kind() string {
+	return ReadEmailKind
+}
+
+func (ReadEmail) Execute(ctx context.Context, ec plugin.ExecutionContext) (map[string]any, error) {
+	var args readEmailArgs
+	if err := integrations.DecodeArgs(ec.Parameters, &args); err != nil {
+		return nil, err
+	}
+	if args.ID == "" {
+		return nil, errors.New("argument 'id' is required")
+	}
+
+	return connector.Do(ctx, ec, connector.Spec{
+		Method:   "GET",
+		BaseURL:  baseURL,
+		Path:     "/gmail/v1/users/me/messages/{id}",
+		PathArgs: map[string]string{"id": args.ID},
+		Query:    optionalQuery("format", args.Format),
+	})
+}
+
+func init() {
+	integrations.Register(ReadEmail{})
+}

--- a/services/rune-worker/pkg/integrations/providers/google/gmail/read_email_test.go
+++ b/services/rune-worker/pkg/integrations/providers/google/gmail/read_email_test.go
@@ -1,0 +1,89 @@
+package gmail
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"rune-worker/pkg/integrations/internal/connector"
+	"rune-worker/plugin"
+)
+
+func TestReadEmail(t *testing.T) {
+	origBaseURL := baseURL
+	defer func() { baseURL = origBaseURL }()
+
+	var gotPath string
+	var gotFormat string
+	var gotAuth string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		gotFormat = r.URL.Query().Get("format")
+		gotAuth = r.Header.Get("Authorization")
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{"id": "msg-1"})
+	}))
+	defer server.Close()
+	baseURL = server.URL
+
+	ec := plugin.ExecutionContext{
+		Type:       ReadEmailKind,
+		Parameters: map[string]any{"id": "msg-1", "format": "metadata"},
+	}
+	ec.SetCredentials(map[string]any{
+		"type":         "oauth2",
+		"access_token": "tok-read",
+	})
+
+	out, err := ReadEmail{}.Execute(context.Background(), ec)
+	if err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	if gotPath != "/gmail/v1/users/me/messages/msg-1" {
+		t.Fatalf("path = %q", gotPath)
+	}
+	if gotFormat != "metadata" {
+		t.Fatalf("format = %q", gotFormat)
+	}
+	if gotAuth != "Bearer tok-read" {
+		t.Fatalf("auth = %q", gotAuth)
+	}
+	if status, _ := out["status"].(int); status != 200 {
+		t.Fatalf("status = %v", out["status"])
+	}
+}
+
+func TestReadEmailRequiresID(t *testing.T) {
+	_, err := ReadEmail{}.Execute(context.Background(), plugin.ExecutionContext{
+		Type:       ReadEmailKind,
+		Parameters: map[string]any{},
+	})
+	if err == nil {
+		t.Fatal("expected missing id error")
+	}
+}
+
+func TestReadEmailNon2xx(t *testing.T) {
+	origBaseURL := baseURL
+	defer func() { baseURL = origBaseURL }()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		_ = json.NewEncoder(w).Encode(map[string]any{"error": "unauthorized"})
+	}))
+	defer server.Close()
+	baseURL = server.URL
+
+	_, err := ReadEmail{}.Execute(context.Background(), plugin.ExecutionContext{
+		Type:       ReadEmailKind,
+		Parameters: map[string]any{"id": "msg-1"},
+	})
+	if err == nil {
+		t.Fatal("expected connector error")
+	}
+	if _, ok := err.(*connector.Error); !ok {
+		t.Fatalf("expected *connector.Error, got %T", err)
+	}
+}

--- a/services/rune-worker/pkg/integrations/providers/google/gmail/search_emails.go
+++ b/services/rune-worker/pkg/integrations/providers/google/gmail/search_emails.go
@@ -1,0 +1,59 @@
+package gmail
+
+import (
+	"context"
+	"errors"
+	"strconv"
+	"strings"
+
+	"rune-worker/pkg/integrations"
+	"rune-worker/pkg/integrations/internal/connector"
+	"rune-worker/plugin"
+)
+
+type SearchEmails struct{}
+
+type searchEmailsArgs struct {
+	Q                string `json:"q"`
+	MaxResults       int    `json:"maxResults"`
+	LabelIDs         string `json:"labelIds"`
+	IncludeSpamTrash bool   `json:"includeSpamTrash"`
+}
+
+func (SearchEmails) Kind() string {
+	return SearchEmailsKind
+}
+
+func (SearchEmails) Execute(ctx context.Context, ec plugin.ExecutionContext) (map[string]any, error) {
+	var args searchEmailsArgs
+	if err := integrations.DecodeArgs(ec.Parameters, &args); err != nil {
+		return nil, err
+	}
+	if args.Q == "" {
+		return nil, errors.New("argument 'q' is required")
+	}
+
+	query := map[string]string{
+		"q": args.Q,
+	}
+	if args.MaxResults > 0 {
+		query["maxResults"] = strconv.Itoa(args.MaxResults)
+	}
+	if labels := splitCSV(args.LabelIDs); len(labels) > 0 {
+		query["labelIds"] = strings.Join(labels, ",")
+	}
+	if args.IncludeSpamTrash {
+		query["includeSpamTrash"] = "true"
+	}
+
+	return connector.Do(ctx, ec, connector.Spec{
+		Method:  "GET",
+		BaseURL: baseURL,
+		Path:    "/gmail/v1/users/me/messages",
+		Query:   query,
+	})
+}
+
+func init() {
+	integrations.Register(SearchEmails{})
+}

--- a/services/rune-worker/pkg/integrations/providers/google/gmail/search_emails_test.go
+++ b/services/rune-worker/pkg/integrations/providers/google/gmail/search_emails_test.go
@@ -1,0 +1,68 @@
+package gmail
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"rune-worker/plugin"
+)
+
+func TestSearchEmails(t *testing.T) {
+	origBaseURL := baseURL
+	defer func() { baseURL = origBaseURL }()
+
+	var query map[string]string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		query = map[string]string{
+			"q":                r.URL.Query().Get("q"),
+			"maxResults":       r.URL.Query().Get("maxResults"),
+			"labelIds":         r.URL.Query().Get("labelIds"),
+			"includeSpamTrash": r.URL.Query().Get("includeSpamTrash"),
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{"messages": []any{}})
+	}))
+	defer server.Close()
+	baseURL = server.URL
+
+	out, err := SearchEmails{}.Execute(context.Background(), plugin.ExecutionContext{
+		Type: SearchEmailsKind,
+		Parameters: map[string]any{
+			"q":                "is:unread",
+			"maxResults":       3,
+			"labelIds":         "INBOX,UNREAD",
+			"includeSpamTrash": true,
+		},
+	})
+	if err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+
+	if query["q"] != "is:unread" {
+		t.Fatalf("q = %q", query["q"])
+	}
+	if query["maxResults"] != "3" {
+		t.Fatalf("maxResults = %q", query["maxResults"])
+	}
+	if query["labelIds"] != "INBOX,UNREAD" {
+		t.Fatalf("labelIds = %q", query["labelIds"])
+	}
+	if query["includeSpamTrash"] != "true" {
+		t.Fatalf("includeSpamTrash = %q", query["includeSpamTrash"])
+	}
+	if status, _ := out["status"].(int); status != 200 {
+		t.Fatalf("status = %v", out["status"])
+	}
+}
+
+func TestSearchEmailsRequiresQ(t *testing.T) {
+	_, err := SearchEmails{}.Execute(context.Background(), plugin.ExecutionContext{
+		Type:       SearchEmailsKind,
+		Parameters: map[string]any{},
+	})
+	if err == nil {
+		t.Fatal("expected missing q error")
+	}
+}

--- a/services/rune-worker/pkg/integrations/providers/google/gmail/send_email.go
+++ b/services/rune-worker/pkg/integrations/providers/google/gmail/send_email.go
@@ -1,0 +1,89 @@
+package gmail
+
+import (
+	"context"
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"strings"
+
+	"rune-worker/pkg/integrations"
+	"rune-worker/pkg/integrations/internal/connector"
+	"rune-worker/plugin"
+)
+
+type SendEmail struct{}
+
+type sendEmailArgs struct {
+	To      string `json:"to"`
+	CC      string `json:"cc"`
+	BCC     string `json:"bcc"`
+	Subject string `json:"subject"`
+	Body    string `json:"body"`
+}
+
+func (SendEmail) Kind() string {
+	return SendEmailKind
+}
+
+func (SendEmail) Execute(ctx context.Context, ec plugin.ExecutionContext) (map[string]any, error) {
+	var args sendEmailArgs
+	if err := integrations.DecodeArgs(ec.Parameters, &args); err != nil {
+		return nil, err
+	}
+	if args.To == "" {
+		return nil, errors.New("argument 'to' is required")
+	}
+	if args.Subject == "" {
+		return nil, errors.New("argument 'subject' is required")
+	}
+	if args.Body == "" {
+		return nil, errors.New("argument 'body' is required")
+	}
+
+	raw, err := buildRawMessage(args)
+	if err != nil {
+		return nil, err
+	}
+
+	return connector.Do(ctx, ec, connector.Spec{
+		Method:  "POST",
+		BaseURL: baseURL,
+		Path:    "/gmail/v1/users/me/messages/send",
+		Body: map[string]any{
+			"raw": raw,
+		},
+	})
+}
+
+func buildRawMessage(args sendEmailArgs) (string, error) {
+	var lines []string
+	lines = append(lines, fmt.Sprintf("To: %s", sanitizeHeaderValue(args.To)))
+
+	if cc := sanitizeHeaderValue(args.CC); cc != "" {
+		lines = append(lines, fmt.Sprintf("Cc: %s", cc))
+	}
+	if bcc := sanitizeHeaderValue(args.BCC); bcc != "" {
+		lines = append(lines, fmt.Sprintf("Bcc: %s", bcc))
+	}
+
+	lines = append(lines,
+		fmt.Sprintf("Subject: %s", sanitizeHeaderValue(args.Subject)),
+		"MIME-Version: 1.0",
+		"Content-Type: text/plain; charset=UTF-8",
+		"",
+		args.Body,
+	)
+
+	message := strings.Join(lines, "\r\n")
+	return base64.RawURLEncoding.EncodeToString([]byte(message)), nil
+}
+
+func sanitizeHeaderValue(v string) string {
+	v = strings.ReplaceAll(v, "\r", " ")
+	return strings.ReplaceAll(v, "\n", " ")
+}
+
+func init() {
+	integrations.Register(SendEmail{})
+}

--- a/services/rune-worker/pkg/integrations/providers/google/gmail/send_email_test.go
+++ b/services/rune-worker/pkg/integrations/providers/google/gmail/send_email_test.go
@@ -1,0 +1,121 @@
+package gmail
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"rune-worker/pkg/integrations/internal/connector"
+	"rune-worker/plugin"
+)
+
+func TestSendEmail(t *testing.T) {
+	origBaseURL := baseURL
+	defer func() { baseURL = origBaseURL }()
+
+	var gotMethod string
+	var gotPath string
+	var gotAuth string
+	var gotRaw string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotMethod = r.Method
+		gotPath = r.URL.Path
+		gotAuth = r.Header.Get("Authorization")
+		var body map[string]any
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		gotRaw, _ = body["raw"].(string)
+		_ = json.NewEncoder(w).Encode(map[string]any{"id": "sent-1"})
+	}))
+	defer server.Close()
+	baseURL = server.URL
+
+	ec := plugin.ExecutionContext{
+		Type: SendEmailKind,
+		Parameters: map[string]any{
+			"to":      "team@example.com",
+			"cc":      "cc1@example.com",
+			"bcc":     "bcc1@example.com",
+			"subject": "Hello",
+			"body":    "Testing body",
+		},
+	}
+	ec.SetCredentials(map[string]any{
+		"type":         "oauth2",
+		"access_token": "tok-send",
+	})
+
+	out, err := SendEmail{}.Execute(context.Background(), ec)
+	if err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+
+	if gotMethod != "POST" {
+		t.Fatalf("method = %q", gotMethod)
+	}
+	if gotPath != "/gmail/v1/users/me/messages/send" {
+		t.Fatalf("path = %q", gotPath)
+	}
+	if gotAuth != "Bearer tok-send" {
+		t.Fatalf("auth = %q", gotAuth)
+	}
+	if gotRaw == "" {
+		t.Fatal("raw message should not be empty")
+	}
+
+	decoded, err := base64.RawURLEncoding.DecodeString(gotRaw)
+	if err != nil {
+		t.Fatalf("decode raw error = %v", err)
+	}
+	msg := string(decoded)
+	if !strings.Contains(msg, "To: team@example.com") ||
+		!strings.Contains(msg, "Cc: cc1@example.com") ||
+		!strings.Contains(msg, "Bcc: bcc1@example.com") ||
+		!strings.Contains(msg, "Subject: Hello") {
+		t.Fatalf("unexpected mime message: %s", msg)
+	}
+
+	if status, _ := out["status"].(int); status != 200 {
+		t.Fatalf("status = %v", out["status"])
+	}
+}
+
+func TestSendEmailRequiredArgs(t *testing.T) {
+	_, err := SendEmail{}.Execute(context.Background(), plugin.ExecutionContext{
+		Type:       SendEmailKind,
+		Parameters: map[string]any{"to": "team@example.com"},
+	})
+	if err == nil {
+		t.Fatal("expected missing subject/body error")
+	}
+}
+
+func TestSendEmailNon2xx(t *testing.T) {
+	origBaseURL := baseURL
+	defer func() { baseURL = origBaseURL }()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		_ = json.NewEncoder(w).Encode(map[string]any{"error": "bad_token"})
+	}))
+	defer server.Close()
+	baseURL = server.URL
+
+	_, err := SendEmail{}.Execute(context.Background(), plugin.ExecutionContext{
+		Type: SendEmailKind,
+		Parameters: map[string]any{
+			"to":      "team@example.com",
+			"subject": "Hello",
+			"body":    "Body",
+		},
+	})
+	if err == nil {
+		t.Fatal("expected connector error")
+	}
+	if _, ok := err.(*connector.Error); !ok {
+		t.Fatalf("expected *connector.Error, got %T", err)
+	}
+}

--- a/services/rune-worker/pkg/integrations/providers/google/google.go
+++ b/services/rune-worker/pkg/integrations/providers/google/google.go
@@ -1,0 +1,3 @@
+package google
+
+// Package google contains Google provider integration tools.

--- a/services/rune-worker/pkg/integrations/registry.go
+++ b/services/rune-worker/pkg/integrations/registry.go
@@ -1,0 +1,65 @@
+package integrations
+
+import (
+	"context"
+	"fmt"
+	"sync"
+
+	"rune-worker/pkg/nodes"
+	"rune-worker/plugin"
+)
+
+// Tool is a stateless integration tool handler.
+type Tool interface {
+	Kind() string
+	Execute(ctx context.Context, ec plugin.ExecutionContext) (map[string]any, error)
+}
+
+var (
+	registryMu sync.RWMutex
+	registry   = make(map[string]Tool)
+)
+
+// Register stores a tool in the integrations registry and wires it into the
+// global node registration queue for node factory creation.
+func Register(t Tool) {
+	kind := t.Kind()
+	if kind == "" {
+		panic("integrations: empty kind")
+	}
+
+	registryMu.Lock()
+	if _, exists := registry[kind]; exists {
+		registryMu.Unlock()
+		panic("integrations: duplicate kind " + kind)
+	}
+	registry[kind] = t
+	registryMu.Unlock()
+
+	nodes.RegisterNodeType(func(reg *nodes.Registry) {
+		reg.Register(kind, newIntegrationNode)
+	})
+}
+
+func get(kind string) (Tool, bool) {
+	registryMu.RLock()
+	defer registryMu.RUnlock()
+	t, ok := registry[kind]
+	return t, ok
+}
+
+type integrationNode struct {
+	kind string
+}
+
+func newIntegrationNode(ec plugin.ExecutionContext) plugin.Node {
+	return &integrationNode{kind: ec.Type}
+}
+
+func (n *integrationNode) Execute(ctx context.Context, ec plugin.ExecutionContext) (map[string]any, error) {
+	t, ok := get(n.kind)
+	if !ok {
+		return nil, fmt.Errorf("integration not registered: %s", n.kind)
+	}
+	return t.Execute(ctx, ec)
+}

--- a/services/rune-worker/pkg/integrations/registry_test.go
+++ b/services/rune-worker/pkg/integrations/registry_test.go
@@ -1,0 +1,67 @@
+package integrations
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"rune-worker/plugin"
+)
+
+type testTool struct {
+	kind string
+}
+
+func (t testTool) Kind() string { return t.kind }
+
+func (t testTool) Execute(ctx context.Context, ec plugin.ExecutionContext) (map[string]any, error) {
+	return map[string]any{"kind": t.kind}, nil
+}
+
+func TestRegisterAndLookup(t *testing.T) {
+	kind := fmt.Sprintf("integration.test.%d", time.Now().UnixNano())
+	Register(testTool{kind: kind})
+
+	tool, ok := get(kind)
+	if !ok {
+		t.Fatalf("expected tool %q to be registered", kind)
+	}
+	if tool.Kind() != kind {
+		t.Fatalf("registered tool kind = %q, want %q", tool.Kind(), kind)
+	}
+}
+
+func TestIntegrationNodeExecuteByType(t *testing.T) {
+	kind := fmt.Sprintf("integration.test.execute.%d", time.Now().UnixNano())
+	Register(testTool{kind: kind})
+
+	n := &integrationNode{kind: kind}
+	out, err := n.Execute(context.Background(), plugin.ExecutionContext{Type: kind})
+	if err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	if out["kind"] != kind {
+		t.Fatalf("unexpected output kind: %v", out["kind"])
+	}
+}
+
+func TestIntegrationNodeUnknownKind(t *testing.T) {
+	n := &integrationNode{kind: "integration.unknown.kind"}
+	_, err := n.Execute(context.Background(), plugin.ExecutionContext{})
+	if err == nil {
+		t.Fatal("expected error for unknown integration kind")
+	}
+}
+
+func TestRegisterDuplicatePanics(t *testing.T) {
+	kind := fmt.Sprintf("integration.test.dup.%d", time.Now().UnixNano())
+	Register(testTool{kind: kind})
+
+	defer func() {
+		if recover() == nil {
+			t.Fatal("expected panic for duplicate kind")
+		}
+	}()
+	Register(testTool{kind: kind})
+}

--- a/services/rune-worker/pkg/registry/init_registry.go
+++ b/services/rune-worker/pkg/registry/init_registry.go
@@ -5,6 +5,7 @@ import (
 
 	"rune-worker/pkg/nodes"
 	// Import all node packages to trigger their init() functions
+	_ "rune-worker/pkg/integrations/bootstrap"
 	_ "rune-worker/pkg/nodes/custom/agent"
 	_ "rune-worker/pkg/nodes/custom/aggregator"
 	_ "rune-worker/pkg/nodes/custom/conditional"

--- a/services/rune-worker/rfcs/README.md
+++ b/services/rune-worker/rfcs/README.md
@@ -133,6 +133,19 @@ Specification for the typed date/time node family:
 
 ---
 
+### [RFC-010-integration-nodes.md](./RFC-010-integration-nodes.md)
+**Status**: Implemented  
+**Created**: 2026-05-07  
+**Title**: Integration Nodes Architecture for rune-worker
+
+Specification for integration node execution in worker:
+- Canonical kind format: `integration.<provider>.<service>.<tool>`
+- Internal integrations registry + adapter wiring into global node registry
+- Shared connector on top of `httpcore` for URL/auth/request execution
+- Phase 1 Gmail tools with typed args parsing and non-2xx error contract
+
+---
+
 ### [ISSUE_RECURSIVE_EXECUTOR.md](./ISSUE_RECURSIVE_EXECUTOR.md)
 **Status**: Superseded by RFC-001  
 **Title**: Implement Recursive Node-by-Node Executor with RabbitMQ

--- a/services/rune-worker/rfcs/RFC-010-integration-nodes.md
+++ b/services/rune-worker/rfcs/RFC-010-integration-nodes.md
@@ -1,0 +1,207 @@
+# RFC-010: Integration Nodes Architecture for rune-worker
+
+## Status
+
+Implemented (Phase 1: Gmail)
+
+## Authors
+
+Rune Worker Team
+
+## Created
+
+2026-05-07
+
+## Abstract
+
+This RFC defines the architecture for executing integration nodes in
+`services/rune-worker` using node kinds in the format:
+
+`integration.<provider>.<service>.<tool>`
+
+The design introduces a dedicated `pkg/integrations` package with:
+
+- A local tool registry keyed by full integration kind.
+- A thin adapter wired into the global node registry.
+- A shared connector layer that reuses `pkg/nodes/shared/httpcore`.
+- Per-tool typed argument parsing and validation.
+
+Phase 1 implements Gmail tools with tests and documentation.
+
+## Motivation
+
+The frontend integration catalog already defines provider/service/tool metadata and
+arguments, but the worker lacked a standardized execution layer for those nodes.
+Without a dedicated package, adding integrations would duplicate HTTP logic,
+credential handling, registration patterns, and tests.
+
+We need:
+
+- A scalable structure for many tools across providers.
+- Consistent dispatch and output contracts.
+- Reuse of existing shared HTTP behavior (`httpcore`).
+- Predictable error behavior integrating with existing worker error strategies.
+
+## Scope
+
+In scope:
+
+- New `pkg/integrations` architecture and wiring.
+- Shared connector implementation on top of `httpcore`.
+- Gmail tools:
+  - `integration.google.gmail.send_email`
+  - `integration.google.gmail.read_email`
+  - `integration.google.gmail.search_emails`
+  - `integration.google.gmail.list_labels`
+- Unit tests for connector, registry, args decode, and Gmail tools.
+
+Out of scope:
+
+- Token refresh lifecycle in worker.
+- Sheets and Outlook tools (follow-up phases).
+- Cross-service protocol changes to API/frontend payload contracts.
+
+## Design Decisions
+
+### 1) Execution model
+
+Integration tools execute in-process in worker, same as other node types.
+
+### 2) Credentials
+
+Credentials are already resolved by master and inserted into node credentials.
+Worker uses `ExecutionContext.GetCredentials()` as-is.
+
+### 3) Node kind dispatch
+
+- Global registry still requires exact node type registration.
+- Integrations register each full kind using a shared adapter factory.
+- Adapter delegates execution to integration-local registry by kind.
+
+### 4) Tool contract
+
+Each tool is a stateless singleton:
+
+```go
+type Tool interface {
+    Kind() string
+    Execute(context.Context, plugin.ExecutionContext) (map[string]any, error)
+}
+```
+
+### 5) HTTP behavior reuse
+
+All HTTP calls are routed through shared `httpcore`:
+
+- URL/path/query assembly via connector.
+- Auth header injection via `httpcore.ApplyCredential`.
+- HTTP execution via `httpcore.Execute`.
+
+### 6) Error behavior
+
+Connector defaults to fail on non-2xx and returns typed `*connector.Error`.
+Tools can opt into pass-through with `AllowNon2xx` for special cases.
+
+### 7) Output contract
+
+Tools return the same envelope shape as HTTP node by default:
+
+`{status, status_text, body, headers, duration_ms}`.
+
+### 8) Arguments
+
+Each tool defines a typed args struct and decodes from `ec.Parameters` via shared
+`DecodeArgs(...)` helper (JSON marshal/unmarshal round-trip).
+
+## Package Layout
+
+```text
+pkg/integrations/
+  args.go
+  registry.go
+  loader.go
+  internal/connector/connector.go
+  providers/google/gmail/*.go
+```
+
+Wiring point:
+
+- `pkg/registry/init_registry.go` blank-imports `rune-worker/pkg/integrations`.
+
+## Runtime Flow
+
+1. Executor builds `plugin.ExecutionContext`.
+2. `Registry.Create(ec.Type, ec)` returns integration adapter for matching kind.
+3. Adapter looks up tool in integration map and calls `Tool.Execute`.
+4. Tool parses args, builds connector spec, calls connector.
+5. Connector builds request and invokes `httpcore`.
+6. Tool returns envelope output or error.
+7. Existing executor status/error handling logic proceeds unchanged.
+
+## Security Considerations
+
+- Credential values are never resolved in worker and are consumed only from
+  pre-resolved execution context.
+- Auth header injection uses existing shared credential logic from `httpcore`.
+- Non-2xx response handling preserves provider error payload in typed connector
+  errors for observability.
+- No additional credential storage/persistence is introduced.
+
+## Testing Strategy
+
+- Unit tests for:
+  - argument decode helper,
+  - integration registry + adapter dispatch,
+  - connector URL/auth/error handling,
+  - each Gmail tool behavior.
+- `httptest.Server` is used for tool and connector tests.
+- Service package `baseURL` vars are swapped in tests for deterministic endpoints.
+
+## Trade-offs
+
+Pros:
+
+- Reuses mature HTTP core behavior.
+- Isolates integration complexity from generic executor code.
+- Scales linearly with new tools using small focused files.
+- Keeps contracts consistent with existing HTTP output shape.
+
+Cons:
+
+- Global registry still receives one registration per integration kind.
+- Connector currently uses one-value-per-query-key map (no repeated-key query
+  encoding yet).
+- Worker does not refresh OAuth tokens in this phase.
+
+## Future Work
+
+1. Add Sheets and Outlook tool implementations.
+2. Introduce richer query encoding support (repeated query keys where needed).
+3. Optional provider-aware retry/backoff policies.
+4. Evaluate token refresh strategy with API coordination.
+5. Add integration/e2e scenarios through full worker execution pipeline.
+
+## Rollout Plan
+
+Phase 1 (this RFC implementation):
+
+- Scaffold architecture and Gmail tools.
+- Add tests and docs.
+
+Phase 2:
+
+- Add Google Sheets tools.
+
+Phase 3:
+
+- Add Microsoft Outlook tools.
+
+## Acceptance Criteria
+
+- Worker can execute Gmail integration kinds from DSL nodes.
+- Auth is injected through existing credential mechanism.
+- Non-2xx responses surface as node execution errors.
+- Unit tests pass for connector/registry/args/Gmail tools.
+- Docs exist:
+  - `pkg/integrations/README.md`
+  - RFC entry in `rfcs/README.md`.


### PR DESCRIPTION
## Summary
- Introduces a worker-side integrations framework in `services/rune-worker/pkg/integrations` for node kinds in the format `integration.<provider>.<service>.<tool>`.
- Adds Gmail Phase 1 tools: `send_email`, `read_email`, `search_emails`, and `list_labels`.
- Adds a shared connector layer built on `httpcore` for URL/path/query building, credential injection, and HTTP execution.
- Wires integrations into registry bootstrap via `pkg/integrations/bootstrap` (avoids import cycles).
- Adds tests, package docs, and RFC-010.

## Why
- Frontend already emits integration node kinds and arguments, but worker lacked a scalable execution layer.
- This creates a consistent pattern to add more integrations without changing executor flow per tool.

## What Changed

### Integration Framework
- Added:
  - `pkg/integrations/registry.go`
  - `pkg/integrations/args.go`
  - `pkg/integrations/bootstrap/loader.go`
- Tool dispatch is kind-based using `ExecutionContext.Type`.

### Shared Connector
- Added:
  - `pkg/integrations/internal/connector/connector.go`
- Responsibilities:
  - Build full URL from base/path/path args
  - Apply credentials using `httpcore.ApplyCredential`
  - Execute request through `httpcore.Execute`
  - Return standard envelope (`status`, `status_text`, `body`, `headers`, `duration_ms`)
  - Raise typed error on non-2xx by default

### Gmail Tools
- Added:
  - `pkg/integrations/providers/google/gmail/send_email.go`
  - `pkg/integrations/providers/google/gmail/read_email.go`
  - `pkg/integrations/providers/google/gmail/search_emails.go`
  - `pkg/integrations/providers/google/gmail/list_labels.go`
  - `pkg/integrations/providers/google/gmail/gmail.go`
- `send_email` builds RFC-2822 message, base64url encodes, and calls Gmail send endpoint.

### Registry Wiring
- Updated:
  - `pkg/registry/init_registry.go`
- Integration bootstrap package is imported so Gmail tool `init()` registrations execute at startup.

### Docs & RFC
- Added:
  - `pkg/integrations/README.md`
  - `rfcs/RFC-010-integration-nodes.md`
- Updated:
  - `rfcs/README.md` (RFC-010 entry)

## Testing
- Added tests for:
  - args decode helper
  - integration registry dispatch
  - connector behavior
  - all Gmail tools
- Verification run:
  - `make worker-format`
  - `make worker-lint`
  - `make worker-test`
  - `go test ./pkg/integrations/...`

## Follow-ups (Out of Scope)
- Add Google Sheets tools
- Add Microsoft Outlook tools
- Evaluate repeated-key query support in connector if needed
- Define token refresh strategy (currently uses master-injected creds as-is)
