### PR TITLE
ci(worker): add golangci-lint config (gofmt) and fix worker-lint

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -296,7 +296,13 @@ worker-lint:
 	@echo "Vetting code..."
 	cd services/rune-worker && go vet ./...
 	@echo "Checking code formatting..."
-	@cd services/rune-worker && gofmt -l . | grep -q . && (echo "❌ Code formatting issues found. Run 'make worker-format' to fix." && gofmt -l . && exit 1) || echo "✓ Code formatting OK"
+	@if cd services/rune-worker && gofmt -l . | grep -q .; then \
+		echo "❌ Code formatting issues found. Run 'make worker-format' to fix."; \
+		cd services/rune-worker && gofmt -l .; \
+		exit 1; \
+	else \
+		echo "✓ Code formatting OK"; \
+	fi
 
 worker-format:
 	@echo "Formatting worker code..."

--- a/services/rune-worker/.golangci.yml
+++ b/services/rune-worker/.golangci.yml
@@ -1,0 +1,15 @@
+# golangci-lint v2 — picked up automatically by golangci-lint-action when running in this directory.
+# See: https://golangci-lint.run/docs/configuration/file/
+version: "2"
+
+run:
+  timeout: 5m
+
+linters:
+  # Preserve typical CI defaults (same spirit as golangci-lint without a config file).
+  default: standard
+
+formatters:
+  # Align with `make worker-lint` / `gofmt -l` so CI catches formatting drift.
+  enable:
+    - gofmt

--- a/services/rune-worker/pkg/integrations/providers/google/sheets/delete_columns.go
+++ b/services/rune-worker/pkg/integrations/providers/google/sheets/delete_columns.go
@@ -68,7 +68,7 @@ func (DeleteColumns) Execute(ctx context.Context, ec plugin.ExecutionContext) (m
 					"deleteDimension": map[string]any{
 						"range": map[string]any{
 							"sheetId":    sheetID,
-							"dimension": "COLUMNS",
+							"dimension":  "COLUMNS",
 							"startIndex": startIndex,
 							"endIndex":   endIndex,
 						},

--- a/services/rune-worker/pkg/integrations/providers/google/sheets/delete_columns.go
+++ b/services/rune-worker/pkg/integrations/providers/google/sheets/delete_columns.go
@@ -68,7 +68,7 @@ func (DeleteColumns) Execute(ctx context.Context, ec plugin.ExecutionContext) (m
 					"deleteDimension": map[string]any{
 						"range": map[string]any{
 							"sheetId":    sheetID,
-							"dimension":  "COLUMNS",
+							"dimension": "COLUMNS",
 							"startIndex": startIndex,
 							"endIndex":   endIndex,
 						},

--- a/services/rune-worker/pkg/integrations/providers/google/sheets/delete_rows.go
+++ b/services/rune-worker/pkg/integrations/providers/google/sheets/delete_rows.go
@@ -63,7 +63,7 @@ func (DeleteRows) Execute(ctx context.Context, ec plugin.ExecutionContext) (map[
 					"deleteDimension": map[string]any{
 						"range": map[string]any{
 							"sheetId":    sheetID,
-							"dimension":  "ROWS",
+							"dimension": "ROWS",
 							"startIndex": startIndex,
 							"endIndex":   endIndex,
 						},

--- a/services/rune-worker/pkg/integrations/providers/google/sheets/delete_rows.go
+++ b/services/rune-worker/pkg/integrations/providers/google/sheets/delete_rows.go
@@ -63,7 +63,7 @@ func (DeleteRows) Execute(ctx context.Context, ec plugin.ExecutionContext) (map[
 					"deleteDimension": map[string]any{
 						"range": map[string]any{
 							"sheetId":    sheetID,
-							"dimension": "ROWS",
+							"dimension":  "ROWS",
 							"startIndex": startIndex,
 							"endIndex":   endIndex,
 						},


### PR DESCRIPTION
## Summary
- Add `services/rune-worker/.golangci.yml` (golangci-lint **v2**) so Worker CI matches local formatting expectations: **`linters.default: standard`** plus **`formatters.enable: gofmt`** (same idea as `gofmt -l` / `make worker-format`).
- Fix **`make worker-lint`** so a gofmt failure no longer prints `✓ Code formatting OK` (broken `&& … || echo` shell logic).
- Run **`gofmt`** on `pkg/integrations/providers/google/sheets/delete_columns.go` and `delete_rows.go` so the branch passes the new formatter check.
## Test plan
- [x] `make worker-lint`
- [x] Match CI lint job: `docker run --rm -v "$(pwd)/services/rune-worker:/src" -w /src golangci/golangci-lint:v2.11.4 golangci-lint run --timeout=5m`
- [x] Worker CI green on PR (`Lint` job uses existing `golangci-lint-action` + discovers `.golangci.yml` in module dir)
