### PR TITLE
fix(docs): replace dropdowns with non-modal controls

### DIFF
--- a/apps/web/mdx-components.tsx
+++ b/apps/web/mdx-components.tsx
@@ -1,8 +1,20 @@
 import { useMDXComponents as getDocsMDXComponents } from 'nextra-theme-docs';
+import { DocsCopyPage } from '@/components/layout/DocsCopyPage';
+
+const docsComponents = getDocsMDXComponents();
+const DocsWrapper = docsComponents.wrapper;
 
 export function useMDXComponents(components = {}) {
   return {
-    ...getDocsMDXComponents(),
+    ...docsComponents,
+    wrapper({ sourceCode, children, ...props }: React.ComponentProps<typeof DocsWrapper>) {
+      return (
+        <DocsWrapper {...props} sourceCode="">
+          {sourceCode && <DocsCopyPage sourceCode={sourceCode} />}
+          {children}
+        </DocsWrapper>
+      );
+    },
     ...components,
   };
 }

--- a/apps/web/src/app/docs/[[...mdxPath]]/layout.tsx
+++ b/apps/web/src/app/docs/[[...mdxPath]]/layout.tsx
@@ -39,10 +39,12 @@ export default async function DocsLayout({
   return (
     <Layout
       pageMap={pageMap}
-      docsRepositoryBase="https://github.com/rune-org/rune/tree/main/apps/web/content"
+      docsRepositoryBase="https://github.com/rune-org/rune/tree/main/apps/web"
       editLink={ui.editLink}
+      darkMode={false}
       sidebar={{
         defaultMenuCollapseLevel: 1,
+        toggleButton: false,
       }}
       navbar={<DocsNavbar key="navbar" />}
       footer={<Footer key="footer" />}

--- a/apps/web/src/components/layout/DocsCopyPage.tsx
+++ b/apps/web/src/components/layout/DocsCopyPage.tsx
@@ -24,8 +24,7 @@ export function DocsCopyPage({ sourceCode }: { sourceCode: string }) {
   };
 
   const openInAssistant = (assistant: "chatgpt" | "claude") => {
-    const url =
-      assistant === "chatgpt" ? "chatgpt.com/?hints=search&prompt" : "claude.ai/new?q";
+    const url = assistant === "chatgpt" ? "chatgpt.com/?hints=search&prompt" : "claude.ai/new?q";
     const query = `Read from ${location.href} so I can ask questions about it.`;
     window.open(`https://${url}=${encodeURIComponent(query)}`, "_blank");
   };
@@ -52,9 +51,7 @@ export function DocsCopyPage({ sourceCode }: { sourceCode: string }) {
             <Copy className="size-4 shrink-0" />
             <span className="flex flex-col">
               <span className="font-medium">Copy page</span>
-              <span className="text-xs text-muted-foreground">
-                Copy page as Markdown for LLMs
-              </span>
+              <span className="text-xs text-muted-foreground">Copy page as Markdown for LLMs</span>
             </span>
           </DropdownMenuItem>
           <DropdownMenuItem
@@ -66,9 +63,7 @@ export function DocsCopyPage({ sourceCode }: { sourceCode: string }) {
               <span className="flex items-center gap-1 font-medium">
                 Open in ChatGPT <LinkArrowIcon height="1em" />
               </span>
-              <span className="text-xs text-muted-foreground">
-                Ask questions about this page
-              </span>
+              <span className="text-xs text-muted-foreground">Ask questions about this page</span>
             </span>
           </DropdownMenuItem>
           <DropdownMenuItem
@@ -80,9 +75,7 @@ export function DocsCopyPage({ sourceCode }: { sourceCode: string }) {
               <span className="flex items-center gap-1 font-medium">
                 Open in Claude <LinkArrowIcon height="1em" />
               </span>
-              <span className="text-xs text-muted-foreground">
-                Ask questions about this page
-              </span>
+              <span className="text-xs text-muted-foreground">Ask questions about this page</span>
             </span>
           </DropdownMenuItem>
         </DropdownMenuContent>

--- a/apps/web/src/components/layout/DocsCopyPage.tsx
+++ b/apps/web/src/components/layout/DocsCopyPage.tsx
@@ -1,0 +1,92 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { Check, ChevronDown, Copy } from "lucide-react";
+import { ChatGPTIcon, ClaudeIcon, LinkArrowIcon } from "nextra/icons";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+
+export function DocsCopyPage({ sourceCode }: { sourceCode: string }) {
+  const [isCopied, setIsCopied] = useState(false);
+  const timeoutRef = useRef<ReturnType<typeof setTimeout>>(undefined);
+
+  useEffect(() => () => clearTimeout(timeoutRef.current), []);
+
+  const handleCopy = async () => {
+    await navigator.clipboard.writeText(sourceCode);
+    setIsCopied(true);
+    clearTimeout(timeoutRef.current);
+    timeoutRef.current = setTimeout(() => setIsCopied(false), 2000);
+  };
+
+  const openInAssistant = (assistant: "chatgpt" | "claude") => {
+    const url =
+      assistant === "chatgpt" ? "chatgpt.com/?hints=search&prompt" : "claude.ai/new?q";
+    const query = `Read from ${location.href} so I can ask questions about it.`;
+    window.open(`https://${url}=${encodeURIComponent(query)}`, "_blank");
+  };
+
+  return (
+    <div className="float-end ms-4 mb-2 inline-flex items-stretch overflow-hidden rounded-md border border-border/70">
+      <button
+        type="button"
+        onClick={handleCopy}
+        className="flex cursor-pointer items-center gap-2 ps-3 pe-2 py-1.5 text-sm font-medium text-foreground transition-colors hover:bg-muted/60"
+      >
+        {isCopied ? <Check className="size-4" /> : <Copy className="size-4" />}
+        {isCopied ? "Copied" : "Copy page"}
+      </button>
+      <DropdownMenu modal={false}>
+        <DropdownMenuTrigger
+          className="flex cursor-pointer items-center border-s border-border/70 px-1.5 text-muted-foreground transition-colors hover:bg-muted/60 hover:text-foreground"
+          aria-label="More copy options"
+        >
+          <ChevronDown className="size-3.5" />
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="end" sideOffset={10}>
+          <DropdownMenuItem onSelect={handleCopy} className="cursor-pointer gap-3">
+            <Copy className="size-4 shrink-0" />
+            <span className="flex flex-col">
+              <span className="font-medium">Copy page</span>
+              <span className="text-xs text-muted-foreground">
+                Copy page as Markdown for LLMs
+              </span>
+            </span>
+          </DropdownMenuItem>
+          <DropdownMenuItem
+            onSelect={() => openInAssistant("chatgpt")}
+            className="cursor-pointer gap-3"
+          >
+            <ChatGPTIcon width="16" className="shrink-0" />
+            <span className="flex flex-col">
+              <span className="flex items-center gap-1 font-medium">
+                Open in ChatGPT <LinkArrowIcon height="1em" />
+              </span>
+              <span className="text-xs text-muted-foreground">
+                Ask questions about this page
+              </span>
+            </span>
+          </DropdownMenuItem>
+          <DropdownMenuItem
+            onSelect={() => openInAssistant("claude")}
+            className="cursor-pointer gap-3"
+          >
+            <ClaudeIcon width="16" className="shrink-0" />
+            <span className="flex flex-col">
+              <span className="flex items-center gap-1 font-medium">
+                Open in Claude <LinkArrowIcon height="1em" />
+              </span>
+              <span className="text-xs text-muted-foreground">
+                Ask questions about this page
+              </span>
+            </span>
+          </DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>
+    </div>
+  );
+}

--- a/apps/web/src/components/layout/DocsNavbar.tsx
+++ b/apps/web/src/components/layout/DocsNavbar.tsx
@@ -5,6 +5,7 @@ import { usePathname } from "next/navigation";
 import { Logo } from "@/components/shared/Logo";
 import { DocsSearch } from "@/components/layout/DocsSearch";
 import { DocsLanguageSwitcher } from "@/components/layout/DocsLanguageSwitcher";
+import { ThemeToggle } from "@/components/shared/ThemeToggle";
 import { docsLocaleFromPath } from "@/lib/docs-locales";
 
 export function DocsNavbar() {
@@ -21,6 +22,7 @@ export function DocsNavbar() {
       </div>
 
       <div className="flex items-center gap-4">
+        <ThemeToggle />
         <DocsLanguageSwitcher />
         <Link
           href="https://github.com/rune-org/rune"


### PR DESCRIPTION
The Mermaid component Nextra injects re-renders diagrams on every `<html>` attribute mutation, and destructively wipes its container  in the process, so opening the theme dropdown or the "Copy page" dropdown (both Headless UI components that scroll-lock the page via `<html>` styles) blanked all diagrams. Instead of waiting for an upstream patch, I've removed the triggers:

- Replaced the sidebar theme dropdown with a plain light/dark toggle button in the docs navbar; system stays the initial default but is no longer a menu option.
- Replaced the built-in "Copy page" split button with our own (DocsCopyPage) using a non-modal Radix dropdown that doesn't touch `<html>`.
- Removed the now-stranded sidebar collapse button row.
- Also fixed a "Edit this page" link 404: docsRepositoryBase included /content, which Nextra's filePath (already content/...-prefixed) duplicated.