### PR TITLE
fix(canvas): count only executable nodes in progress

### DIFF
--- a/apps/web/src/features/canvas/components/ExecutionStatusBar.test.tsx
+++ b/apps/web/src/features/canvas/components/ExecutionStatusBar.test.tsx
@@ -44,14 +44,15 @@ describe("ExecutionStatusBar", () => {
       workflowId: 12,
       status: "running",
       nodes: new Map([
-        ["trigger", { nodeId: "trigger", status: "success" }],
         ["http", { nodeId: "http", status: "running" }],
+        ["edit", { nodeId: "edit", status: "success" }],
         ["log", { nodeId: "log", status: "failed" }],
       ]),
     });
 
     render(
       <ExecutionStatusBar
+        totalNodes={5}
         wsStatus="reconnecting"
         wsReconnectAttempts={2}
         onDismissRunning={onDismissRunning}
@@ -60,7 +61,7 @@ describe("ExecutionStatusBar", () => {
 
     expect(screen.getByText("Reconnecting...")).toBeInTheDocument();
     expect(
-      screen.getByLabelText("2 of 3 nodes completed, 1 currently running"),
+      screen.getByLabelText("2 of 5 nodes completed, 1 currently running"),
     ).toBeInTheDocument();
     expect(screen.getByLabelText("Execution ID: exec-abcdef123")).toBeInTheDocument();
 

--- a/apps/web/src/features/canvas/components/ExecutionStatusBar.tsx
+++ b/apps/web/src/features/canvas/components/ExecutionStatusBar.tsx
@@ -92,10 +92,12 @@ function getStatusConfig(
  * Auto-dismisses after completion/failure/halt.
  */
 export function ExecutionStatusBar({
+  totalNodes: graphTotalNodes,
   wsStatus = "disconnected",
   wsReconnectAttempts = 0,
   onDismissRunning,
 }: {
+  totalNodes?: number;
   wsStatus?: WsConnectionStatus;
   wsReconnectAttempts?: number;
   onDismissRunning?: () => void;
@@ -140,13 +142,12 @@ export function ExecutionStatusBar({
   }
 
   // Count completed/total nodes
-  const totalNodes = state.nodes.size;
-  const completedNodes = Array.from(state.nodes.values()).filter(
+  const observedNodes = Array.from(state.nodes.values());
+  const totalNodes = graphTotalNodes ?? state.nodes.size;
+  const completedNodes = observedNodes.filter(
     (n) => n.status === "success" || n.status === "failed",
   ).length;
-  const runningNodes = Array.from(state.nodes.values()).filter(
-    (n) => n.status === "running",
-  ).length;
+  const runningNodes = observedNodes.filter((n) => n.status === "running").length;
 
   const canDismiss = state.status !== "running";
   const canDismissRunningHint =

--- a/apps/web/src/features/canvas/components/FlowViewport.tsx
+++ b/apps/web/src/features/canvas/components/FlowViewport.tsx
@@ -18,7 +18,7 @@ import {
 } from "@xyflow/react";
 import { nodeTypes } from "../nodes";
 import { cn } from "@/lib/cn";
-import type { CanvasNode, StickyNoteColor } from "../types";
+import type { CanvasNode, NodeKind, StickyNoteColor } from "../types";
 import { getMiniMapNodeColor, isValidNodeKind } from "../lib/nodeRegistry";
 import { ClickConnectBridge } from "./ClickConnectBridge";
 import { ExecutionStatusBar } from "./ExecutionStatusBar";
@@ -35,6 +35,13 @@ const STICKY_NOTE_MINIMAP_COLORS: Record<StickyNoteColor, string> = {
   purple: "#c4b5fd",
   gray: "#d4d4d8",
 };
+
+const NON_EXECUTABLE_NODE_TYPES = new Set<NodeKind>([
+  "stickyNote",
+  "trigger",
+  "webhookTrigger",
+  "scheduledTrigger",
+]);
 
 function getNodeColor(node: { type?: string; data?: Record<string, unknown> }) {
   if (node.type === "stickyNote") {
@@ -100,6 +107,10 @@ export const FlowViewport = memo(function FlowViewport({
       return { ...node, data: { ...node.data, readOnly: true } };
     });
   }, [nodes, readOnly]);
+  const executableNodeCount = useMemo(
+    () => nodes.filter((node) => !NON_EXECUTABLE_NODE_TYPES.has(node.type)).length,
+    [nodes],
+  );
 
   return (
     <ReactFlow
@@ -147,6 +158,7 @@ export const FlowViewport = memo(function FlowViewport({
       <Controls style={{ height: 107, marginLeft: "222px", opacity: 0.85 }} />
 
       <ExecutionStatusBar
+        totalNodes={executableNodeCount}
         wsStatus={wsStatus}
         wsReconnectAttempts={wsReconnectAttempts}
         onDismissRunning={onDismissRunning}


### PR DESCRIPTION
Fixes the execution status bar counter so the total node count comes from the canvas graph instead of live execution events.

Closes #665