### PR TITLE
fix(worker): remove misleading trigger variable references

### DIFF
--- a/apps/web/src/client/sdk.gen.ts
+++ b/apps/web/src/client/sdk.gen.ts
@@ -1102,8 +1102,8 @@ export const oauthCallbackOauthCallbackGet = <ThrowOnError extends boolean = fal
  *
  * Trigger a workflow via its registered webhook URL.
  *
- * The request body (JSON) is forwarded to the worker as trigger data
- * under the ``$trigger`` key in the execution context.
+ * The request body (JSON) is forwarded to the worker as webhook request
+ * payload under the ``$trigger`` key in the execution context.
  *
  * No authentication is required — the GUID itself is the secret.
  * Returns 404 if the GUID is unknown or the workflow is inactive.

--- a/apps/web/src/client/types.gen.ts
+++ b/apps/web/src/client/types.gen.ts
@@ -1680,10 +1680,14 @@ export type UserBasicInfo = {
 export type UserCreate = {
     /**
      * Name
+     *
+     * User display name
      */
     name: string;
     /**
      * Email
+     *
+     * User email
      */
     email: string;
     /**

--- a/services/api/openapi.yaml
+++ b/services/api/openapi.yaml
@@ -2465,10 +2465,10 @@ paths:
       - Webhook
       summary: Trigger Webhook
       description: "Trigger a workflow via its registered webhook URL.\n\nThe request\
-        \ body (JSON) is forwarded to the worker as trigger data\nunder the ``$trigger``\
-        \ key in the execution context.\n\nNo authentication is required \u2014 the\
-        \ GUID itself is the secret.\nReturns 404 if the GUID is unknown or the workflow\
-        \ is inactive."
+        \ body (JSON) is forwarded to the worker as webhook request\npayload under\
+        \ the ``$trigger`` key in the execution context.\n\nNo authentication is required\
+        \ \u2014 the GUID itself is the secret.\nReturns 404 if the GUID is unknown\
+        \ or the workflow is inactive."
       operationId: trigger_webhook_webhook__guid__post
       parameters:
       - name: guid
@@ -2513,12 +2513,16 @@ components:
           - type: string
             maxLength: 40
             minLength: 3
+            description: User display name
           - type: 'null'
           title: Name
         email:
           anyOf:
           - type: string
+            maxLength: 255
+            minLength: 3
             format: email
+            description: User email
           - type: 'null'
           title: Email
         role:
@@ -3577,11 +3581,14 @@ components:
           description: Admin's full name
         email:
           type: string
+          maxLength: 255
+          minLength: 3
           format: email
           title: Email
           description: Admin's email address
         password:
           type: string
+          maxLength: 128
           minLength: 8
           title: Password
           description: Admin's password
@@ -3649,6 +3656,7 @@ components:
       properties:
         email:
           type: string
+          minLength: 1
           format: email
           title: Email
           description: User's email address
@@ -3670,12 +3678,16 @@ components:
           - type: string
             maxLength: 40
             minLength: 3
+            description: User display name
           - type: 'null'
           title: Name
         email:
           anyOf:
           - type: string
+            maxLength: 255
+            minLength: 3
             format: email
+            description: User email
           - type: 'null'
           title: Email
       type: object
@@ -4085,10 +4097,14 @@ components:
           maxLength: 40
           minLength: 3
           title: Name
+          description: User display name
         email:
           type: string
+          maxLength: 255
+          minLength: 3
           format: email
           title: Email
+          description: User email
         role:
           $ref: '#/components/schemas/UserRole'
           description: 'User role: ''user'' or ''admin'''
@@ -4102,10 +4118,12 @@ components:
       properties:
         old_password:
           type: string
+          minLength: 1
           title: Old Password
           description: Current password for verification
         new_password:
           type: string
+          maxLength: 128
           minLength: 8
           title: New Password
           description: New password

--- a/services/api/src/webhook/router.py
+++ b/services/api/src/webhook/router.py
@@ -14,8 +14,8 @@ async def trigger_webhook(
 ) -> Response:
     """Trigger a workflow via its registered webhook URL.
 
-    The request body (JSON) is forwarded to the worker as trigger data
-    under the ``$trigger`` key in the execution context.
+    The request body (JSON) is forwarded to the worker as webhook request
+    payload under the ``$trigger`` key in the execution context.
 
     No authentication is required — the GUID itself is the secret.
     Returns 404 if the GUID is unknown or the workflow is inactive.

--- a/services/api/src/workflow/queue.py
+++ b/services/api/src/workflow/queue.py
@@ -68,7 +68,7 @@ class WorkflowQueueService(BaseQueuePublisher):
 
         Creates a NodeExecutionMessage with the proper structure
         including workflow_id, execution_id, current_node (first node), workflow_definition,
-        and accumulated_context (with trigger data).
+        and accumulated_context (with optional caller-provided data).
 
         Args:
             workflow_id: The workflow database ID

--- a/services/rune-worker/docs/ARCHITECTURE.md
+++ b/services/rune-worker/docs/ARCHITECTURE.md
@@ -238,7 +238,7 @@ workflows Exchange (topic, durable)
   "current_node": "node_1",
   "workflow_definition": { /* full workflow */ },
   "accumulated_context": {
-    "$input": { /* trigger data */ },
+    "$input": { /* optional caller-provided input */ },
     "$node_1": { /* previous output */ }
   }
 }

--- a/services/rune-worker/docs/CUSTOM_NODES.md
+++ b/services/rune-worker/docs/CUSTOM_NODES.md
@@ -329,9 +329,9 @@ func (n *MyNode) Execute(ctx context.Context, execCtx plugin.ExecutionContext) (
         slog.Info("processing user", "user_id", userID)
     }
     
-    // Access workflow input
-    if triggerData, ok := execCtx.Input["$input"].(map[string]interface{}); ok {
-        requestID, _ := triggerData["request_id"].(string)
+    // Access caller-provided workflow input, when present
+    if inputData, ok := execCtx.Input["$input"].(map[string]interface{}); ok {
+        requestID, _ := inputData["request_id"].(string)
         slog.Info("processing request", "request_id", requestID)
     }
     

--- a/services/rune-worker/docs/NODE_TYPES.md
+++ b/services/rune-worker/docs/NODE_TYPES.md
@@ -41,7 +41,7 @@ All nodes share these common properties:
 
 Nodes can access data using template interpolation:
 
-- `{{$input.field}}` - Access workflow input/trigger data
+- `{{$input.field}}` - Access caller-provided workflow input, when present
 - `{{$previous_node.field}}` - Access output from a specific node
 - `{{$credential.field}}` - Access credential values
 

--- a/services/rune-worker/pkg/executor/executor_paths_test.go
+++ b/services/rune-worker/pkg/executor/executor_paths_test.go
@@ -87,7 +87,7 @@ func TestExecutorHandleSplitFanOutPublishesPerItemAndNode(t *testing.T) {
 				{ID: "next-b", Name: "Next B", Type: "conditional", Parameters: map[string]any{"expression": "true"}},
 			},
 		},
-		AccumulatedContext: map[string]any{"$trigger": "ok"},
+		AccumulatedContext: map[string]any{"$payload": "ok"},
 	}
 
 	node := &core.Node{
@@ -98,7 +98,7 @@ func TestExecutorHandleSplitFanOutPublishesPerItemAndNode(t *testing.T) {
 
 	nextNodes := []string{"next-a", "next-b"}
 	items := []any{"item-1", "item-2"}
-	baseContext := map[string]any{"$trigger": "ok"}
+	baseContext := map[string]any{"$payload": "ok"}
 
 	if err := exec.handleSplitFanOut(context.Background(), msg, node, nextNodes, items, baseContext); err != nil {
 		t.Fatalf("handleSplitFanOut failed: %v", err)
@@ -116,6 +116,9 @@ func TestExecutorHandleSplitFanOutPublishesPerItemAndNode(t *testing.T) {
 
 	if first.AccumulatedContext["$item"] != "item-1" {
 		t.Fatalf("expected first item in context, got %v", first.AccumulatedContext["$item"])
+	}
+	if first.AccumulatedContext["$payload"] != "ok" {
+		t.Fatalf("expected caller-provided payload to be preserved, got %v", first.AccumulatedContext["$payload"])
 	}
 	if first.WorkflowVersion != msg.WorkflowVersion || first.WorkflowVersionID != msg.WorkflowVersionID {
 		t.Fatalf("expected workflow version metadata to be preserved")
@@ -160,7 +163,7 @@ func TestExecutorExecuteSplitWithEmptyItemsCompletes(t *testing.T) {
 				{ID: "edge-1", Src: "split-1", Dst: "next-1"},
 			},
 		},
-		AccumulatedContext: map[string]any{"$trigger": "ok"},
+		AccumulatedContext: map[string]any{"$payload": "ok"},
 	}
 
 	if err := exec.Execute(context.Background(), msg); err != nil {
@@ -183,8 +186,8 @@ func TestExecutorExecuteSplitWithEmptyItemsCompletes(t *testing.T) {
 	if completion.Status != messages.CompletionStatusCompleted {
 		t.Fatalf("expected completed status, got %s", completion.Status)
 	}
-	if completion.FinalContext["$trigger"] != "ok" {
-		t.Fatalf("expected final context to preserve trigger data")
+	if completion.FinalContext["$payload"] != "ok" {
+		t.Fatalf("expected final context to preserve caller-provided payload, got %#v", completion.FinalContext)
 	}
 }
 

--- a/services/rune-worker/pkg/executor/executor_test.go
+++ b/services/rune-worker/pkg/executor/executor_test.go
@@ -379,7 +379,7 @@ func TestExecutor_ContextAccumulation(t *testing.T) {
 	}
 
 	initialContext := map[string]interface{}{
-		"$trigger": map[string]interface{}{"user_id": "123"},
+		"$payload": map[string]interface{}{"event_id": "evt_123"},
 	}
 
 	msg := &messages.NodeExecutionMessage{
@@ -406,9 +406,9 @@ func TestExecutor_ContextAccumulation(t *testing.T) {
 		t.Fatalf("Failed to unmarshal execution message: %v", err)
 	}
 
-	// Verify context contains both trigger and node output
-	if _, ok := nextMsg.AccumulatedContext["$trigger"]; !ok {
-		t.Error("Expected context to preserve $trigger")
+	// Verify context contains both initial payload and node output
+	if _, ok := nextMsg.AccumulatedContext["$payload"]; !ok {
+		t.Error("Expected context to preserve $payload")
 	}
 
 	nodeOutput, ok := nextMsg.AccumulatedContext["$Test Node"]

--- a/services/rune-worker/pkg/resolver/resolver_test.go
+++ b/services/rune-worker/pkg/resolver/resolver_test.go
@@ -19,9 +19,9 @@ func TestResolver_ResolveParameters(t *testing.T) {
 				},
 			},
 		},
-		"$trigger": map[string]interface{}{
-			"user_id": "456",
-			"action":  "login",
+		"$payload": map[string]interface{}{
+			"event_id": "evt_456",
+			"action":   "login",
 		},
 		"$json": []interface{}{
 			map[string]interface{}{"id": 1, "name": "First"},
@@ -38,10 +38,10 @@ func TestResolver_ResolveParameters(t *testing.T) {
 		{
 			name: "simple field reference",
 			parameters: map[string]interface{}{
-				"user_id": "$trigger.user_id",
+				"event_id": "$payload.event_id",
 			},
 			want: map[string]interface{}{
-				"user_id": "456",
+				"event_id": "evt_456",
 			},
 			wantErr: false,
 		},
@@ -78,7 +78,7 @@ func TestResolver_ResolveParameters(t *testing.T) {
 		{
 			name: "multiple references in same string",
 			parameters: map[string]interface{}{
-				"message": "User $http_node.body.user.name from $trigger.action",
+				"message": "User $http_node.body.user.name from $payload.action",
 			},
 			want: map[string]interface{}{
 				"message": "User John Doe from login",
@@ -89,13 +89,13 @@ func TestResolver_ResolveParameters(t *testing.T) {
 			name: "nested map with references",
 			parameters: map[string]interface{}{
 				"config": map[string]interface{}{
-					"user_id":   "$trigger.user_id",
+					"event_id":  "$payload.event_id",
 					"user_name": "$http_node.body.user.name",
 				},
 			},
 			want: map[string]interface{}{
 				"config": map[string]interface{}{
-					"user_id":   "456",
+					"event_id":  "evt_456",
 					"user_name": "John Doe",
 				},
 			},
@@ -105,13 +105,13 @@ func TestResolver_ResolveParameters(t *testing.T) {
 			name: "array with references",
 			parameters: map[string]interface{}{
 				"items": []interface{}{
-					"$trigger.user_id",
+					"$payload.event_id",
 					"$http_node.body.user.name",
 				},
 			},
 			want: map[string]interface{}{
 				"items": []interface{}{
-					"456",
+					"evt_456",
 					"John Doe",
 				},
 			},
@@ -132,12 +132,12 @@ func TestResolver_ResolveParameters(t *testing.T) {
 		{
 			name: "reference to entire node",
 			parameters: map[string]interface{}{
-				"trigger_data": "$trigger",
+				"payload_data": "$payload",
 			},
 			want: map[string]interface{}{
-				"trigger_data": map[string]interface{}{
-					"user_id": "456",
-					"action":  "login",
+				"payload_data": map[string]interface{}{
+					"event_id": "evt_456",
+					"action":   "login",
 				},
 			},
 			wantErr: false,

--- a/services/rune-worker/rfcs/RFC-001-recursive-executor.md
+++ b/services/rune-worker/rfcs/RFC-001-recursive-executor.md
@@ -458,7 +458,6 @@ This unified message structure ensures that both initial workflow starts and rec
   "execution_id": "exec_20251009_123456",
   "status": "completed",
   "final_context": {
-    "$trigger": {...},
     "$http_fetch_user": {...},
     "$smtp_send_email": {
       "sent": true,

--- a/services/rune-worker/rfcs/RFC-001-recursive-executor.md
+++ b/services/rune-worker/rfcs/RFC-001-recursive-executor.md
@@ -232,13 +232,13 @@ This proposal aims to achieve the following objectives:
 ┌─────────────────────────────────────────────────────────────┐
 │ INITIATION (Master Service)                                 │
 ├─────────────────────────────────────────────────────────────┤
-│ 1. Trigger fires (e.g., manual trigger, webhook)            │
-│ 2. Master executes trigger logic                            │
+│ 1. Workflow start is requested (e.g., manual run, webhook)  │
+│ 2. Master determines the first executable node              │
 │ 3. Master resolves ALL credentials for workflow nodes       │
 │ 4. Master publishes NodeExecutionMessage:                    │
 │    - current_node = first_execution_node_id                 │
 │    - workflow_definition (with resolved credentials)        │
-│    - accumulated_context = {"$trigger": trigger_output}     │
+│    - accumulated_context = optional caller-provided context │
 └─────────────────────────────────────────────────────────────┘
                            ↓
 ┌─────────────────────────────────────────────────────────────┐
@@ -285,7 +285,7 @@ Execution state is maintained through message payload propagation:
 ### 6.1 NodeExecutionMessage
 
 **Purpose**: Instructs a worker to execute a specific node. This message serves dual purposes:
-1. **Initial workflow start**: Published by master service after trigger execution
+1. **Initial workflow start**: Published by master service after run validation
 2. **Recursive execution**: Published by workers after completing a node
 
 **Queue**: `workflow.execution`
@@ -325,12 +325,7 @@ Execution state is maintained through message payload propagation:
     "nodes": [...],
     "edges": [...]
   },
-  "accumulated_context": {
-    "$trigger": {
-      "user_id": "user_123",
-      "timestamp": "2025-10-09T12:34:56Z"
-    }
-  }
+  "accumulated_context": {}
 }
 ```
 
@@ -345,7 +340,7 @@ This unified message structure ensures that both initial workflow starts and rec
 
 **Initial vs Recursive Messages**:
 
-- **Initial Message**: `current_node` points to the first execution node (trigger outputs already in `accumulated_context` as `$trigger`)
+- **Initial Message**: `current_node` points to the first executable node after the trigger node
 - **Recursive Message**: `current_node` points to next node, `accumulated_context` includes all previous node outputs with `$<node_name>` keys
 
 ### 6.2 NodeStatusMessage
@@ -554,20 +549,20 @@ Workers MUST:
 Example accumulation:
 
 ```
-Initial context:
+Initial context, if the caller provided one:
   {
-    "$trigger": {"user_id": "123"}
+    "$payload": {"event_id": "evt_123"}
   }
 
 After "Fetch User" node execution:
   {
-    "$trigger": {"user_id": "123"},
+    "$payload": {"event_id": "evt_123"},
     "$Fetch User": {"status": 200, "body": {...}}
   }
 
 After "Check Status" conditional node execution:
   {
-    "$trigger": {"user_id": "123"},
+    "$payload": {"event_id": "evt_123"},
     "$Fetch User": {"status": 200, "body": {...}},
     "$Check Status": {"result": true}
   }

--- a/services/rune-worker/rfcs/RFC-002-workflow-dsl.md
+++ b/services/rune-worker/rfcs/RFC-002-workflow-dsl.md
@@ -500,7 +500,7 @@ Initiates workflow execution through manual user action.
 {}
 ```
 
-Manual trigger nodes have no parameters. They are executed in the master service and provide initial context to the workflow.
+Manual trigger nodes have no parameters and no output. The master service uses them only to locate the workflow entry point.
 
 **Example:**
 


### PR DESCRIPTION
Remove inaccurate references that implied trigger nodes expose runtime variables such as `$trigger.user_id`. Trigger nodes are workflow entry markers and do not produce variable data. Kept webhook payload behavior intact, where webhook request JSON is still available under `$trigger`, and clarified docs/tests/UI metadata accordingly.