### PR TITLE
fix(auth): sync session state across browser tabs

### DIFF
--- a/apps/web/src/lib/auth.tsx
+++ b/apps/web/src/lib/auth.tsx
@@ -189,6 +189,23 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     };
   }, [initialize]);
 
+  useEffect(() => {
+    const handleStorageChange = (e: StorageEvent) => {
+      if (e.key === REFRESH_TOKEN_KEY || e.key === ACCESS_EXP_KEY) {
+        if (!e.newValue) {
+          storeRefreshToken(null);
+          storeAccessExp(null);
+          clearScheduledRefresh();
+          setUser(null);
+        } else {
+          fetchProfile();
+        }
+      }
+    };
+    window.addEventListener("storage", handleStorageChange);
+    return () => window.removeEventListener("storage", handleStorageChange);
+  }, [fetchProfile]);
+
   const login = useCallback(
     async (email: string, password: string) => {
       setLoading(true);


### PR DESCRIPTION
- closes #499 

- Listen to browser `storage` events to detect session changes in other tabs
- When a user logs out in one tab, other tabs now immediately clear the local user state
- When a user logs into a different account, other tabs refetch the profile to display the correct identity