### PR TITLE
feat(web): DialogContent closeOnOutsideClick / closeOnEscape; sticky …

### DIFF
--- a/apps/web/src/components/admin/TempPasswordModal.tsx
+++ b/apps/web/src/components/admin/TempPasswordModal.tsx
@@ -36,7 +36,12 @@ export function TempPasswordModal({ open, onClose, email, password }: TempPasswo
         if (!nextOpen) onClose();
       }}
     >
-      <DialogContent hideCloseButton className="max-w-md gap-4">
+      <DialogContent
+        hideCloseButton
+        closeOnOutsideClick={false}
+        closeOnEscape={false}
+        className="max-w-md gap-4"
+      >
         <DialogHeader className="gap-2 text-left">
           <DialogTitle className="text-lg">Invitation created</DialogTitle>
           <DialogDescription>

--- a/apps/web/src/components/ui/dialog.tsx
+++ b/apps/web/src/components/ui/dialog.tsx
@@ -31,31 +31,77 @@ DialogOverlay.displayName = DialogPrimitive.Overlay.displayName;
 type DialogContentProps = React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content> & {
   /** When true, omits the default top-right close control (e.g. footer-only actions). */
   hideCloseButton?: boolean;
+  /** When false, backdrop / outside pointer and focus do not dismiss the dialog. Default true. */
+  closeOnOutsideClick?: boolean;
+  /** When false, Escape does not dismiss the dialog. Default true. */
+  closeOnEscape?: boolean;
 };
 
 const DialogContent = React.forwardRef<
   React.ElementRef<typeof DialogPrimitive.Content>,
   DialogContentProps
->(({ className, children, hideCloseButton, ...props }, ref) => (
-  <DialogPortal>
-    <DialogOverlay />
-    <DialogPrimitive.Content
-      ref={ref}
-      className={cn(
-        "fixed left-1/2 top-1/2 z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-6 rounded-[var(--radius)] border border-border/70 bg-card p-6 shadow-lg shadow-black/50 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95",
-        className,
-      )}
-      {...props}
-    >
-      {children}
-      {hideCloseButton ? null : (
-        <DialogPrimitive.Close className="absolute right-3 top-3 inline-flex h-9 w-9 items-center justify-center rounded-full text-lg text-muted-foreground transition-colors hover:bg-primary/10 hover:text-foreground focus-visible:outline-none focus-visible:ring-primary/50 focus-visible:ring-offset-background">
-          <span className="sr-only">Close</span>×
-        </DialogPrimitive.Close>
-      )}
-    </DialogPrimitive.Content>
-  </DialogPortal>
-));
+>(
+  (
+    {
+      className,
+      children,
+      hideCloseButton,
+      closeOnOutsideClick = true,
+      closeOnEscape = true,
+      onPointerDownOutside,
+      onInteractOutside,
+      onFocusOutside,
+      onEscapeKeyDown,
+      ...rest
+    },
+    ref,
+  ) => {
+    const handlePointerDownOutside: DialogContentProps["onPointerDownOutside"] = (e) => {
+      onPointerDownOutside?.(e);
+      if (!closeOnOutsideClick && !e.defaultPrevented) e.preventDefault();
+    };
+
+    const handleInteractOutside: DialogContentProps["onInteractOutside"] = (e) => {
+      onInteractOutside?.(e);
+      if (!closeOnOutsideClick && !e.defaultPrevented) e.preventDefault();
+    };
+
+    const handleFocusOutside: DialogContentProps["onFocusOutside"] = (e) => {
+      onFocusOutside?.(e);
+      if (!closeOnOutsideClick && !e.defaultPrevented) e.preventDefault();
+    };
+
+    const handleEscapeKeyDown: DialogContentProps["onEscapeKeyDown"] = (e) => {
+      onEscapeKeyDown?.(e);
+      if (!closeOnEscape && !e.defaultPrevented) e.preventDefault();
+    };
+
+    return (
+      <DialogPortal>
+        <DialogOverlay />
+        <DialogPrimitive.Content
+          ref={ref}
+          className={cn(
+            "fixed left-1/2 top-1/2 z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-6 rounded-[var(--radius)] border border-border/70 bg-card p-6 shadow-lg shadow-black/50 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95",
+            className,
+          )}
+          onPointerDownOutside={handlePointerDownOutside}
+          onInteractOutside={handleInteractOutside}
+          onFocusOutside={handleFocusOutside}
+          onEscapeKeyDown={handleEscapeKeyDown}
+          {...rest}
+        >
+          {children}
+          {hideCloseButton ? null : (
+            <DialogPrimitive.Close className="absolute right-3 top-3 inline-flex h-9 w-9 items-center justify-center rounded-full text-lg text-muted-foreground transition-colors hover:bg-primary/10 hover:text-foreground focus-visible:outline-none focus-visible:ring-primary/50 focus-visible:ring-offset-background">
+              <span className="sr-only">Close</span>×
+            </DialogPrimitive.Close>
+          )}
+        </DialogPrimitive.Content>
+      </DialogPortal>
+    );
+  },
+);
 DialogContent.displayName = DialogPrimitive.Content.displayName;
 
 const DialogHeader = ({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) => (


### PR DESCRIPTION
## Summary

Adds optional **`closeOnOutsideClick`** and **`closeOnEscape`** on shared **`DialogContent`** (defaults preserve existing Radix dismiss behavior). **`TempPasswordModal`** sets both to **`false`** so users cannot lose the one-time password via backdrop misclick or Escape before copying.

## Changes

- **`apps/web/src/components/ui/dialog.tsx`**: compose `onPointerDownOutside`, `onInteractOutside`, `onFocusOutside`, and `onEscapeKeyDown` with consumer handlers; when `closeOnOutsideClick` is `false`, `preventDefault` on outside events (unless already prevented); when `closeOnEscape` is `false`, same for Escape.
- **`apps/web/src/components/admin/TempPasswordModal.tsx`**: `closeOnOutsideClick={false}` `closeOnEscape={false}`.

## Acceptance criteria
- [x] With both new props omitted, behavior matches today (backdrop + Escape still dismiss).
- [x] Temp password modal: backdrop click and Escape do **not** dismiss; **Close** still dismisses; copy flow unchanged.
- [x] Callers that pass their own `onPointerDownOutside` / `onInteractOutside` / `onFocusOutside` / `onEscapeKeyDown` still run; guards respect existing `defaultPrevented`.
- [x] Lint / typecheck / web tests pass.

## Testing

- [x] `make web-lint`
- [x] `make web-test`
- [x] `pnpm exec tsc --noEmit` (from `apps/web`)

**Manual:** Admin → Users → invite flow → temp password modal: backdrop and Escape do not close; **Close** does; another dialog (e.g. invite) still dismisses on backdrop + Escape with no new props.


Closes #622.