### PR TITLE
fix(web): allow canvas runs for draft/inactive workflows

### DIFF
--- a/apps/web/src/app/(canvas)/create/app/page.tsx
+++ b/apps/web/src/app/(canvas)/create/app/page.tsx
@@ -32,6 +32,17 @@ type WorkflowMeta = {
   latestVersionNumber: number | null;
 };
 
+function updateWorkflowMetaAfterSave(
+  previous: WorkflowMeta | null,
+  version: { id: number; version: number; is_published: boolean },
+): WorkflowMeta {
+  return {
+    publishedVersionId: version.is_published ? version.id : (previous?.publishedVersionId ?? null),
+    hasUnpublishedChanges: !version.is_published,
+    latestVersionNumber: version.version,
+  };
+}
+
 function getApiErrorMessage(error: unknown, fallback: string): string {
   if (error && typeof error === "object" && "detail" in error) {
     const detail = (error as { detail: unknown }).detail;
@@ -191,13 +202,12 @@ function CanvasPageInner() {
         });
 
         const newVersion = response.data!.data;
+        const didCreateVersion = newVersion.id !== baseVersionIdRef.current;
         setBaseVersionId(newVersion.id);
-        setWorkflowMeta((prev) => ({
-          publishedVersionId: prev?.publishedVersionId ?? null,
-          hasUnpublishedChanges: true,
-          latestVersionNumber: newVersion.version,
-        }));
-        toast.success("Version saved");
+        setWorkflowMeta((prev) => updateWorkflowMetaAfterSave(prev, newVersion));
+        if (didCreateVersion) {
+          toast.success("Version saved");
+        }
         return newVersion.id;
       } catch (err) {
         const conflict = workflows.isVersionConflict(err);
@@ -295,13 +305,12 @@ function CanvasPageInner() {
       });
 
       const newVersion = response.data!.data;
+      const didCreateVersion = newVersion.id !== conflictData.serverVersionId;
       setBaseVersionId(newVersion.id);
-      setWorkflowMeta((prev) => ({
-        publishedVersionId: prev?.publishedVersionId ?? null,
-        hasUnpublishedChanges: true,
-        latestVersionNumber: newVersion.version,
-      }));
-      toast.success("Version saved");
+      setWorkflowMeta((prev) => updateWorkflowMetaAfterSave(prev, newVersion));
+      if (didCreateVersion) {
+        toast.success("Version saved");
+      }
     } catch (err) {
       const nestedConflict = workflows.isVersionConflict(err);
       if (nestedConflict) {

--- a/services/api/src/workflow/service.py
+++ b/services/api/src/workflow/service.py
@@ -356,10 +356,10 @@ class WorkflowService:
     async def get_run_version(
         self, workflow: Workflow, version_id: int | None
     ) -> WorkflowVersion:
-        if not workflow.is_active:
-            raise BadRequest(detail="Workflow is inactive")
-
         if version_id is None:
+            if not workflow.is_active:
+                raise BadRequest(detail="Workflow is inactive")
+
             if workflow.published_version_id is None:
                 raise BadRequest(detail="Workflow has no published version")
 

--- a/services/api/test/workflow/test_workflow_api.py
+++ b/services/api/test/workflow/test_workflow_api.py
@@ -249,6 +249,82 @@ class TestWorkflowExecution:
         await channel.close()
 
     @pytest.mark.asyncio
+    async def test_specific_version_can_run_for_draft_workflow(
+        self,
+        authenticated_client,
+        sample_workflow,
+        test_rabbitmq,
+        test_settings,
+    ):
+        """Canvas runs pin the latest draft version and bypass table status gating."""
+        detail = await authenticated_client.get(f"/workflows/{sample_workflow.id}")
+        version = detail.json()["data"]["latest_version"]
+
+        channel = await test_rabbitmq.channel()
+        queue = await channel.declare_queue(
+            test_settings.rabbitmq_workflow_queue,
+            durable=True,
+        )
+        await queue.purge()
+
+        response = await authenticated_client.post(
+            f"/workflows/{sample_workflow.id}/run",
+            json={"version_id": version["id"]},
+        )
+        assert response.status_code == 200
+
+        message = await queue.get(timeout=5)
+        assert message is not None
+        payload = json.loads(message.body.decode("utf-8"))
+        assert payload["workflow_version_id"] == version["id"]
+
+        await channel.close()
+
+    @pytest.mark.asyncio
+    async def test_specific_version_can_run_for_inactive_workflow(
+        self,
+        authenticated_client,
+        sample_workflow,
+        test_rabbitmq,
+        test_settings,
+    ):
+        """Explicit version runs still work after a published workflow is deactivated."""
+        detail = await authenticated_client.get(f"/workflows/{sample_workflow.id}")
+        version = detail.json()["data"]["latest_version"]
+
+        publish = await authenticated_client.post(
+            f"/workflows/{sample_workflow.id}/publish",
+            json={"version_id": version["id"]},
+        )
+        assert publish.status_code == 200
+
+        deactivate = await authenticated_client.put(
+            f"/workflows/{sample_workflow.id}/status",
+            json={"is_active": False},
+        )
+        assert deactivate.status_code == 200
+
+        channel = await test_rabbitmq.channel()
+        queue = await channel.declare_queue(
+            test_settings.rabbitmq_workflow_queue,
+            durable=True,
+        )
+        await queue.purge()
+
+        response = await authenticated_client.post(
+            f"/workflows/{sample_workflow.id}/run",
+            json={"version_id": version["id"]},
+        )
+        assert response.status_code == 200
+
+        message = await queue.get(timeout=5)
+        assert message is not None
+        payload = json.loads(message.body.decode("utf-8"))
+        assert payload["workflow_version_id"] == version["id"]
+
+        await channel.close()
+
+    @pytest.mark.asyncio
     async def test_unpublished_workflow_cannot_be_executed(
         self,
         authenticated_client,


### PR DESCRIPTION
Fixes a canvas run regression introduced in #607 by allowing explicit version runs to execute regardless of workflow status, while keeping draft/inactive gating for workflow table runs as intended.

Also fixes a stale “Version saved” toast when an unchanged save is deduplicated and no new version is created.