### PR TITLE
fix(canvas): prevent overlay controls from overlapping at narrow widths

### DIFF
--- a/apps/web/src/features/canvas/FlowCanvas.tsx
+++ b/apps/web/src/features/canvas/FlowCanvas.tsx
@@ -31,6 +31,7 @@ import { ImportTemplateDialog } from "./components/ImportTemplateDialog";
 import { SaveVersionDialog } from "./components/SaveVersionDialog";
 import { VersionConflictDialog } from "./components/VersionConflictDialog";
 import { SmithButton } from "./components/SmithButton";
+import { ScrybInterface } from "./components/ScrybInterface";
 import { FlowViewport } from "./components/FlowViewport";
 import { useCanvasShortcuts } from "./hooks/useCanvasShortcuts";
 import { useNodeShortcuts } from "./hooks/useNodeShortcuts";
@@ -117,6 +118,7 @@ function FlowCanvasInner({
   const [edges, setEdges, onEdgesChange] = useEdgesState<Edge>(externalEdges ?? []);
   const [selectedNodeId, setSelectedNodeId] = useState<string | null>(null);
   const [isInspectorExpanded, setIsInspectorExpanded] = useState(false);
+  const [isScrybOpen, setIsScrybOpen] = useState(false);
   const [renameDialog, setRenameDialog] = useState<{
     oldName: string;
     newName: string;
@@ -765,7 +767,7 @@ function FlowCanvasInner({
           onDismissRunning={stopExecution}
         />
 
-        <div className="pointer-events-none absolute left-4 top-4 z-35">
+        <div className="pointer-events-none absolute inset-x-4 top-4 z-35 flex flex-wrap items-start gap-2">
           <div
             ref={toolbarRef}
             data-onboarding="toolbar"
@@ -812,23 +814,33 @@ function FlowCanvasInner({
               disabled={isViewingSnapshot}
             />
           </div>
+
+          <RightPanelStack
+            selectedNode={selectedNode}
+            updateSelectedNodeLabel={updateSelectedNodeLabel}
+            updateData={updateNodeData}
+            onDelete={selectedNode && !isViewingSnapshot ? deleteSelectedElements : undefined}
+            isExpandedDialogOpen={isInspectorExpanded}
+            setIsExpandedDialogOpen={setIsInspectorExpanded}
+            onTogglePin={isViewingSnapshot ? undefined : togglePin}
+            notePlacementMode={notePlacementMode}
+            onToggleNotePlacement={isViewingSnapshot ? undefined : onToggleNotePlacement}
+            selectMode={selectMode}
+            onToggleSelectMode={isViewingSnapshot ? undefined : onToggleSelectMode}
+            isScrybOpen={isScrybOpen}
+            readOnly={isViewingSnapshot}
+          />
         </div>
 
-        <RightPanelStack
-          selectedNode={selectedNode}
-          updateSelectedNodeLabel={updateSelectedNodeLabel}
-          updateData={updateNodeData}
-          onDelete={selectedNode && !isViewingSnapshot ? deleteSelectedElements : undefined}
-          isExpandedDialogOpen={isInspectorExpanded}
-          setIsExpandedDialogOpen={setIsInspectorExpanded}
-          onTogglePin={isViewingSnapshot ? undefined : togglePin}
-          notePlacementMode={notePlacementMode}
-          onToggleNotePlacement={isViewingSnapshot ? undefined : onToggleNotePlacement}
-          selectMode={selectMode}
-          onToggleSelectMode={isViewingSnapshot ? undefined : onToggleSelectMode}
-          workflowId={workflowId}
-          readOnly={isViewingSnapshot}
-        />
+        <div className="pointer-events-none absolute bottom-8 right-4 z-35">
+          <div className="pointer-events-auto">
+            <ScrybInterface
+              isOpen={isScrybOpen}
+              onOpenChange={setIsScrybOpen}
+              workflowId={workflowId}
+            />
+          </div>
+        </div>
 
         <div className="pointer-events-none absolute bottom-4 left-1/2 z-30 -translate-x-1/2">
           <div className="rounded-full border border-border/40 bg-background/20 px-3 py-1 text-xs text-muted-foreground/96 backdrop-blur">

--- a/apps/web/src/features/canvas/components/RightPanelStack.tsx
+++ b/apps/web/src/features/canvas/components/RightPanelStack.tsx
@@ -1,8 +1,7 @@
 "use client";
 
-import { memo, useState } from "react";
+import { memo } from "react";
 import { Inspector } from "./Inspector";
-import { ScrybInterface } from "./ScrybInterface";
 import { SelectionModeButton } from "./SelectionModeButton";
 import { StickyNoteButton } from "./StickyNoteButton";
 import { cn } from "@/lib/cn";
@@ -22,7 +21,7 @@ type RightPanelStackProps = {
   onToggleNotePlacement?: () => void;
   selectMode?: boolean;
   onToggleSelectMode?: () => void;
-  workflowId?: number | null;
+  isScrybOpen?: boolean;
   readOnly?: boolean;
 };
 
@@ -40,7 +39,7 @@ function isEquivalentSelectedNode(prev: CanvasNode | null, next: CanvasNode | nu
 
 function areEqual(prev: RightPanelStackProps, next: RightPanelStackProps) {
   return (
-    prev.workflowId === next.workflowId &&
+    prev.isScrybOpen === next.isScrybOpen &&
     prev.isExpandedDialogOpen === next.isExpandedDialogOpen &&
     prev.readOnly === next.readOnly &&
     prev.selectMode === next.selectMode &&
@@ -53,9 +52,8 @@ function areEqual(prev: RightPanelStackProps, next: RightPanelStackProps) {
 }
 
 export const RightPanelStack = memo(function RightPanelStack(props: RightPanelStackProps) {
-  const [isScrybOpen, setIsScrybOpen] = useState(false);
   const {
-    workflowId,
+    isScrybOpen,
     readOnly,
     notePlacementMode,
     onToggleNotePlacement,
@@ -72,37 +70,24 @@ export const RightPanelStack = memo(function RightPanelStack(props: RightPanelSt
   return (
     <div
       data-onboarding="inspector"
-      className="pointer-events-none absolute right-4 top-4 bottom-8 z-35 flex h-auto flex-col items-end justify-between gap-4"
+      className="pointer-events-auto ml-auto flex min-h-0 items-start gap-2 overflow-visible"
     >
-      <div className="pointer-events-auto flex min-h-0 items-start gap-2 overflow-visible">
-        {!readOnly && onToggleSelectMode && (
-          <SelectionModeButton active={Boolean(selectMode)} onToggle={onToggleSelectMode} />
+      {!readOnly && onToggleSelectMode && (
+        <SelectionModeButton active={Boolean(selectMode)} onToggle={onToggleSelectMode} />
+      )}
+      {!readOnly && onToggleNotePlacement && (
+        <StickyNoteButton active={Boolean(notePlacementMode)} onClick={onToggleNotePlacement} />
+      )}
+      <Inspector
+        {...inspectorProps}
+        selectedNode={inspectorSelectedNode}
+        readOnly={readOnly}
+        renderInPanel={false}
+        className={cn(
+          "transition-all duration-500 ease-[cubic-bezier(0.23,1,0.32,1)]",
+          isScrybOpen ? "max-h-[40vh]" : "max-h-[calc(100vh-12rem)]",
         )}
-        {!readOnly && onToggleNotePlacement && (
-          <StickyNoteButton active={Boolean(notePlacementMode)} onClick={onToggleNotePlacement} />
-        )}
-        <Inspector
-          {...inspectorProps}
-          selectedNode={inspectorSelectedNode}
-          readOnly={readOnly}
-          renderInPanel={false}
-          className={cn(
-            "transition-all duration-500 ease-[cubic-bezier(0.23,1,0.32,1)]",
-            // When Scryb is open, shrink the max-height of the Inspector to avoid overlap
-            // The Inspector handles internal scrolling via overflow-y-auto
-            isScrybOpen ? "max-h-[40vh]" : "max-h-[calc(100vh-12rem)]",
-          )}
-        />
-      </div>
-
-      {/* Bottom: Scryb */}
-      <div className="pointer-events-auto shrink-0">
-        <ScrybInterface
-          isOpen={isScrybOpen}
-          onOpenChange={setIsScrybOpen}
-          workflowId={workflowId}
-        />
-      </div>
+      />
     </div>
   );
 }, areEqual);

--- a/apps/web/src/features/canvas/components/Toolbar.tsx
+++ b/apps/web/src/features/canvas/components/Toolbar.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { memo } from "react";
+import { memo, useState } from "react";
 import Link from "next/link";
 import { Logo } from "@/components/shared/Logo";
 import {
@@ -108,6 +108,11 @@ export const Toolbar = memo(function Toolbar({
   viewingVersionNumber,
   onExecutionUrlChange,
 }: ToolbarProps) {
+  const [openMenu, setOpenMenu] = useState<"import" | "export" | null>(null);
+  const handleMenuOpenChange = (menu: "import" | "export") => (open: boolean) => {
+    setOpenMenu((prev) => (open ? menu : prev === menu ? null : prev));
+  };
+
   const isExecuting = executionStatus === "running" || isStartingExecution;
   const isRunDisabled = executeDisabled || readOnly;
   const liveStatusLabel =
@@ -135,12 +140,14 @@ export const Toolbar = memo(function Toolbar({
     title,
     children,
     disabled,
+    iconOnly,
     "data-onboarding": dataOnboarding,
   }: {
     onClick: () => void;
     title: string;
     children: React.ReactNode;
     disabled?: boolean;
+    iconOnly?: boolean;
     "data-onboarding"?: string;
   }) => (
     <button
@@ -149,7 +156,10 @@ export const Toolbar = memo(function Toolbar({
       onClick={disabled ? undefined : onClick}
       disabled={disabled}
       data-onboarding={dataOnboarding}
-      className="inline-flex h-8 items-center gap-2 rounded-sm border border-border/60 bg-muted/40 px-2.5 text-xs hover:bg-muted/60 disabled:cursor-not-allowed disabled:opacity-50"
+      className={cn(
+        "inline-flex h-8 items-center gap-2 rounded-sm border border-border/60 bg-muted/40 text-xs hover:bg-muted/60 disabled:cursor-not-allowed disabled:opacity-50",
+        iconOnly ? "w-8 justify-center" : "px-2.5",
+      )}
     >
       {children}
     </button>
@@ -219,14 +229,20 @@ export const Toolbar = memo(function Toolbar({
           disabled={readOnly && viewingVersionNumber == null}
         />
       )}
-      <Btn onClick={onUndo} title="Undo (Ctrl+Z)" disabled={!canUndo}>
-        <RotateCcw className="h-4 w-4" /> Undo
+      <Btn onClick={onUndo} title="Undo (Ctrl+Z)" disabled={!canUndo} iconOnly>
+        <RotateCcw className="h-4 w-4" />
       </Btn>
-      <Btn onClick={onRedo} title="Redo (Ctrl+Shift+Z)" disabled={!canRedo}>
-        <RotateCw className="h-4 w-4" /> Redo
+      <Btn onClick={onRedo} title="Redo (Ctrl+Shift+Z)" disabled={!canRedo} iconOnly>
+        <RotateCw className="h-4 w-4" />
       </Btn>
-      <Btn onClick={onSave} title="Save (Ctrl+S)" disabled={saveDisabled} data-onboarding="save">
-        <Save className="h-4 w-4" /> Save
+      <Btn
+        onClick={onSave}
+        title="Save (Ctrl+S)"
+        disabled={saveDisabled}
+        data-onboarding="save"
+        iconOnly
+      >
+        <Save className="h-4 w-4" />
       </Btn>
       {onPublish && hasUnpublishedChanges && !viewingVersionNumber && !readOnly && (
         <div className="relative">
@@ -240,7 +256,7 @@ export const Toolbar = memo(function Toolbar({
         </div>
       )}
 
-      <DropdownMenu>
+      <DropdownMenu open={openMenu === "import"} onOpenChange={handleMenuOpenChange("import")}>
         <DropdownMenuTrigger className={btnClass} disabled={readOnly}>
           <Download className="h-4 w-4" /> Import <ChevronDown className="h-3 w-3 opacity-60" />
         </DropdownMenuTrigger>
@@ -257,7 +273,7 @@ export const Toolbar = memo(function Toolbar({
         </DropdownMenuContent>
       </DropdownMenu>
 
-      <DropdownMenu>
+      <DropdownMenu open={openMenu === "export"} onOpenChange={handleMenuOpenChange("export")}>
         <DropdownMenuTrigger className={btnClass}>
           <Upload className="h-4 w-4" /> Export <ChevronDown className="h-3 w-3 opacity-60" />
         </DropdownMenuTrigger>
@@ -283,7 +299,7 @@ export const Toolbar = memo(function Toolbar({
         </Btn>
       )}
       {onOpenOnboarding && (
-        <Btn onClick={onOpenOnboarding} title="Open onboarding guide">
+        <Btn onClick={onOpenOnboarding} title="Open onboarding guide" iconOnly>
           <HelpCircle className="h-4 w-4" />
         </Btn>
       )}


### PR DESCRIPTION
The canvas toolbar and the right-hand controls (selection mode, sticky note, Inspector) were two independent absolutely-positioned overlays growing toward each other, so they overlapped at some resolutions. They now share a single wrapping flex row, so when space runs out the right group would wrap below the toolbar instead of stacking over it.

The toolbar's Undo, Redo, and Save buttons are now icon-only to reduce toolbar width too.