### PR TITLE
ci: pin hey-api/openapi-ts to 0.97.3

### DIFF
--- a/.github/workflows/generate-client.yml
+++ b/.github/workflows/generate-client.yml
@@ -46,7 +46,8 @@ jobs:
         working-directory: ./services/api
       
       - name: Generate client with hey-api
-        run: pnpm dlx @hey-api/openapi-ts -f heyapi.conf.js
+        # Keep this pinned until a hey-api release special-cases SSE annotations.
+        run: pnpm dlx @hey-api/openapi-ts@0.97.3 -f heyapi.conf.js
       
       - name: Create PR with client changes
         run: |


### PR DESCRIPTION
The recent 0.98.x updates to openapi-ts are causing problems in typechecks for regenerated clients that consume SSE streams.

This pins client generation to `@hey-api/openapi-ts@0.97.3`, the last known-good version before the explicit SDK return-type change that caused this bug.

The pin should be removed once hey-api fixes the SSE return annotation. 