### PR TITLE
docs: fix installation guide

### DIFF
--- a/apps/web/content/en/getting-started/index.mdx
+++ b/apps/web/content/en/getting-started/index.mdx
@@ -1,18 +1,57 @@
-# Getting Started
+# Installation
 
-Rune is organized around one main job: helping you create, run, and improve workflows.
+Use this page when you need to run Rune yourself. If someone has already given you access to a Rune workspace, you can skip to the [Quick Start](/docs/getting-started/quick-start).
 
-## App areas
+The installation path below follows the project README.
 
-- **Create** is the starting point. Choose a blank workflow, a template, or Smith.
-- **Workflows** lists workflows you own or can access.
-- **Canvas** is where you add nodes, connect them, save versions, run the workflow, and inspect output.
-- **Executions** shows workflow run history and status.
-- **Credentials** stores the keys and accounts workflows need to call external services.
-- **Templates** gives you reusable workflow starting points.
-- **Docs** brings you back here when you need help.
+## Run Rune with Docker
 
-## A simple mental model
+The fastest way to get Rune running locally is with Docker:
+
+```bash
+git clone https://github.com/rune-org/rune.git
+cd rune
+
+cp .env.example .env
+make up
+```
+
+When the containers are running, open:
+
+```text
+http://localhost:3000
+```
+
+## What starts
+
+`make up` starts the full Rune stack:
+
+| Service | Port | What it does |
+| --- | --- | --- |
+| Frontend | `3000` | Web app and workflow canvas |
+| API | `8000` | REST API for auth, workflows, credentials, templates, and orchestration |
+| RTES | `8080` | Real-time execution streaming |
+| Worker | N/A | Background workflow execution engine |
+| Archivist | N/A | Completion recorder and data maintainer |
+| Scheduler | N/A | Scheduled workflow trigger service |
+| PostgreSQL | `5432` | Primary database |
+| MongoDB | `27017` | Execution history |
+| Redis | `6379` | State and caching |
+| RabbitMQ | `5672` / `15672` | Message broker |
+| OpenObserve | `5080` | Observability platform |
+| OpenTelemetry | `4317` / `4318` | Telemetry collector |
+
+## Stop Rune
+
+From the repository root, run:
+
+```bash
+make down
+```
+
+## After installation
+
+Once the web app opens, the product flow looks like this:
 
 ```mermaid
 flowchart TD
@@ -24,7 +63,7 @@ flowchart TD
   Improve --> Run
 ```
 
-## Recommended path
+Next steps:
 
 1. Run the [Quick Start](/docs/getting-started/quick-start).
 2. Read [How Rune Works](/docs/how-rune-works) when a term feels unfamiliar.

--- a/apps/web/content/en/guides/nodes.mdx
+++ b/apps/web/content/en/guides/nodes.mdx
@@ -1,6 +1,6 @@
 # Node Families
 
-Nodes are the building blocks of a Rune workflow. V1 docs explain node families and common uses, not every field on every node.
+Nodes are the building blocks of a Rune workflow. This guide explains the main node families and when to use them.
 
 ## Triggers
 
@@ -10,7 +10,7 @@ Triggers start workflows.
 - **Scheduled Trigger:** run repeatedly on an interval.
 - **Webhook Trigger:** start from an external HTTP event.
 
-Use one trigger near the beginning of the workflow.
+Most workflows start with one trigger near the beginning of the flow.
 
 ## Flow control
 

--- a/apps/web/content/en/how-rune-works.mdx
+++ b/apps/web/content/en/how-rune-works.mdx
@@ -10,6 +10,8 @@ A workflow is the full automation: its name, description, nodes, connections, an
 
 Use a workflow for a repeatable task, such as checking an API, transforming a list, sending an email, or routing work based on conditions.
 
+If you are running Rune locally for the first time, start with [Installation](/docs/getting-started). If Rune is already running, start with [Quick Start](/docs/getting-started/quick-start).
+
 ### Triggers
 
 A trigger starts a workflow.

--- a/apps/web/content/en/index.mdx
+++ b/apps/web/content/en/index.mdx
@@ -6,9 +6,9 @@ These docs are written for people using the Rune app. You do not need to know th
 
 ## Start here
 
-1. Open **Getting Started** to learn the main areas of the app.
-2. Follow the **Quick Start** to run a workflow that does not require credentials.
-3. Use the **Guides** when you want to connect services, work with data, use templates, or understand failed runs.
+1. If you need to run Rune yourself, start with [Installation](/docs/getting-started).
+2. If Rune is already available to you, follow the [Quick Start](/docs/getting-started/quick-start) to run a workflow that does not require credentials.
+3. Use the [Guides](/docs/guides/creating-workflows) when you want to connect services, work with data, use templates, or understand failed runs.
 
 ## What you can do with Rune
 


### PR DESCRIPTION
## Summary
- Replace the Getting Started placeholder/orientation page with a README-backed Installation guide
- Clarify the docs home path for users who need to install Rune versus users who already have access
- Lightly polish node-family and how-it-works wording for readability

## Validation
- cd apps/web && pnpm build
